### PR TITLE
Rmsd in smallmol docking

### DIFF
--- a/source/src/protocols/ligand_docking/HighResDocker.hh
+++ b/source/src/protocols/ligand_docking/HighResDocker.hh
@@ -95,6 +95,10 @@ public:
 
 	void set_all_residues(bool input);
 
+    void set_rmsd_limit(core::Real rmsd_limit);
+
+    void disable_rmsd_limit();
+
 public: //For CitationManager:
 
 	/// @brief Provide the citation.
@@ -152,6 +156,9 @@ private:
 	bool allow_minimization_ = true;
 	bool allow_repacking_ = true;
 	bool all_residues_ = false;
+
+    core::Real rmsd_max_ = 99999.999;
+    bool check_rmsd_ = false;
 
 };
 


### PR DESCRIPTION
This PR does two things:

1. It fixes the RMSD accept/reject option in the TransformMover. The old version did not square the distances and was not automorphic. The new version simply uses the Rosetta automorphic rmsd function. Additionally, there is now an informative print to tell a user how many moves were rejected due to rmsd criteria.
2. The RMSD criteria is copied 1 to 1 to the HighResMover and follows the same functionality.

Both changes are useful to limit docking exploration during execution towards the starting position and enforces local refinements.