### PR TITLE
Fix compilation issue with SmartFixbbSimAnnealer.cc

### DIFF
--- a/source/src/core/pack/annealer/SmartFixbbSimAnnealer.cc
+++ b/source/src/core/pack/annealer/SmartFixbbSimAnnealer.cc
@@ -41,6 +41,7 @@
 #include <numeric/random/random.hh>
 #include <ObjexxFCL/FArray1D.hh>
 #include <unordered_map>
+#include <array>
 
 #include <tensorflow/c/c_api.h>
 #include <basic/tensorflow_manager/RosettaTensorflowManager.hh>


### PR DESCRIPTION
Discussion #106 indicated that we may be missing an include for std::array in the USE_TENSORFLOW case.