### PR TITLE
libxml2 build: strcasecmp needs strings.h on Debian

### DIFF
--- a/source/external/libxml2/triostr.c
+++ b/source/external/libxml2/triostr.c
@@ -62,6 +62,7 @@
 #endif
 
 #if defined(TRIO_PLATFORM_UNIX)
+# include <strings.h>
 # define USE_STRCASECMP
 # define USE_STRNCASECMP
 # if defined(TRIO_PLATFORM_SUNOS)


### PR DESCRIPTION
The exact error (by clang) was that a missing declaration is no longer supported with the latest C++ standards.