### PR TITLE
build: use python3 as binary name, not python

### DIFF
--- a/source/external/scons-local/scons.py
+++ b/source/external/scons-local/scons.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # SCons - a Software Constructor
 #

--- a/source/update_ResidueType_enum_files.sh
+++ b/source/update_ResidueType_enum_files.sh
@@ -5,7 +5,7 @@
 # (c) For more information, see http://www.rosettacommons.org. Questions about this can be
 # (c) addressed to University of Washington CoMotion, email: license@uw.edu.
 cd "src/core/chemical/residue_properties"
-python update_ResidueType_enum_files.py
+python3 update_ResidueType_enum_files.py
 exitcode=$?
 cd ../../../..
 exit $exitcode

--- a/source/update_options.sh
+++ b/source/update_options.sh
@@ -5,7 +5,7 @@
 # (c) For more information, see http://www.rosettacommons.org. Questions about this can be
 # (c) addressed to University of Washington CoMotion, email: license@uw.edu.
 cd "src/basic/options/"
-python options.py
+python3 options.py
 exitcode=$?
 cd ../../..
 exit $exitcode

--- a/source/version.py
+++ b/source/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This function expects that the current working directory is the Rosetta root directory.
 # If that's ever not true, we need to modify this to take an optional dir name on the cmd line.
 # (c) Copyright Rosetta Commons Member Institutions.


### PR DESCRIPTION
I apologize for this triviality, but if compatible with the other distros I kind request to adopt the "3". It just broke the build on Debian/Ubuntu where python2 can still be co-installed.