### PR TITLE
Fix windows build.

### DIFF
--- a/source/external/cifparse/CifScanner.c
+++ b/source/external/cifparse/CifScanner.c
@@ -40,7 +40,12 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+
+#ifdef WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 /* end standard C headers. */
 

--- a/source/external/cifparse/DICScanner.c
+++ b/source/external/cifparse/DICScanner.c
@@ -40,7 +40,12 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+
+#ifdef WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 /* end standard C headers. */
 


### PR DESCRIPTION
Make use of POSIX header platform dependent.
I believe that io.h is the Windows equivalent for getting the read() function.