### PR TITLE
Fix some currently broken tests.

### DIFF
--- a/source/src/core/energy_methods/ImplicitMembraneCoulomb.hh
+++ b/source/src/core/energy_methods/ImplicitMembraneCoulomb.hh
@@ -39,7 +39,7 @@ public:
 	ImplicitMembraneCoulomb(ImplicitMembraneCoulomb const & src);
 
 	/// @brief Destructor.
-	virtual ~ImplicitMembraneCoulomb();
+	~ImplicitMembraneCoulomb() override;
 
 	/// @brief Clone operation: make a copy of this object, and return an owning pointer to the copy.
 	ImplicitMembraneCoulombOP clone() const;

--- a/source/src/core/energy_methods/ImplicitMembraneElecEnergy.hh
+++ b/source/src/core/energy_methods/ImplicitMembraneElecEnergy.hh
@@ -76,7 +76,7 @@ public:
 	core::scoring::methods::EnergyMethodOP clone() const override;
 
 	// destructor (important for properly forward-declaring smart-pointer members)
-	virtual ~ImplicitMembraneElecEnergy() override;
+	~ImplicitMembraneElecEnergy() override;
 
 	void
 	setup_for_derivatives( pose::Pose & pose, core::scoring::ScoreFunction const & ) const override;

--- a/tests/scientific/tests/peptide_pnear_vs_ic50/2.analyze.py
+++ b/tests/scientific/tests/peptide_pnear_vs_ic50/2.analyze.py
@@ -78,7 +78,7 @@ def analyze_one_funnel( suffix='1A', expected_rmsd_of_lowest=0.3, expected_min_r
     in_table = False
     for line in logfile_contents:
         try:
-            sline = line.split():
+            sline = line.split()
             if in_table:
                 if line.startswith("End summary"):
                     in_table = False

--- a/tests/scientific/tests/simple_cycpep_predict/2.analyze.py
+++ b/tests/scientific/tests/simple_cycpep_predict/2.analyze.py
@@ -70,7 +70,7 @@ pnear_to_lowest = None
 in_table = False
 for line in logfile_contents:
     try:
-        sline = line.split():
+        sline = line.split()
         if in_table:
             if line.startswith("End summary"):
                 in_table = False


### PR DESCRIPTION
There are clang-tidy errors for ImplicitMembraneCoulomb & ImplicitMembraneElecEnergy due to virtual/override.

There are running errors for the scientific tests due to a typo I made earlier.