### PR TITLE
Fix pre-compile script calls on Windows build

### DIFF
--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -17,13 +17,13 @@ PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 def execute_rosetta_script_from_source_dir(script_name, parser='bash'):
     command = os.path.join( '.', script_name )
     print("Executing setup script:", command)
-    result = subprocess.run([parser, command], cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    result = subprocess.run([parser, command], cwd="..", check=True, stderr=subprocess.STDOUT)
     print("Setup script finished", command)
     print("Return code: ", result.returncode)
-    print("Output: ", result.stdout.decode("utf-8") )
+    #print("Output: ", result.stdout.decode("utf-8") )
     print("-----------------------------------")
 
-def update_version(): execute_rosetta_script_from_source_dir('version.py','python')
+def update_version(): execute_rosetta_script_from_source_dir('version.py',sys.executable)
 
 def update_options(): execute_rosetta_script_from_source_dir('update_options.sh','bash')
 

--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -15,16 +15,13 @@ PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 
 
 def execute_rosetta_script_from_source_dir(script_name, parser='bash'):
-    command = os.path.join( '.', script_name )
-    command = parser + ' ' + command
-    print("Executing setup script:", command)
-    result = subprocess.run(command, cwd="..", check=True, stderr=subprocess.STDOUT, shell=True)
-    print("Setup script finished", command)
-    print("Return code: ", result.returncode)
-    #print("Output: ", result.stdout.decode("utf-8") )
-    print("-----------------------------------")
+    if parser == 'python':
+        parser = sys.executable
+    command = parser + ' ' + script_name
+    subprocess.run(command, cwd="..", check=True, stderr=subprocess.STDOUT, shell=True)
 
-def update_version(): execute_rosetta_script_from_source_dir('version.py',sys.executable)
+
+def update_version(): execute_rosetta_script_from_source_dir('version.py','python')
 
 def update_options(): execute_rosetta_script_from_source_dir('update_options.sh','bash')
 

--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -15,9 +15,14 @@ PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 
 
 def execute_rosetta_script_from_source_dir(script_name):
-    slash = '\\' if sys.platform == "win32" else '/'
-    return subprocess.check_call('cd .. && .' + slash + script_name, shell=True)
-
+    command = os.path.join( '.', script_name )
+    print("Executing setup script:", command)
+    result = subprocess.run([command], cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    print("Setup script finished", command)
+    print("Return code: ", result.returncode)
+    print("Output: ", result.stdout)
+    print("Stderr: ", result.stderr)
+    print("-----------------------------------")
 
 def update_version(): execute_rosetta_script_from_source_dir('version.py')
 

--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -16,8 +16,9 @@ PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 
 def execute_rosetta_script_from_source_dir(script_name, parser='bash'):
     command = os.path.join( '.', script_name )
+    command = parser + ' ' + command
     print("Executing setup script:", command)
-    result = subprocess.run([parser, command], cwd="..", check=True, stderr=subprocess.STDOUT)
+    result = subprocess.run(command, cwd="..", check=True, stderr=subprocess.STDOUT, shell=True)
     print("Setup script finished", command)
     print("Return code: ", result.returncode)
     #print("Output: ", result.stdout.decode("utf-8") )

--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -14,23 +14,22 @@ PATH_TO_SOURCE_DIR = os.path.dirname( os.path.dirname( os.path.abspath(sys.argv[
 PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 
 
-def execute_rosetta_script_from_source_dir(script_name):
+def execute_rosetta_script_from_source_dir(script_name, parser='bash'):
     command = os.path.join( '.', script_name )
     print("Executing setup script:", command)
-    result = subprocess.run(command, cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    result = subprocess.run([parser, command], cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     print("Setup script finished", command)
     print("Return code: ", result.returncode)
-    print("Output: ", result.stdout)
-    print("Stderr: ", result.stderr)
+    print("Output: ", result.stdout.decode("utf-8") )
     print("-----------------------------------")
 
-def update_version(): execute_rosetta_script_from_source_dir('version.py')
+def update_version(): execute_rosetta_script_from_source_dir('version.py','python')
 
-def update_options(): execute_rosetta_script_from_source_dir('update_options.sh')
+def update_options(): execute_rosetta_script_from_source_dir('update_options.sh','bash')
 
-def update_submodules(): execute_rosetta_script_from_source_dir('update_submodules.sh')
+def update_submodules(): execute_rosetta_script_from_source_dir('update_submodules.sh','bash')
 
-def update_ResidueType_enum_files(): execute_rosetta_script_from_source_dir('update_ResidueType_enum_files.sh')
+def update_ResidueType_enum_files(): execute_rosetta_script_from_source_dir('update_ResidueType_enum_files.sh','bash')
 
 
 def project_callback(project, project_path, project_files):

--- a/source/cmake/make_project.py
+++ b/source/cmake/make_project.py
@@ -17,7 +17,7 @@ PATH_TO_SOURCE_DIR = PATH_TO_SOURCE_DIR.replace('\\', '/')
 def execute_rosetta_script_from_source_dir(script_name):
     command = os.path.join( '.', script_name )
     print("Executing setup script:", command)
-    result = subprocess.run([command], cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    result = subprocess.run(command, cwd="..", check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     print("Setup script finished", command)
     print("Return code: ", result.returncode)
     print("Output: ", result.stdout)


### PR DESCRIPTION
The windows build test on the test server doesn't seem to be updating options appropriately. 

It looks like the issue is that the *.sh files aren't being properly called -- adding "bash" to the front of them allows them to run properly:

Before:
```
Running versioning script ... Done. (0.4 seconds)
```

After:
```
Running versioning script ... Done. (0.4 seconds)
file ./options.dox being updated
file ./full-options-list.md being updated
Number of option files updated: 2
Total 4680 options.
Updating submodules needed for compilation.
Finished updating ResidueProperty code
-- no changes needed
Finished updating VariantType code
-- no changes needed
```
