### PR TITLE
Add ability to specify compiler version ranges in scons settings.

### DIFF
--- a/source/src/protocols/ligand_docking/GALigandDock/LigandAligner.cc
+++ b/source/src/protocols/ligand_docking/GALigandDock/LigandAligner.cc
@@ -2086,10 +2086,10 @@ LigandAligner::apply(
 	//5*50*3 takes 2sec per model; 5*10*3 1sec ~1sec
 	core::Size cycles1 = 20, minsteps1 = 0, repeats1 = 0; // very fast... ~0.001 s per cycle
 	if ( lig.has_density_map() ) {
-		cycles1 = 20, minsteps1 = 10, repeats1 = 1;
+		cycles1 = 20; minsteps1 = 10; repeats1 = 1;
 	}
 	if ( prealigned_input_ ) {
-		cycles1 = 5, minsteps1 = 10, repeats1 = 1;
+		cycles1 = 5; minsteps1 = 10; repeats1 = 1;
 	}
 	core::Size cycles2 = 5, minsteps2 = 50, repeats2 = 3; // adjusted for init-pool gen
 	core::Size minsteps_med = 30; // proper minimization b/w stage 1~2

--- a/source/src/utility/tag/Tag.cc
+++ b/source/src/utility/tag/Tag.cc
@@ -745,7 +745,8 @@ void Tag::read( std::string const & str ) {
 
 	TagOP tag; // don't need to initialize this at all
 	tag_grammar g;
-	bool full = parse(begin, end, g[ var(tag) = arg1 ] ).full;
+	auto parsed = parse(begin, end, g[ var(tag) = arg1 ] ); // on a separate line to get around GCC 3.12 peculiarities
+	bool full = parsed.full;
 
 	if ( tag && full ) {
 		*this = *tag;

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -443,13 +443,22 @@ settings = {
         },
     },
 
+    "gcc, |cxx_ver:>=13.0|" : {
+        "appends" : {
+            "flags" : {
+                "warn" : [
+                    "Wno-error=dangling-reference", # Too agressive.
+                ],
+            },
+        },
+    },
+
     "gcc, |cxx_ver:>=12.0|" : {
         "appends" : {
             "flags" : {
                 "warn" : [
                     "Wno-error=array-bounds=", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
                     "Wno-error=stringop-overread", # Issue with Eigen
-                    "Wno-error=dangling-reference", # Too agressive.
                     "Wno-error=restrict", # Issue with json-spirit
                 ],
             },

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -462,7 +462,7 @@ settings = {
                 "warn" : [
                     "Wno-error=array-bounds", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
                     "Wno-error=restrict", # Issue with json-spirit
-
+                    "Wno-error=use-after-free", # Issue with utility/tag/Tag.cc
                 ],
             },
         },

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -443,7 +443,7 @@ settings = {
         },
     },
 
-    "gcc, |cxx_ver:>=13.0|" : {
+    "gcc, |cxx_ver:>=12.0|" : {
         "appends" : {
             "flags" : {
                 "warn" : [

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -443,7 +443,7 @@ settings = {
         },
     },
 
-    "gcc, 13.1" : {
+    "gcc, |cxx_ver:>=13.0|" : {
         "appends" : {
             "flags" : {
                 "warn" : [
@@ -454,165 +454,9 @@ settings = {
                 ],
             },
         },
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
     },
 
-    "gcc, 12.3" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 12.2" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 12.1" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-
-    "gcc, 11.4" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 11.3" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 11.2" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 11.1" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-
-
-    "gcc, 10.5" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 10.4" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 10.3" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 10.2" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 10.1" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-
-
-    "gcc, 9.5" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 9.4" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 9.3" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 9.2" : {
-        "removes" : {
-            "flags" : {
-                "cxx" : [
-                    "ffor-scope",
-                ],
-            },
-        },
-    },
-    "gcc, 9.1" : {
+    "gcc, |cxx_ver:>9.0|" : {
         "removes" : {
             "flags" : {
                 "cxx" : [
@@ -2322,7 +2166,7 @@ settings = {
     #    },
     #},
 
-    "clang, 3.7" : {
+    "clang, |cxx_ver:>=3.7|" : {
         "appends" : {
             "flags" : {
                 "warn" : [
@@ -2332,77 +2176,11 @@ settings = {
         },
     },
 
-    "clang, 3.8" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 3.9" : {
+    "clang, |cxx_ver:>=3.9|" : {
         "appends" : {
             "flags" : {
                 "warn" : [
                     "Wcomma",
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 4.0" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Wcomma",
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 4.1" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Wcomma",
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 4.2" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Wcomma",
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 5.0" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Wcomma",
-                    "Winconsistent-missing-override",
-                ],
-            },
-        },
-    },
-
-    "clang, 5.1" : {
-        "appends" : {
-            "flags" : {
-                "warn" : [
-                    "Wcomma",
-                    "Winconsistent-missing-override",
                 ],
             },
         },

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -461,6 +461,8 @@ settings = {
             "flags" : {
                 "warn" : [
                     "Wno-error=array-bounds", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
+                    "Wno-error=restrict", # Issue with json-spirit
+
                 ],
             },
         },

--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -447,19 +447,20 @@ settings = {
         "appends" : {
             "flags" : {
                 "warn" : [
+                    "Wno-error=array-bounds=", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
+                    "Wno-error=stringop-overread", # Issue with Eigen
+                    "Wno-error=restrict", # Issue with json-spirit
                     "Wno-error=dangling-reference", # Too agressive.
                 ],
             },
         },
     },
 
-    "gcc, |cxx_ver:>=12.0|" : {
+    "gcc, |cxx_ver:>=12.0,<13.0|" : {
         "appends" : {
             "flags" : {
                 "warn" : [
-                    "Wno-error=array-bounds=", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
-                    "Wno-error=stringop-overread", # Issue with Eigen
-                    "Wno-error=restrict", # Issue with json-spirit
+                    "Wno-error=array-bounds", # There's a probably spurious "__builtin_memmove() forming offset is out of the bounds" warning for vector1<bool>
                 ],
             },
         },

--- a/source/tools/build/setup.py
+++ b/source/tools/build/setup.py
@@ -153,7 +153,61 @@ directory it is built to, and what settings it ultimately uses.
 
     return requested, actual
 
+def split_ver( ver_string, leng=None ):
+    "Splits a dotted version specification into a tuple, optionally matching the length"
+    split = tuple(int(v) for v in ver_string.split('.'))
+    if leng is None:
+        return split
+    elif leng == len(split):
+        return split
+    elif leng < len(split):
+        return split[:leng]
+    else:
+        return split + ( (0,) * (len(split) - len) )
 
+def cxx_version_match( spec, ver ):
+    """Does the provided version match the specification?
+    Specifications are a comma separated list of comparisons, all of which need to match, e.g. '>3.5,<=5.2'
+    """
+    if '*' in ver:
+        return False # Initial, pre-compiler knowledge specification
+
+    ver_tuple = split_ver(ver)
+    vt_len = len(ver_tuple)
+
+    #Relies on Python lexigraphical sorting of tuples
+    for case in spec.split(','):
+        case = case.strip()
+        if case.startswith("<="):
+            if not ver_tuple <= split_ver(case[2:], vt_len):
+                return False
+        elif case.startswith(">="):
+            if not ver_tuple >= split_ver(case[2:], vt_len):
+                return False
+        elif case.startswith(">"):
+            if not ver_tuple > split_ver(case[1:], vt_len):
+                return False
+        elif case.startswith("<"):
+            if not ver_tuple < split_ver(case[1:], vt_len):
+                return False
+        else:
+            raise ValueError("Cannot interpret version specification `" + case + "`")
+
+    return True
+
+def expand_pattern( pattern, options ):
+    """Expand a pattern from within the settings keys, substituting values if appropriate.
+    Will return None if the pattern doesn't match.
+
+    Right now this is rather rudimentary, only handling cxx_ver
+    """
+    if '|cxx_ver:' in pattern:
+        pre, ver_spec, post = pattern.split('|')
+        if cxx_version_match(ver_spec[len('cxx_ver:'):], options.cxx_ver):
+            return pre + options.cxx_ver + post
+        else:
+            return None
+    return None
 
 def setup_build_settings(options):
     """Select the build settings needed to generate the combined settings.
@@ -239,6 +293,12 @@ combinatorically unmanageable.
         supported.update(user)
     possible += [ "user" ]
 
+    # If we have ranges in the specifications, we may need to expand them later
+    patterned = []
+    for key in list(supported.keys()):
+        if '|' in key:
+            patterned.append( key )
+
     # Actual ids are those possible ids which are actually supported
     # by the settings in the settings file.
     actual = []
@@ -249,6 +309,10 @@ combinatorically unmanageable.
         # to recognize the absence of a given id.
         if id in supported and supported[id]:
             actual += [ id ]
+        else:
+            for pattern in patterned:
+                if id == expand_pattern(pattern, options):
+                    actual += [ pattern ]
 
     # Create the build settings which match all actual build ids
     settings = []

--- a/source/tools/build/setup.py
+++ b/source/tools/build/setup.py
@@ -163,7 +163,7 @@ def split_ver( ver_string, leng=None ):
     elif leng < len(split):
         return split[:leng]
     else:
-        return split + ( (0,) * (len(split) - len) )
+        return split + ( (0,) * (len(split) - leng) )
 
 def cxx_version_match( spec, ver ):
     """Does the provided version match the specification?


### PR DESCRIPTION
The basic.settings file has had a limitation for a long while where any version-specific settings are tied to an exact version. That is, settings for gcc 9.0 can't also apply to 10.0 (or even 9.1). This makes things difficult when a potential range of different compilers need to be dealt with in the same fashion, especially in a forward-compatible way. (e.g. the lack of `-ffor-scope` on any GCC newer than 9.0, including ones not yet released)

An adjustment to one of the build files allows us to use a pattern matching specification to add parameter blocks for ranges of compilers (e.g. `cxx_ver:>9.0` for any compiler version greater than 9.0, or `cxx_ver:>=5.2,<7.0` for compiler versions between 5.2 (inclusive) and 7.0 (exclusive).)

Should address issue #29 and #28