### PR TITLE
Update benchmark scripts for Python3.12.

### DIFF
--- a/source/version.py
+++ b/source/version.py
@@ -145,7 +145,7 @@ def generate_version_information(rosetta_dir, url=None, branch=None, package=Non
         if res: git_describe = None
         else:
             git_describe_str = git_describe_str[:-1] # remove \n at the end
-            describe_match = re.match("v(?P<year>\d+)\.(?P<week>\d+)(-dev(?P<dev_revision>\d+))?-(?P<post_revision>\d+)-g(?P<commit>\w+)", git_describe_str)
+            describe_match = re.match(r"v(?P<year>\d+)\.(?P<week>\d+)(-dev(?P<dev_revision>\d+))?-(?P<post_revision>\d+)-g(?P<commit>\w+)", git_describe_str)
 
             if describe_match:
                 git_describe = describe_match.groupdict()

--- a/tests/benchmark/benchmark.py
+++ b/tests/benchmark/benchmark.py
@@ -90,7 +90,7 @@ def setup_from_options(options):
             interpolation = ExtendedInterpolation()
         )
 
-        with open(options.config) as f: user_config.readfp(f)
+        with open(options.config) as f: user_config.read_file(f)
 
     else:
         print(f"\n\n>>> Config file `{options.config}` not found. You may want to manually copy `benchmark.template.ini` to `{options.config}` and edit the settings\n\n")
@@ -288,9 +288,9 @@ def run_test(setup):
 
         if state_override:
             log_prefix = \
-                f'WARNING: Previous test results does not have `.execution.results.json` file, so comparision with None was performed instead!\n' \
+                f'WARNING: Previous test results does not have `.execution.results.json` file, so comparison with None was performed instead!\n' \
                 f'WARNING: This can often be fixed by merging with the latest `main`.\n' \
-                f'WARNING: Overriding calcualted test state `{res[_StateKey_]}` → `{_S_failed_}`...\n\n'
+                f'WARNING: Overriding calculated test state `{res[_StateKey_]}` → `{_S_failed_}`...\n\n'
 
             res[_LogKey_] = log_prefix + res[_LogKey_]
             res[_StateKey_] = _S_failed_

--- a/tests/benchmark/tests/PyRosetta.py
+++ b/tests/benchmark/tests/PyRosetta.py
@@ -12,9 +12,6 @@
 ## @brief  PyRosetta binding self tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import sys, os, os.path, json, shutil
 import codecs
 
@@ -25,6 +22,10 @@ import codecs
 
 try: from setuptools.distutils import dir_util as dir_util_module
 except ModuleNotFoundError: from distutils import dir_util as dir_util_module
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/PyRosetta.py
+++ b/tests/benchmark/tests/PyRosetta.py
@@ -12,6 +12,9 @@
 ## @brief  PyRosetta binding self tests
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import sys, os, os.path, json, shutil
 import codecs
 
@@ -22,9 +25,6 @@ import codecs
 
 try: from setuptools.distutils import dir_util as dir_util_module
 except ModuleNotFoundError: from distutils import dir_util as dir_util_module
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -935,12 +935,13 @@ def generate_version_information(rosetta_dir, **kwargs):
     This is a light wrapper around the generate_version_information() function in Rosetta/main/source/version.py -- see there for the interface definition.
     '''
 
-    contents = {}
-    exec(open(rosetta_dir + '/source/version.py').read(), contents)
-    generate_version_information = contents['generate_version_information']
+    import importlib.util
 
-    return version.generate_version_information(rosetta_dir=rosetta_dir, **kwargs)
+    spec = importlib.util.spec_from_file_location('rosetta_source_version', rosetta_dir + '/source/version.py' )
+    rosetta_source_version = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rosetta_source_version)
 
+    return rosetta_source_version.generate_version_information(rosetta_dir=rosetta_dir, **kwargs)
 
 
 def _get_path_to_conda_root(platform, config):

--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -12,7 +12,7 @@
 ## @brief  Common constats and types for all test types
 ## @author Sergey Lyskov
 
-import os, time, sys, shutil, codecs, urllib.request, imp, subprocess, json, hashlib  # urllib.error, urllib.parse,
+import os, time, sys, shutil, codecs, urllib.request, subprocess, json, hashlib  # urllib.error, urllib.parse,
 import platform as  platform_module
 import types as types_module
 
@@ -935,7 +935,10 @@ def generate_version_information(rosetta_dir, **kwargs):
     This is a light wrapper around the generate_version_information() function in Rosetta/main/source/version.py -- see there for the interface definition.
     '''
 
-    version = imp.load_source('version', rosetta_dir + '/source/version.py')
+    contents = {}
+    exec(open(rosetta_dir + '/source/version.py').read(), contents)
+    generate_version_information = contents['generate_version_information']
+
     return version.generate_version_information(rosetta_dir=rosetta_dir, **kwargs)
 
 
@@ -974,7 +977,7 @@ def _get_path_to_conda_root(platform, config):
     #packages = ['conda-build gcc'] # libgcc installs is workaround for "Anaconda libstdc++.so.6: version `GLIBCXX_3.4.20' not found", see: https://stackoverflow.com/questions/48453497/anaconda-libstdc-so-6-version-glibcxx-3-4-20-not-found
     packages = ['conda-build anaconda-client conda-verify',]
 
-    signature = f'url: {url}\nversion: {version}\channels: {channels}\npackages: {packages}\n'
+    signature = f'url: {url}\nversion: {version}\nchannels: {channels}\npackages: {packages}\n'
 
     root = calculate_unique_prefix_path(platform, config) + '/conda'
 

--- a/tests/benchmark/tests/build.py
+++ b/tests/benchmark/tests/build.py
@@ -12,11 +12,11 @@
 ## @brief  Rosetta/PyRosetta build tests
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, json, shutil
 import codecs
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/build.py
+++ b/tests/benchmark/tests/build.py
@@ -12,11 +12,12 @@
 ## @brief  Rosetta/PyRosetta build tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, json, shutil
 import codecs
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/code_quality.py
+++ b/tests/benchmark/tests/code_quality.py
@@ -13,14 +13,13 @@
 ## Benchmark script for running serialization test
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, json
 import glob, shutil
 import plistlib
 import time
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/code_quality.py
+++ b/tests/benchmark/tests/code_quality.py
@@ -13,13 +13,14 @@
 ## Benchmark script for running serialization test
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, json
 import glob, shutil
 import plistlib
 import time
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/integration.py
+++ b/tests/benchmark/tests/integration.py
@@ -14,13 +14,13 @@
 ## @author Rocco Moretti (Valgrind additions)
 ## @author Jared Adolf-Bryfogle( Demos/Tutorials additions)
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, os.path, shutil, re, fnmatch
 from collections import defaultdict
 import json
 import codecs
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/integration.py
+++ b/tests/benchmark/tests/integration.py
@@ -14,13 +14,14 @@
 ## @author Rocco Moretti (Valgrind additions)
 ## @author Jared Adolf-Bryfogle( Demos/Tutorials additions)
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, shutil, re, fnmatch
 from collections import defaultdict
 import json
 import codecs
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/maintenance.py
+++ b/tests/benchmark/tests/maintenance.py
@@ -12,10 +12,10 @@
 ## @brief  Benchmark tests which are intended for housekeeping purposes
 ## @author Rocco Moretti (rmorettiase@gmail.com)
 
-import os, os.path, json, shutil, stat, glob
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import os, os.path, json, shutil, stat, glob
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/maintenance.py
+++ b/tests/benchmark/tests/maintenance.py
@@ -12,10 +12,11 @@
 ## @brief  Benchmark tests which are intended for housekeeping purposes
 ## @author Rocco Moretti (rmorettiase@gmail.com)
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, json, shutil, stat, glob
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/performance.py
+++ b/tests/benchmark/tests/performance.py
@@ -12,11 +12,11 @@
 ## @brief  Performace benchmark test
 ## @author Sergey Lyskov
 
-import os, os.path, json, shutil, stat
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
+import os, os.path, json, shutil, stat
 import codecs
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/performance.py
+++ b/tests/benchmark/tests/performance.py
@@ -12,11 +12,13 @@
 ## @brief  Performace benchmark test
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, json, shutil, stat
+
 import codecs
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/profile.py
+++ b/tests/benchmark/tests/profile.py
@@ -13,12 +13,11 @@
 ## Benchmark script for running Rosetta profile tests
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import json, os, os.path, shutil
 import codecs
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/profile.py
+++ b/tests/benchmark/tests/profile.py
@@ -13,11 +13,12 @@
 ## Benchmark script for running Rosetta profile tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import json, os, os.path, shutil
 import codecs
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -12,6 +12,9 @@
 ## @brief  Rosetta and PyRosetta release scripts
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, os.path, json, shutil, tarfile, datetime, re as re_module
 import codecs
 
@@ -20,9 +23,6 @@ try:
 except ModuleNotFoundError:
     from distutils import dir_util as dir_util_module
 
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -12,9 +12,6 @@
 ## @brief  Rosetta and PyRosetta release scripts
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, json, shutil, tarfile, datetime, re as re_module
 import codecs
 
@@ -23,6 +20,10 @@ try:
 except ModuleNotFoundError:
     from distutils import dir_util as dir_util_module
 
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/scientific/_dir_template_/command.py
+++ b/tests/benchmark/tests/scientific/_dir_template_/command.py
@@ -14,8 +14,8 @@
 ## For example of how to implement test which does not require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_.py
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+# A bit of Python magic here, what we trying to say is this: from ../../../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-3]) +  '/__init__.py').read(), globals())
 
 import os, json
 

--- a/tests/benchmark/tests/scientific/_dir_template_/command.py
+++ b/tests/benchmark/tests/scientific/_dir_template_/command.py
@@ -14,10 +14,11 @@
 ## For example of how to implement test which does not require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_.py
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../../../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-3]) +  '/__init__.py').read(), globals())
-
 import os, json
+
+# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-3]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.0'  # api version
 

--- a/tests/benchmark/tests/scientific/_dir_template_/command.py
+++ b/tests/benchmark/tests/scientific/_dir_template_/command.py
@@ -14,10 +14,10 @@
 ## For example of how to implement test which does not require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_.py
 ## @author Sergey Lyskov
 
-import os, json
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/../../__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init is calculated from file location
+import os, json
 
 _api_version_ = '1.0'  # api version
 

--- a/tests/benchmark/tests/scientific/_template_test_suite_.py
+++ b/tests/benchmark/tests/scientific/_template_test_suite_.py
@@ -14,8 +14,8 @@
 ## For example of how to implement test which require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_dir_
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-2]) +  '/__init__.py').read(), globals())
 
 import os, json
 

--- a/tests/benchmark/tests/scientific/_template_test_suite_.py
+++ b/tests/benchmark/tests/scientific/_template_test_suite_.py
@@ -14,10 +14,11 @@
 ## For example of how to implement test which require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_dir_
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-2]) +  '/__init__.py').read(), globals())
-
 import os, json
+
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-2]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 
 _api_version_ = '1.0'  # api version

--- a/tests/benchmark/tests/scientific/_template_test_suite_.py
+++ b/tests/benchmark/tests/scientific/_template_test_suite_.py
@@ -14,10 +14,10 @@
 ## For example of how to implement test which require extra files (beside access to 'data' checkout) please see rosetta/benchmark/tests/benchmark/tests/scientific/_template_dir_
 ## @author Sergey Lyskov
 
-import os, json
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/../__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+import os, json
 
 
 _api_version_ = '1.0'  # api version

--- a/tests/benchmark/tests/scientific/command.py
+++ b/tests/benchmark/tests/scientific/command.py
@@ -13,8 +13,8 @@
 ## Python script for running multi-step scientific tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-2]) +  '/__init__.py').read(), globals())
 
 import os, json
 

--- a/tests/benchmark/tests/scientific/command.py
+++ b/tests/benchmark/tests/scientific/command.py
@@ -13,10 +13,11 @@
 ## Python script for running multi-step scientific tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-2]) +  '/__init__.py').read(), globals())
-
 import os, json
+
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-2]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/scientific/command.py
+++ b/tests/benchmark/tests/scientific/command.py
@@ -13,10 +13,10 @@
 ## Python script for running multi-step scientific tests
 ## @author Sergey Lyskov
 
-import os, json
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/../__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+import os, json
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
+++ b/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
@@ -12,8 +12,8 @@
 ## @brief  Benchmark script for testing how Rosetta can load PBD's from www.rcsb.org
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+# A bit of Python magic here, what we trying to say is this: from ../../../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-3]) +  '/__init__.py').read(), globals())
 
 import os, json, enum, time, shutil
 from collections import namedtuple, OrderedDict

--- a/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
+++ b/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
@@ -12,9 +12,6 @@
 ## @brief  Benchmark script for testing how Rosetta can load PBD's from www.rcsb.org
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../../../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-3]) +  '/__init__.py').read(), globals())
-
 import os, json, enum, time, shutil
 from collections import namedtuple, OrderedDict
 
@@ -23,6 +20,10 @@ script_name = os.path.abspath(__file__)  # keep this line above imp.load_source(
 _api_version_ = '1.1'
 
 _number_of_jobs_ = 1024
+
+# A bit of Python magic here, what we trying to say is this: from ../../__init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-3]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 Job = namedtuple('Job', 'name pdbs path rosetta_dir command_line')  #  hpc_job_id
 #Job.__new__.__defaults__ = (None, )

--- a/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
+++ b/tests/benchmark/tests/scientific/protein_data_bank_diagnostic/command.py
@@ -12,7 +12,10 @@
 ## @brief  Benchmark script for testing how Rosetta can load PBD's from www.rcsb.org
 ## @author Sergey Lyskov
 
-import os, json, enum, imp, time, shutil
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
+import os, json, enum, time, shutil
 from collections import namedtuple, OrderedDict
 
 script_name = os.path.abspath(__file__)  # keep this line above imp.load_source(...) line below, beacuse later change value of __file__ variable
@@ -20,8 +23,6 @@ script_name = os.path.abspath(__file__)  # keep this line above imp.load_source(
 _api_version_ = '1.1'
 
 _number_of_jobs_ = 1024
-
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/../../__init__.py')  # A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
 
 Job = namedtuple('Job', 'name pdbs path rosetta_dir command_line')  #  hpc_job_id
 #Job.__new__.__defaults__ = (None, )

--- a/tests/benchmark/tests/score.py
+++ b/tests/benchmark/tests/score.py
@@ -12,10 +12,10 @@
 ## @brief  Rosetta score function fingerprint tests
 ## @author Sergey Lyskov
 
-import os, shutil
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import os, shutil
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/score.py
+++ b/tests/benchmark/tests/score.py
@@ -12,10 +12,11 @@
 ## @brief  Rosetta score function fingerprint tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, shutil
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/scripts.py
+++ b/tests/benchmark/tests/scripts.py
@@ -12,10 +12,12 @@
 ## @brief  Test suite for Rosetta/PyRosetta scripts
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
 import os, sys, json, shutil, distutils.dir_util, codecs
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/scripts.py
+++ b/tests/benchmark/tests/scripts.py
@@ -12,9 +12,10 @@
 ## @brief  Test suite for Rosetta/PyRosetta scripts
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import os, sys, imp, json, shutil, distutils.dir_util, codecs
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import os, sys, json, shutil, distutils.dir_util, codecs
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/self.py
+++ b/tests/benchmark/tests/self.py
@@ -12,13 +12,12 @@
 ## @brief  self-test and debug-aids tests
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, os.path, shutil, re, string
 import json
-
 import random
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/self.py
+++ b/tests/benchmark/tests/self.py
@@ -12,12 +12,13 @@
 ## @brief  self-test and debug-aids tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, shutil, re, string
 import json
 import random
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/unit.py
+++ b/tests/benchmark/tests/unit.py
@@ -12,12 +12,12 @@
 ## @brief  Rosetta/PyRosetta unit tests
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, json, functools
 import codecs
 import pprint
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/unit.py
+++ b/tests/benchmark/tests/unit.py
@@ -12,12 +12,13 @@
 ## @brief  Rosetta/PyRosetta unit tests
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, json, functools
 import codecs
 import pprint
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'
 

--- a/tests/benchmark/tests/util.py
+++ b/tests/benchmark/tests/util.py
@@ -12,10 +12,10 @@
 ## @brief  Benchmark utility tests for various auxiliary tasks
 ## @author Sergey Lyskov
 
-import os, os.path, json, shutil, stat, glob, collections
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
 
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import os, os.path, json, shutil, stat, glob, collections
 
 _api_version_ = '1.1'  # api version
 

--- a/tests/benchmark/tests/util.py
+++ b/tests/benchmark/tests/util.py
@@ -12,10 +12,11 @@
 ## @brief  Benchmark utility tests for various auxiliary tasks
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, json, shutil, stat, glob, collections
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'  # api version
 

--- a/tests/benchmark/tests/windows.py
+++ b/tests/benchmark/tests/windows.py
@@ -12,12 +12,13 @@
 ## @brief  Benchmark tests for various tests for Windows platform
 ## @author Sergey Lyskov
 
-# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
-exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
-
 import os, os.path, json, shutil, stat, glob, collections, codecs
 
 from subprocess import getstatusoutput, getoutput
+
+# A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
+import importlib.util, sys
+importlib.util.spec_from_file_location(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py').loader.exec_module(sys.modules[__name__])
 
 _api_version_ = '1.1'  # api version
 

--- a/tests/benchmark/tests/windows.py
+++ b/tests/benchmark/tests/windows.py
@@ -12,12 +12,12 @@
 ## @brief  Benchmark tests for various tests for Windows platform
 ## @author Sergey Lyskov
 
+# A bit of Python magic here, what we trying to say is this: from ../__init__ import *, but init path is calculated relatively to this location
+exec(open('/'.join(__file__.split('/')[:-1]) +  '/__init__.py').read(), globals())
+
 import os, os.path, json, shutil, stat, glob, collections, codecs
 
 from subprocess import getstatusoutput, getoutput
-
-import imp
-imp.load_source(__name__, '/'.join(__file__.split('/')[:-1]) +  '/__init__.py')  # A bit of Python magic here, what we trying to say is this: from __init__ import *, but init is calculated from file location
 
 _api_version_ = '1.1'  # api version
 


### PR DESCRIPTION
Python 3.12 gets rid of the `imp` module. Moreover, it gets rid of `imp.load_source()` altogether. We thus need to change around how we do the magic 'import from parent directory' statement.

There are also a few other things which were popping up warnings when I ran things locally.