### PR TITLE
cifparse: Debian missing unistd include

### DIFF
--- a/source/external/cifparse/CifScanner.c
+++ b/source/external/cifparse/CifScanner.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* end standard C headers. */
 

--- a/source/external/cifparse/DICScanner.c
+++ b/source/external/cifparse/DICScanner.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* end standard C headers. */
 


### PR DESCRIPTION
Addresses https://github.com/RosettaCommons/rosetta/issues/31, @roccomoretti already had a first look.