### PR TITLE
Clean up integration tests for running on Python 3.12

### DIFF
--- a/tests/integration/integration.py
+++ b/tests/integration/integration.py
@@ -6,19 +6,20 @@
 # (c) For more information, see http://www.rosettacommons.org. Questions about this can be
 # (c) addressed to University of Washington CoMotion, email: license@uw.edu.
 #
-# For help, run with -h.  Requires Python 2.4+, like the unit tests.
+# For help, run with -h.  Requires Python 3.5+, like the unit tests.
 # Author: Sergey Lyskov
 # Author: Jared Adof-Bryfogle (demo extension)
 from __future__ import print_function
 
 import sys
-if not hasattr(sys, "version_info") or sys.version_info < (2,4):
-    raise ValueError("Script requires Python 2.4 or higher!")
+if not hasattr(sys, "version_info") or sys.version_info < (3,5):
+    raise ValueError("Script requires Python 3.5 or higher!")
 
 import os, shutil, threading, subprocess, signal, time, re, random, datetime, copy, traceback
 import io
 import json
 import glob
+import importlib
 from os import path
 from optparse import OptionParser, IndentedHelpFormatter
 
@@ -357,8 +358,6 @@ EXAMPLES For Running Demos/Tutorials
 
     globalparams = generateIntegrationTestGlobalSubstitutionParameters()
     print("Python: `"  + globalparams.get("python","")  +"`")
-    print("Python2: `" + globalparams.get("python2","") +"`")
-    print("Python3: `" + globalparams.get("python3","") +"`")
     print("\n")
 
     #All tests are in a subdirectory.  We set these up here.
@@ -707,7 +706,7 @@ def setup_demo_command_file(demo_subdir):
     OUTFILE.write("cd %(workdir)s\n\n")
 
     for exe in sorted(set(rosetta_binaries)):
-        chars = "~!@#$%^&*()`+=[]{}\|;:',<.>?" #People do some wierd stuff.
+        chars = r"~!@#$%^&*()`+=[]{}\|;:',<.>?" #People do some wierd stuff.
         for c in chars:
             exe = exe.replace(c, "")
 
@@ -1017,6 +1016,11 @@ def get_binext():
     binext = extras.replace(',', '')+"."+platform+compiler+mode
     return binext, dict(locals())
 
+def check_for_module(module_name):
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        print("WARNING: Python", sys.executable, "does not have module", module_name, "which may cause some tests to show errors.")
 
 def verify_python_version(executable, version):
     command_line = "{executable} -c 'import sys; sys.exit(sys.version_info[0] != {version})'".format(**vars())
@@ -1025,31 +1029,13 @@ def verify_python_version(executable, version):
 def generateIntegrationTestGlobalSubstitutionParameters():
     # Variables that may be referenced in the cmd string:
     python = sys.executable
-    if sys.version_info[0] == 2:
-        python2 = sys.executable
-        python3 = execute("Find python3","which python3",return_="stdout",print_output=False,verbose=False).strip()
-    elif sys.version_info[0] == 3:
-        python3 = sys.executable
-        python2 = execute("Find python2","which python2",return_="stdout",print_output=False,verbose=False).strip()
-        if python2 == "":
-            # On the Mac test servers, there isn't a `python2`, but the regular `python` should be python2
-            # however if we inside Python virtual environemnt then `which python2` migh give nothing so we will look for python2.7
-            python2 = execute("Find python (assume python2.7)", "which python2.7",return_="stdout",print_output=False,verbose=False).strip()
-    else:
-        print("ERROR: Unrecognized Python version!")
-        sys.exit(-1)
+    #verify_python_version(python, 3) # Will do -- we check at the top
+    python3 = sys.executable
+    # No python2!
 
-    if python2 == "":
-        print("ERROR: Unable to find Python2 executable -- some integration tests may fail on that basis alone.")
-        python2 = "PYTHON2_NOT_FOUND"
-    else:
-        verify_python_version(python2, 2)
-
-    if python3 == "":
-        print("ERROR: Unable to find Python3 executable -- some integration tests may fail on that basis alone.")
-        python3 = "PYTHON3_NOT_FOUND"
-    else:
-        verify_python_version(python3, 3)
+    # Check if the current entry has all the modules needed to run tests
+    for module in ["scipy","pubmed_lookup","networkx","mrcfile"]:
+        check_for_module(module)
 
     minidir = Options.mini_home
     database = Options.database
@@ -1649,7 +1635,7 @@ class Queue:
             if unfinished <= 0:
                 if unfinished < 0:
                     raise ValueError('task_done() called too many times')
-                self.all_tasks_done.notifyAll()
+                self.all_tasks_done.notify_all()
             self.unfinished_tasks = unfinished
         finally:
             self.all_tasks_done.release()

--- a/tests/integration/tests/auto-drrafter_final_results/command
+++ b/tests/integration/tests/auto-drrafter_final_results/command
@@ -61,11 +61,11 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round FINAL_R3 -nmodels 10 -rosetta_directory %(raw_bin_dir)s/ -rosetta_extension .%(binext)s -test  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round FINAL_R3 -nmodels 10 -rosetta_directory %(raw_bin_dir)s/ -rosetta_extension .%(binext)s -test  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/finalize_models.py -fasta input_files/fasta.txt -out_pref mini_example -final_round FINAL_R3 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/finalize_models.py -fasta input_files/fasta.txt -out_pref mini_example -final_round FINAL_R3 2>&1 \
     | egrep -vf ../../ignore_list \
     >> log
 

--- a/tests/integration/tests/auto-drrafter_setup_run_R1/command
+++ b/tests/integration/tests/auto-drrafter_setup_run_R1/command
@@ -61,11 +61,11 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup.py -map_thr 30 -full_dens_map input_files/map.mrc -full_dens_map_reso 10.0 -fasta input_files/fasta.txt -secstruct input_files/secstruct.txt -out_pref mini_example -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -repeats 1 -shift_center -nstruct_per_job 1 -cycles 200 -fit_only_one_helix -test  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup.py -map_thr 30 -full_dens_map input_files/map.mrc -full_dens_map_reso 10.0 -fasta input_files/fasta.txt -secstruct input_files/secstruct.txt -out_pref mini_example -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -repeats 1 -shift_center -nstruct_per_job 1 -cycles 200 -fit_only_one_helix -test  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round R1 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round R1 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
     | egrep -vf ../../ignore_list \
     >> log
 

--- a/tests/integration/tests/auto-drrafter_setup_run_R2/command
+++ b/tests/integration/tests/auto-drrafter_setup_run_R2/command
@@ -61,12 +61,12 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round R1 -nmodels 10 -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -test  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round R1 -nmodels 10 -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -test  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round FINAL_R2 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round FINAL_R2 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
     | egrep -vf ../../ignore_list \
     >> log
 

--- a/tests/integration/tests/auto-drrafter_setup_run_R3/command
+++ b/tests/integration/tests/auto-drrafter_setup_run_R3/command
@@ -61,12 +61,12 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round FINAL_R2 -nmodels 10 -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -test  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/auto-DRRAFTER_setup_next_round.py -out_pref mini_example -curr_round FINAL_R2 -nmodels 10 -rosetta_directory %(bin)s/ -rosetta_extension .%(binext)s -test  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round FINAL_R3 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/submit_jobs.py -out_pref mini_example -curr_round FINAL_R3 -njobs 2 -template_submission_script input_files/job_submission_template.sh -queue_command source 2>&1 \
     | egrep -vf ../../ignore_list \
     >> log
 

--- a/tests/integration/tests/code_template_tests_citations/command
+++ b/tests/integration/tests/code_template_tests_citations/command
@@ -47,12 +47,12 @@ cd %(workdir)s
 # "pip install pubmed-lookup" or "pip3 install pubmed-lookup".
 echo "Testing addition of two citations to the Rosetta database." >>out.log
 cp -v database/citations/rosetta_citations.txt database/citations/rosetta_citations.original.txt
-`which python3` %(template_dir)s/add_citation_by_pubmed_id.py --database database/ --pmid 19717430 >>out.log 2>err1.log
+%(python3)s %(template_dir)s/add_citation_by_pubmed_id.py --database database/ --pmid 19717430 >>out.log 2>err1.log
 test "${PIPESTATUS[0]}" != '0' && exit 1 || echo "First script ran successfully."
 
 sleep 5
 
-`which python3` %(template_dir)s/add_citation_by_pubmed_id.py --database database/ --pmid 19880752 >>out.log 2>err2.log
+%(python3)s %(template_dir)s/add_citation_by_pubmed_id.py --database database/ --pmid 19880752 >>out.log 2>err2.log
 test "${PIPESTATUS[0]}" != '0' && exit 1 || echo "Second script ran successfully."
 
 # Check that output matches expected:

--- a/tests/integration/tests/dgdp_script/command
+++ b/tests/integration/tests/dgdp_script/command
@@ -35,7 +35,7 @@ cd %(workdir)s
 
 
 [ -x %(minidir)s/scripts/python/public/cryo_dock_and_assemble/cryo_dock_and_assemble.py ] || exit 1
-%(minidir)s/scripts/python/public/cryo_dock_and_assemble/cryo_dock_and_assemble.py \
+%(python)s %(minidir)s/scripts/python/public/cryo_dock_and_assemble/cryo_dock_and_assemble.py \
 	--rosetta_bin_location %(raw_bin_dir)s \
 	--rosetta_database %(database)s \
 	--bin_extension .%(binext)s \

--- a/tests/integration/tests/drrafter_setup/command
+++ b/tests/integration/tests/drrafter_setup/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct protein_and_RNA_helix_fit_into_density.pdb -map_file 1wsu_simulated_7A.mrc -map_reso 7.0 -residues_to_model E:1-23 -include_as_rigid_body_structures protein_fit_into_density.pdb RNA_helix.pdb -absolute_coordinates_rigid_body_structure protein_fit_into_density.pdb -job_name demo_run -dock_into_density -demo_settings  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct protein_and_RNA_helix_fit_into_density.pdb -map_file 1wsu_simulated_7A.mrc -map_reso 7.0 -residues_to_model E:1-23 -include_as_rigid_body_structures protein_fit_into_density.pdb RNA_helix.pdb -absolute_coordinates_rigid_body_structure protein_fit_into_density.pdb -job_name demo_run -dock_into_density -demo_settings  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_build_missing/command
+++ b/tests/integration/tests/drrafter_setup_build_missing/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct subset_2bh2_bound_full.pdb -map_file empty_2bh2_bound_full.5.00.mrc -map_reso 5.0 -residues_to_model C:844-848 -include_residues_around C:843 C:849 A:13 A:137 -job_name test 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct subset_2bh2_bound_full.pdb -map_file empty_2bh2_bound_full.5.00.mrc -map_reso 5.0 -residues_to_model C:844-848 -include_residues_around C:843 C:849 A:13 A:137 -job_name test 2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_protein_dock/command
+++ b/tests/integration/tests/drrafter_setup_protein_dock/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct unbound_protein_plus_RNA_helix.pdb -map_file empty_2bh2_bound_full.5.00.mrc -map_reso 5.0 -residues_to_model C:834-863 -include_residues_around A:114 -include_as_rigid_body helix_1_aligned_5.pdb protein_2.pdb -job_name test 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct unbound_protein_plus_RNA_helix.pdb -map_file empty_2bh2_bound_full.5.00.mrc -map_reso 5.0 -residues_to_model C:834-863 -include_residues_around A:114 -include_as_rigid_body helix_1_aligned_5.pdb protein_2.pdb -job_name test 2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_real_test_H/command
+++ b/tests/integration/tests/drrafter_setup_real_test_H/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct full_start_struct.pdb -map_file empty_segmented_map.mrc -map_reso 8.0 -residues_to_model A:1-101 B:1-77 -include_residues_around D:137 D:395 -include_as_rigid_body_structures part_of_PBS_helix.pdb start_PBS_bp_helix.pdb trna_helix_1.pdb trna_helix_2.pdb  trna_helix_3.pdb  trna_helix_4.pdb vrna_helix_1.pdb vrna_helix_2.pdb vrna_helix_3.pdb vrna_helix_4.pdb vrna_helix_5.pdb -job_name test 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct full_start_struct.pdb -map_file empty_segmented_map.mrc -map_reso 8.0 -residues_to_model A:1-101 B:1-77 -include_residues_around D:137 D:395 -include_as_rigid_body_structures part_of_PBS_helix.pdb start_PBS_bp_helix.pdb trna_helix_1.pdb trna_helix_2.pdb  trna_helix_3.pdb  trna_helix_4.pdb vrna_helix_1.pdb vrna_helix_2.pdb vrna_helix_3.pdb vrna_helix_4.pdb vrna_helix_5.pdb -job_name test 2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_real_test_H_no_init/command
+++ b/tests/integration/tests/drrafter_setup_real_test_H_no_init/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct full_start_struct.pdb -map_file empty_segmented_map.mrc -map_reso 8.0 -residues_to_model A:1-101 B:1-77 -include_residues_around D:137 D:395 -include_as_rigid_body_structures part_of_PBS_helix.pdb start_PBS_bp_helix.pdb trna_helix_1.pdb trna_helix_2.pdb  trna_helix_3.pdb  trna_helix_4.pdb vrna_helix_1.pdb vrna_helix_2.pdb vrna_helix_3.pdb vrna_helix_4.pdb vrna_helix_5.pdb -job_name test -no_initial_structures -ref_pdb_for_coord_csts full_start_struct.pdb 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct full_start_struct.pdb -map_file empty_segmented_map.mrc -map_reso 8.0 -residues_to_model A:1-101 B:1-77 -include_residues_around D:137 D:395 -include_as_rigid_body_structures part_of_PBS_helix.pdb start_PBS_bp_helix.pdb trna_helix_1.pdb trna_helix_2.pdb  trna_helix_3.pdb  trna_helix_4.pdb vrna_helix_1.pdb vrna_helix_2.pdb vrna_helix_3.pdb vrna_helix_4.pdb vrna_helix_5.pdb -job_name test -no_initial_structures -ref_pdb_for_coord_csts full_start_struct.pdb 2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_ribosome_test/command
+++ b/tests/integration/tests/drrafter_setup_ribosome_test/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta full_fasta.txt -secstruct full_secstruct_fix.txt -map_file empty_emd_2490.mrc -map_reso 4.9 -residues_to_model A:883-893 -job_name test -no_csts -start_struct start_thread_3.pdb -no_initial_structures  2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta full_fasta.txt -secstruct full_secstruct_fix.txt -map_file empty_emd_2490.mrc -map_reso 4.9 -residues_to_model A:883-893 -job_name test -no_csts -start_struct start_thread_3.pdb -no_initial_structures  2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/drrafter_setup_simple/command
+++ b/tests/integration/tests/drrafter_setup_simple/command
@@ -60,7 +60,7 @@ date > start-time.ignore
 # fi
 # `which python3` -m pip install networkx mrcfile >> install_log.ignore 2>&1
 
-`which python3` %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct unbound_protein_5prime_RNA_5.pdb -map_file empty_1b7f_bound.5.00.mrc -map_reso 5.0 -residues_to_model P:3-12 -include_as_rigid_body_structures unbound_protein_5prime_RNA_5A.pdb -absolute_coordinates_rigid_body_structure unbound_protein_5prime_RNA_5A.pdb -job_name test -dock_into_density 2>&1 \
+%(python3)s %(minidir)s/src/apps/public/DRRAFTER/DRRAFTER.py -fasta fasta.txt -secstruct secstruct.txt -start_struct unbound_protein_5prime_RNA_5.pdb -map_file empty_1b7f_bound.5.00.mrc -map_reso 5.0 -residues_to_model P:3-12 -include_as_rigid_body_structures unbound_protein_5prime_RNA_5A.pdb -absolute_coordinates_rigid_body_structure unbound_protein_5prime_RNA_5A.pdb -job_name test -dock_into_density 2>&1 \
     | egrep -vf ../../ignore_list \
     > log
 

--- a/tests/integration/tests/hierarchical_clustering/command
+++ b/tests/integration/tests/hierarchical_clustering/command
@@ -30,7 +30,7 @@ cd %(workdir)s
 
 [ -x %(bin)s/hierarchical_clustering.%(binext)s ] || exit 1
 
-#./letters_clustering_data.py > dm
+#%(python)s ./letters_clustering_data.py > dm
 %(bin)s/hierarchical_clustering.%(binext)s %(additional_flags)s @flags -database %(database)s -testing:INTEGRATION_TEST -clustering:n 3 2>&1 \
     | egrep -vf ../../ignore_list \
     > log_cluster_3

--- a/tests/integration/tests/mmtfIO_score_test/command
+++ b/tests/integration/tests/mmtfIO_score_test/command
@@ -37,7 +37,7 @@ cd %(workdir)s
 test "${PIPESTATUS[0]}" != '0' && exit 1 || true  # Check if the first executable in pipe line return error and exit with error code if so
 
 # If there's some change in how the mmtf files are constructed, dump a readable version
-python3 ../../dump_mmtf_to_json.py *_0001.mmtf *_0002.mmtf > dump_log 2>&1
+%(python3)s ../../dump_mmtf_to_json.py *_0001.mmtf *_0002.mmtf > dump_log 2>&1
 
 # Check if written mmtf files can be read
 %(bin)s/score_jd2.%(binext)s %(additional_flags)s @options -database %(database)s -testing:INTEGRATION_TEST -out:prefix test1_ 2>&1 \

--- a/tests/integration/tests/resource_database_locator/command
+++ b/tests/integration/tests/resource_database_locator/command
@@ -30,7 +30,7 @@ cd %(workdir)s
 
 [ -x %(bin)s/rosetta_scripts_jd3.%(binext)s ] || exit 1
 
-python setup_rosetta_inputs.py &> setup_log
+%(python)s setup_rosetta_inputs.py &> setup_log
 
 %(bin)s/rosetta_scripts_jd3.%(binext)s %(additional_flags)s @flags -database %(database)s -testing:INTEGRATION_TEST 2>&1 \
 	| egrep -vf ../../ignore_list \

--- a/tests/integration/tests/rosie_ligand_docking/command
+++ b/tests/integration/tests/rosie_ligand_docking/command
@@ -13,7 +13,7 @@ cd %(workdir)s/output/trigger-00000.molfile_to_params/
 
 ln -s ../../input/conformers.sdf conformers.sdf
 
-%(pyapps)s/public/molfile_to_params.py -n LG --mm-as-virt --conformers-in-one-file conformers.sdf --chain X 2>&1 \
+%(python)s %(pyapps)s/public/molfile_to_params.py -n LG --mm-as-virt --conformers-in-one-file conformers.sdf --chain X 2>&1 \
     | egrep -vf ../../../../ignore_list \
     > molfile_to_params.log
 

--- a/tests/integration/tests/sequence_profile_constraints/command
+++ b/tests/integration/tests/sequence_profile_constraints/command
@@ -29,7 +29,7 @@
 cd %(workdir)s
 
 [ -x make_sequence_profile.py ] || exit 1
-./make_sequence_profile.py -m BLOSUM62 -p msoleft.pdb -w -1000.0 > make_seq_prof.log 2>&1
+%(python)s ./make_sequence_profile.py -m BLOSUM62 -p msoleft.pdb -w -1000.0 > make_seq_prof.log 2>&1
 
 [ -x %(bin)s/MSA_design.%(binext)s ] || exit 1
 %(bin)s/MSA_design.%(binext)s %(additional_flags)s @MSA.flags -database %(database)s -testing:INTEGRATION_TEST  2>&1 \


### PR DESCRIPTION
If we're updating compilation to only use Python3 (#54), updating the integration tests to remove Python2 dependence also makes sense.

It looks like we've mostly fixed any usage of Python2 already, but I can clean up the ability to use python2 in the framework.

There's also some additional fixes to be compatible with Python 3.12 in particular, as well as some additional diagonstics that can be printed which might be helpful for running on a fresh copy of Python (e.g. a simple Conda environment).

I also cleaned up the test commands such that they all use the same python which is used to launch the integration.py script. (Now that we don't need to have multiple pythons.)