### PR TITLE
Fix issue with JobGenealogist and serialization.

### DIFF
--- a/source/src/protocols/jd3/JobGenealogist.cc
+++ b/source/src/protocols/jd3/JobGenealogist.cc
@@ -647,14 +647,14 @@ CEREAL_REGISTER_TYPE( protocols::jd3::JobGenealogist )
 /// @brief Automatically generated serialization method
 template< class Archive >
 void
-protocols::jd3::compare_job_nodes::save( Archive & arc ) const {
+protocols::jd3::compare_job_nodes::save( Archive & ) const {
 	// No data currently, so this is a no-op.
 }
 
 /// @brief Automatically generated deserialization method
 template< class Archive >
 void
-protocols::jd3::compare_job_nodes::load( Archive & arc ) {
+protocols::jd3::compare_job_nodes::load( Archive & ) {
 	// No data currently, so this is a no-op.
 }
 

--- a/source/src/protocols/jd3/JobGenealogist.cc
+++ b/source/src/protocols/jd3/JobGenealogist.cc
@@ -648,14 +648,14 @@ CEREAL_REGISTER_TYPE( protocols::jd3::JobGenealogist )
 template< class Archive >
 void
 protocols::jd3::compare_job_nodes::save( Archive & arc ) const {
-	arc( cereal::base_class< compare_job_nodes >( this ) );
+	// No data currently, so this is a no-op.
 }
 
 /// @brief Automatically generated deserialization method
 template< class Archive >
 void
 protocols::jd3::compare_job_nodes::load( Archive & arc ) {
-	arc( cereal::base_class< compare_job_nodes >( this ) );
+	// No data currently, so this is a no-op.
 }
 
 SAVE_AND_LOAD_SERIALIZABLE( protocols::jd3::compare_job_nodes );


### PR DESCRIPTION
An attempt at modernizing the serialization method for protocols::jd3::compare_job_nodes accidentally made things be called in an infinite loop. This is breaking the GCC 12 serialization build.

The fix is easy -- there's now no data to serialize, so we can simply replace the functions with empty ones.