### PR TITLE
Fix issue related to PackerTask usage in homodimer_design.

### DIFF
--- a/source/src/apps/public/scenarios/beta_strand_homodimer_design/homodimer_design.cc
+++ b/source/src/apps/public/scenarios/beta_strand_homodimer_design/homodimer_design.cc
@@ -150,7 +150,6 @@ private:
 	core::scoring::ScoreFunctionOP scorefxn_;
 	TaskFactoryOP  tf_design_;
 	//kinematics::MoveMapOP movemap_;
-	pack::task::PackerTaskOP task_design_;
 	Size monomer_nres_;
 	bool ala_interface_, find_bb_binding_E_, skip_hd_docking_;// pymolreport_;
 	int n_pack_min_runs_;
@@ -325,15 +324,10 @@ void HDdesignMover::sym_repack_minimize( pose::Pose & pose ){
 
 	protocols::minimization_packing::MinMoverOP sym_minmover( new protocols::minimization_packing::MinMover(mm, scorefxn_, option[ OptionKeys::run::min_type ].value(), 0.001, true /*use_nblist*/ ) );
 
-	task_design_ = tf_design_->create_task_and_apply_taskoperations( pose );
-	protocols::minimization_packing::PackRotamersMoverOP sym_pack_design( new protocols::minimization_packing::PackRotamersMover(scorefxn_, task_design_) );
+	protocols::minimization_packing::PackRotamersMoverOP sym_pack_design( new protocols::minimization_packing::PackRotamersMover(scorefxn_, tf_design_) );
 
-	TR<< "Monomer total residues: "<< monomer_nres_ << " Repacked/Designed residues: "
-		<< task_design_->num_to_be_packed() / 2 << std::endl;
-
-#ifndef NDEBUG
-	TR<< "DESIGN Packer Task after setup: " << *(task_design_) <<std::endl;
-#endif
+	TR<< "Monomer total residues: "<< monomer_nres_ <<
+		" Repacked/Designed residues: " << tf_design_->create_task_and_apply_taskoperations( pose )->num_to_be_packed() / 2 << std::endl;
 
 	TR<< "Number of repack/minimize runs to do: " << n_pack_min_runs_ << std::endl;
 	TR << "Minimizing with: " << option[ OptionKeys::run::min_type ].value() << std::endl;
@@ -477,8 +471,7 @@ void HDdesignMover::apply (pose::Pose & pose ) {
 		}
 		//fill task factory with these restrictions
 		tf_nataa->push_back( repack_op );
-		PackerTaskOP task_nataa = tf_nataa->create_task_and_apply_taskoperations( pose );
-		protocols::minimization_packing::PackRotamersMoverOP sym_pack_nataa( new protocols::minimization_packing::PackRotamersMover(scorefxn_, task_nataa) );
+		protocols::minimization_packing::PackRotamersMoverOP sym_pack_nataa( new protocols::minimization_packing::PackRotamersMover(scorefxn_, tf_nataa) );
 		sym_pack_nataa->apply( pose );
 		TR << "Default SCORE after all NATAA repack: " << (*scorefxn_)(pose) << std::endl;
 		//JobDistributor::get_instance()->job_outputter()->other_pose( job_me, pose, "nataarepack_");

--- a/source/src/protocols/minimization_packing/PackRotamersMover.cc
+++ b/source/src/protocols/minimization_packing/PackRotamersMover.cc
@@ -125,6 +125,20 @@ PackRotamersMover::PackRotamersMover( std::string const & type_name ) :
 // constructors with arguments
 PackRotamersMover::PackRotamersMover(
 	ScoreFunctionCOP scorefxn,
+	TaskFactoryCOP task_factory,
+	core::Size nloop
+) :
+	protocols::moves::Mover("PackRotamersMover"),
+	scorefxn_(std::move( scorefxn )),
+	task_(/* 0 */),
+	nloop_( nloop ),
+	task_factory_( task_factory ),
+	rotamer_sets_( nullptr ),
+	ig_(/* 0 */)
+{}
+
+PackRotamersMover::PackRotamersMover(
+	ScoreFunctionCOP scorefxn,
 	PackerTaskCOP task,
 	core::Size nloop
 ) :

--- a/source/src/protocols/minimization_packing/PackRotamersMover.hh
+++ b/source/src/protocols/minimization_packing/PackRotamersMover.hh
@@ -74,15 +74,30 @@ public:
 	/// @brief constructor with typename; reads the nloop_ value from the global options system.
 	PackRotamersMover( std::string const & );
 
+	/// @brief Constructs a PackRotamersMover with TaskFactory  <taskfactory>
+	/// evaluated using  <scorefxn>
+	///
+	/// ScoreFunction  scorefxn     /function to minimize while changine rotamers
+	/// TaskFactory    taskfactory  /object specifying what to design/pack
+	/// core::Size (int)     nloop  /number of rounds to run packing
+	PackRotamersMover(
+		ScoreFunctionCOP scorefxn,
+		TaskFactoryCOP task_factory = nullptr,
+		core::Size nloop = 1
+	);
+
 	/// @brief Constructs a PackRotamersMover with PackerTask  <task>
 	/// evaluated using  <scorefxn>
+	///
+	/// Note: The version with the TaskFactory is likely preferred,
+	/// unless you have reasons for using a fixed task.
 	///
 	/// ScoreFunction  scorefxn   /function to minimize while changine rotamers
 	/// PackerTask     task       /object specifying what to design/pack
 	/// core::Size (int)     nloop      /number of rounds to run packing
 	PackRotamersMover(
 		ScoreFunctionCOP scorefxn,
-		PackerTaskCOP task = nullptr,
+		PackerTaskCOP task,
 		core::Size nloop = 1
 	);
 

--- a/tests/integration/tests/beta_strand_homodimer/design_options
+++ b/tests/integration/tests/beta_strand_homodimer/design_options
@@ -3,7 +3,7 @@
 -symmetry:symmetry_definition symmdef
 -nstruct 1 #try 5000 or so for production runs
 # -out::pdb_gz true #do this for production runs
--pack_min_runs 1
+-pack_min_runs 2 # >1 Needed to reproduce a bug with multiple runs
 -make_ala_interface true 
 -find_bb_hbond_E true 
 -no_his_his_pairE true 


### PR DESCRIPTION
With a -pack_min_runs of 2 or greater, there's a chance that the sequence of the structure changes. This is a problem for a fixed PackerTask run, as `task_is_valid( pose )` fails if the base residue types don't match up properly. This is an issue found in Discussion #112 

The fix is simple -- just use the TaskFactory which we already have lying around instead of manually generating the packer task. (The PackRotamersMover will properly re-apply the TaskFactory.) We can also make the interface of PackRotamersMover a bit nicer