### PR TITLE
add rosetta.conda.release

### DIFF
--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -2272,6 +2272,11 @@ settings = {
                 "compile" : [ "march=native", "march=core2", ],
             },
         },
+        "appends" : {
+            "flags" : {
+                "link"   : [ "headerpad_max_install_names"],
+	    },
+	},
     },
 
 

--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -340,8 +340,10 @@ def platform_to_pretty_string(platform):
     ''' Take platform as json object and return normalized human-readable string '''
     return '{}.{}{}{}'.format(platform['os'], platform['compiler'], ('.'+'.'.join(platform['extras']) if 'extras' in platform  and  platform['extras'] else ''), ('.python'+platform['python'] if 'python' in platform else ''))
 
+
 def setup_for_compile(rosetta_dir):
     execute('Updating options, ResidueTypes and version info...', f'cd {rosetta_dir}/source && ' + ' && '.join(PRE_COMPILE_SETUP_SCRIPTS) )
+
 
 def build_rosetta(rosetta_dir, platform, config, mode='release', build_unit=False, verbose=False):
     ''' Compile Rosetta binaries on a given platform return (res, output, build_command_line) '''

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -1132,6 +1132,7 @@ def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, 
         os.makedirs(working_dir_release_path)
 
         conda_build_command_line = f'{conda.activate_base} && conda build purge && conda build --no-locking --quiet {recipe_dir} --output-folder {working_dir_release_path}' # --channel conda-forge
+        if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 128'
         conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
 
         m = re_module.search(r"rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -1027,7 +1027,7 @@ cp -r {payload_dir}/* ${{PREFIX}}/
 #cat ../version.json
 
 # Run initial test to pre-build databases and minimal sanity check
-${{PREFIX}}/bin/score -s ${{PREFIX}}/database/sampling/rna/submotif/srl/GUA_GA_430d.pdb
+${{PREFIX}}/bin/score -no_scorefile -s ${{PREFIX}}/database/sampling/rna/submotif/srl/GUA_GA_430d.pdb
 
 
 echo "-------------------------------- Installing Rosetta package... Done."

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -1132,7 +1132,7 @@ def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, 
         os.makedirs(working_dir_release_path)
 
         conda_build_command_line = f'{conda.activate_base} && conda build purge && conda build --no-locking --quiet {recipe_dir} --output-folder {working_dir_release_path}' # --channel conda-forge
-        if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 128'
+        if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 80'
         conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
 
         m = re_module.search(r"rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -403,13 +403,13 @@ def rosetta_documentation(repository_root, working_dir, platform, config, hpc_dr
 
 
 
-def py_rosetta4_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
+def pyrosetta_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
     memory = config['memory'];  jobs = config['cpu_count']
     if platform['os'] != 'windows': jobs = jobs if memory/jobs >= PyRosetta_unix_memory_requirement_per_cpu else max(1, int(memory/PyRosetta_unix_memory_requirement_per_cpu) )  # PyRosetta require at least X Gb per memory per thread
 
     TR = Tracer(True)
 
-    TR('Running PyRosetta4 release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
+    TR('Running PyRosetta release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
 
     # 'release' debug ----------------------------------
     # output = 'dummy\n'
@@ -503,7 +503,7 @@ def py_rosetta4_release(kind, rosetta_dir, working_dir, platform, config, hpc_dr
 
             package_dir = working_dir + '/' + release_name
 
-            execute('Creating PyRosetta4 distribution package...', '{build_command_line} -sd --create-package {package_dir}'.format(**vars()))
+            execute('Creating PyRosetta distribution package...', '{build_command_line} -sd --create-package {package_dir}'.format(**vars()))
 
             release('PyRosetta4', release_name, package_dir, working_dir, platform, config, release_as_git_repository = True if kind in [] else False )
 
@@ -519,7 +519,7 @@ def py_rosetta4_release(kind, rosetta_dir, working_dir, platform, config, hpc_dr
             else:
                 whell_environment = setup_persistent_python_virtual_environment(result.python_environment, 'setuptools wheel')
 
-                execute('Creating PyRosetta4 distribution Wheel package...', f'{whell_environment.activate} && cd {package_dir}/setup && python setup.py sdist bdist_wheel')
+                execute('Creating PyRosetta distribution Wheel package...', f'{whell_environment.activate} && cd {package_dir}/setup && python setup.py sdist bdist_wheel')
                 wheel_file_name = [ f for f in os.listdir( f'{package_dir}/setup/dist' ) if f.endswith('.whl') ][0]
                 release('PyRosetta4', release_name+'.wheel', package_dir=None, working_dir=working_dir, platform=platform, config=config, release_as_git_repository=False, file=f'{package_dir}/setup/dist/{wheel_file_name}', use_rosetta_versioning=False)
 
@@ -535,13 +535,13 @@ def py_rosetta4_release(kind, rosetta_dir, working_dir, platform, config, hpc_dr
 
 
 
-def py_rosetta4_documentation(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
+def pyrosetta_documentation(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
     memory = config['memory'];  jobs = config['cpu_count']
     #if platform['os'] != 'windows': jobs = jobs if memory/jobs >= PyRosetta_unix_memory_requirement_per_cpu else max(1, int(memory/PyRosetta_unix_memory_requirement_per_cpu) )  # PyRosetta require at least X Gb per memory per thread
 
     TR = Tracer(True)
 
-    TR('Running PyRosetta4-documentation release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
+    TR('Running PyRosetta-documentation release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
 
     release_root = config['release_root']
 
@@ -629,7 +629,7 @@ _index_html_template_ = '''\
 '''
 
 
-_conda_setup_only_build_sh_template_ = '''\
+_conda_pyrosetta_setup_only_build_sh_template_ = '''\
 #Configure!/bin/bash
 #http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
@@ -659,15 +659,15 @@ popd
 echo "-------------------------------- Installing PyRosetta Python package... Done."
 '''
 
-def native_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
+def native_libc_pyrosetta_conda_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
     memory = config['memory'];  jobs = config['cpu_count']
     if platform['os'] != 'windows': jobs = jobs if memory/jobs >= PyRosetta_unix_memory_requirement_per_cpu else max(1, int(memory/PyRosetta_unix_memory_requirement_per_cpu) )  # PyRosetta require at least X Gb per memory per thread
 
-    if 'cxx11thread' not in platform['extras']  or  'serialization' not in platform['extras']: raise BenchmarkError( f'Running native_libc_py_rosetta4_conda_release: on platform with extras={platform["extras"]}, however Conda build on platform without cxx11thread or serialization is not supported!' )
+    if 'cxx11thread' not in platform['extras']  or  'serialization' not in platform['extras']: raise BenchmarkError( f'Running native_libc_pyrosetta_conda_release: on platform with extras={platform["extras"]}, however Conda build on platform without cxx11thread or serialization is not supported!' )
 
     TR = Tracer(True)
 
-    TR('Running PyRosetta4 conda release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
+    TR('Running PyRosetta conda release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
 
     conda = setup_conda_virtual_environment(working_dir, platform, config, packages='setuptools')
 
@@ -730,11 +730,11 @@ def native_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platfo
             with open(working_dir+'/output.json', 'w') as f: json.dump({_ResultsKey_:results[_ResultsKey_], _StateKey_:results[_StateKey_]}, f, sort_keys=True, indent=2)
         else:
 
-            TR('Running PyRosetta4 release test: Build and Unit tests passged! Now creating PyRosetta package...')
+            TR('Running PyRosetta release test: Build and Unit tests passged! Now creating PyRosetta package...')
 
             package_dir = working_dir + '/' + release_name
 
-            execute( f'Creating PyRosetta4 distribution package...', f'{build_command_line} -sd --create-package {package_dir}' )
+            execute( f'Creating PyRosetta distribution package...', f'{build_command_line} -sd --create-package {package_dir}' )
 
             python_version_as_tuple = tuple( map(int, platform.get('python', DEFAULT_PYTHON_VERSION).split('.') ) )
 
@@ -770,7 +770,7 @@ def native_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platfo
 
             with open( recipe_dir + '/meta.yaml', 'w' ) as f: json.dump(recipe, f, sort_keys=True, indent=2)
 
-            with open( recipe_dir + '/build.sh', 'w' ) as f: f.write( _conda_setup_only_build_sh_template_.format(**locals()) )
+            with open( recipe_dir + '/build.sh', 'w' ) as f: f.write( _conda_pyrosetta_setup_only_build_sh_template_.format(**locals()) )
 
             # --output              Output the conda package filename which would have been created
             # --output-folder OUTPUT_FOLDER folder to dump output package to. Package are moved here if build or test succeeds. Destination folder must exist prior to using this.
@@ -934,7 +934,7 @@ ${{PREFIX}}/bin/python setup.py install --single-version-externally-managed --re
 popd
 echo "-------------------------------- Installing PyRosetta Python package... Done."
 '''
-def conda_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
+def conda_libc_pyrosetta_conda_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
     ''' Build PyRosetta package using Conda build tools so it will be linked to Conda provided libc
     '''
     memory = config['memory'];  jobs = config['cpu_count']
@@ -942,7 +942,7 @@ def conda_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platfor
 
     TR = Tracer(True)
 
-    TR('Running PyRosetta4 conda release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
+    TR('Running PyRosetta conda release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...'.format( **vars() ) )
 
     conda = setup_conda_virtual_environment(working_dir, platform, config, packages='gcc')  # gcc cmake ninja
 
@@ -1003,6 +1003,159 @@ def conda_libc_py_rosetta4_conda_release(kind, rosetta_dir, working_dir, platfor
 
     return results
 
+
+
+_conda_rosetta_build_sh_template_ = '''\
+#Configure!/bin/bash
+#http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+echo "--- Build"
+echo "PWD: `pwd`"
+echo "Python: `which python` --> `python --version`"
+echo "PREFIX Python: `which ${{PREFIX}}/bin/python` --> `${{PREFIX}}/bin/python --version`"
+
+
+echo "-------------------------------- Installing Rosetta..."
+
+cp {rosetta_binaries_path}/*.so ${{PREFIX}}/bin/
+
+#cp -r {rosetta_dir}/database ${{PREFIX}}/rosetta_database
+
+#pushd {rosetta_binaries_path}
+
+#cat ../version.json
+
+# Run initial test to prebuild databases
+#${{PREFIX}}/bin/python -c 'import pyrosetta; pyrosetta.init(); pyrosetta.get_score_function()(pyrosetta.pose_from_sequence("TEST"))'
+
+#${{PREFIX}}/bin/python setup.py install --single-version-externally-managed --record=record.txt > install.log
+#popd
+
+echo "-------------------------------- Installing Rosetta package... Done."
+'''
+
+
+def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
+    memory = config['memory'];  jobs = config['cpu_count']
+    if platform['os'] != 'windows': jobs = jobs if memory/jobs >= PyRosetta_unix_memory_requirement_per_cpu else max(1, int(memory/PyRosetta_unix_memory_requirement_per_cpu) )  # PyRosetta require at least X Gb per memory per thread
+
+    #if 'cxx11thread' not in platform['extras']  or  'serialization' not in platform['extras']: raise BenchmarkError( f'Running native_libc_pyrosetta_conda_release: on platform with extras={platform["extras"]}, however Conda build on platform without cxx11thread or serialization is not supported!' )
+
+    TR = Tracer(True)
+
+    TR(f'Running Rosetta conda release test: at working_dir={working_dir!r} with rosetta_dir={rosetta_dir}, platform={platform}, jobs={jobs}, memory={memory}GB, hpc_driver={hpc_driver}...')
+
+    conda = setup_conda_virtual_environment(working_dir, platform, config, packages='setuptools')
+
+    platform_name = get_platform_release_name(platform)
+    release_name = 'Rosetta.conda.{platform}.python{python_version}.{kind}'.format(kind=kind, platform=platform_name, python_version=platform['python'].replace('.', '') )
+
+    version_file = working_dir + '/version.json'
+    version = generate_version_information(rosetta_dir, branch=config['branch'], revision=config['revision'], package=release_name, url='https://github.com/RosettaCommons/rosetta', file_name=version_file)  # date=datetime.datetime.now(), avoid setting date and instead use date from Git commit
+
+    res, build_output, build_command_line = build_rosetta(rosetta_dir, platform, config, mode='release', build_unit=False, verbose=False)
+
+    if res:
+        res_code = _S_build_failed_
+        results = {_StateKey_ : res_code,  _ResultsKey_ : {},  _LogKey_ : build_output }
+        with open(working_dir+'/output.json', 'w') as f: json.dump({_ResultsKey_:results[_ResultsKey_], _StateKey_:results[_StateKey_]}, f, sort_keys=True, indent=2)
+        return results
+
+    codecs.open(working_dir+'/build-log.txt', 'w', encoding='utf-8', errors='backslashreplace').write(build_output)
+
+    full_log = build_output
+
+    platform_prefix_command_line = f'cd {rosetta_dir}/source && ' + build_command_line + ' log=platform unit_test_platform_only'
+    exit_code, prefix_output = execute('getting build platform info...', command_line=platform_prefix_command_line, return_='tuple')
+
+    for line in prefix_output.split('\n'):
+        if 'Platform' in line:
+            platform_prefix = line.split()[1]
+    TR(f'Platform prefix: {platform_prefix!r}')
+
+    rosetta_binaries_path = f'{rosetta_dir}/source/build/src/{platform_prefix}'
+
+    full_log += '\nRosetta binaries location: ' + rosetta_binaries_path + '\n'
+
+    TR('Creating Rosetta package...')
+
+    results = {_StateKey_ : _S_passed_,  _ResultsKey_ : {},  _LogKey_ : full_log}
+    with open(working_dir+'/output.json', 'w') as f: json.dump(results, f, sort_keys=True, indent=2)  # makeing sure that results could be serialize in to json, but ommiting logs because they could take too much space
+
+    recipe_dir = working_dir + '/recipe';  os.makedirs(recipe_dir)
+
+    recipe = dict(
+        package = dict(
+            name    = 'rosetta',
+            version = version['version'],
+        ),
+        requirements = dict(
+            build = [f'python {platform["python"]}'],
+            host  = [f'python {platform["python"]}', 'zlib'],
+            run   = ['zlib'],
+        ),
+
+        about = dict(
+            home    = 'https://github.com/RosettaCommons/rosetta',
+            license = 'Rosetta license',
+            license_file = f'{rosetta_dir}/LICENSE.md',
+            summary = 'Rosetta, biomolecular modeling software package',
+            description = 'The Rosetta software suite includes algorithms for computational modeling and analysis of protein structures. It has enabled notable scientific advances in computational biology, including de novo protein design, enzyme design, ligand docking, and structure prediction of biological macromolecules and macromolecular complexes.',
+        ),
+    )
+
+
+    with open( recipe_dir + '/meta.yaml', 'w' ) as f: json.dump(recipe, f, sort_keys=True, indent=2)
+
+    with open( recipe_dir + '/build.sh', 'w' ) as f: f.write( _conda_rosetta_build_sh_template_.format(**locals()) )
+
+    release_kind = 'release' if config['branch'] == 'release' else 'devel'
+    conda_release_path = '{release_dir}/PyRosetta4/conda/{release_kind}'.format(release_dir=config['release_root'], release_kind = release_kind) # note that we intentionally using `PyRosetta4` path so all our releases is in the same channel
+    if not os.path.isdir(conda_release_path): os.makedirs(conda_release_path)
+
+    with FileLock( '{conda_release_path}/.{os}.rosetta.python{python_version}.release.lock'.format(os=platform['os'], python_version=platform['python'].replace('.', ''), **vars()) ):
+        working_dir_release_path = f'{working_dir}/conda-release'
+        os.makedirs(working_dir_release_path)
+
+        conda_build_command_line = f'{conda.activate_base} && conda build purge && conda build --no-locking --quiet {recipe_dir} --output-folder {working_dir_release_path}' # --channel conda-forge
+        conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
+
+        m = re_module.search(r"rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)
+        conda_package = m.group(0) if m else 'unknown'
+        conda_package_dir = re_module.search(r"/([^/]*)/rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE).group(1)
+
+        TR(f'Building Conda package: {conda_package}...')
+        res, conda_log = execute('Creating Conda package...', conda_build_command_line, return_='tuple', add_message_and_command_line_to_output=True)
+
+        results[_LogKey_]  += f'Got package name from conda build command line `{conda_build_command_line}` : {conda_package}\n' + conda_log
+        with open(working_dir+'/conda-build-log.txt', 'w') as f: f.write( to_unicode(conda_log) )
+
+        if not os.path.isdir(f'{conda_release_path}/{conda_package_dir}'): os.makedirs(f'{conda_release_path}/{conda_package_dir}')
+        shutil.move(f'{working_dir_release_path}/{conda_package_dir}/{conda_package}', f'{conda_release_path}/{conda_package_dir}/{conda_package}')
+
+    if res:
+        results[_StateKey_] = _S_script_failed_
+        results[_LogKey_]  += conda_log
+    else:
+        with FileLock( f'{conda_release_path}/.release.lock' ):
+            if platform['os'] not in ['mac', 'm1']: execute('Regenerating Conda package index...', f'{conda.activate_base} && cd {conda_release_path} && conda index .')
+
+        conda_package_version = conda_package.split('/')[-1].partition('-')[2]
+        print(f'Determent conda_package_version for package {conda_package!r}: {conda_package_version!r}...')
+        with open(f'{working_dir}/index.html', 'w') as f: f.write( _index_html_template_.format(**vars() ) )
+
+
+    if not debug:
+        for d in [conda.root, working_dir_release_path]: shutil.rmtree(d)  # removing packages to keep size of Benchmark database small
+
+    with open(working_dir+'/output.json', 'w') as f: json.dump(results, f, sort_keys=True, indent=2)  # makeing sure that results could be serialize in to json, but ommiting logs because they could take too much space
+
+    return results
 
 
 
@@ -1091,9 +1244,11 @@ def self_release(rosetta_dir, working_dir, platform, config, hpc_driver=None, ve
 
 
 
+def rosetta_conda_release(*args, **kwargs): return native_libc_rosetta_conda_release(*args, **kwargs)
 
-def py_rosetta4_conda_release(*args, **kwargs): return native_libc_py_rosetta4_conda_release(*args, **kwargs)
-#def py_rosetta4_conda_release(*args, **kwargs): return conda_libc_py_rosetta4_conda_release(*args, **kwargs)
+
+def pyrosetta_conda_release(*args, **kwargs): return native_libc_pyrosetta_conda_release(*args, **kwargs)
+#def pyrosetta_conda_release(*args, **kwargs): return conda_libc_pyrosetta_conda_release(*args, **kwargs)
 
 
 def run(test, repository_root, working_dir, platform, config, hpc_driver=None, verbose=False, debug=False):
@@ -1109,17 +1264,19 @@ def run(test, repository_root, working_dir, platform, config, hpc_driver=None, v
 
     elif test =='rosetta.documentation':  return rosetta_documentation(repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
 
-    elif test =='PyRosetta.Debug':          return py_rosetta4_release('Debug',          repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.Release':        return py_rosetta4_release('Release',        repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.MinSizeRel':     return py_rosetta4_release('MinSizeRel',     repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.RelWithDebInfo': return py_rosetta4_release('RelWithDebInfo', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='rosetta.conda.release':  return rosetta_conda_release('Release', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
 
-    elif test =='PyRosetta.conda.Debug':          return py_rosetta4_conda_release('Debug',          repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.conda.Release':        return py_rosetta4_conda_release('Release',        repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.conda.MinSizeRel':     return py_rosetta4_conda_release('MinSizeRel',     repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
-    elif test =='PyRosetta.conda.RelWithDebInfo': return py_rosetta4_conda_release('RelWithDebInfo', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.Debug':          return pyrosetta_release('Debug',          repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.Release':        return pyrosetta_release('Release',        repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.MinSizeRel':     return pyrosetta_release('MinSizeRel',     repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.RelWithDebInfo': return pyrosetta_release('RelWithDebInfo', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
 
-    elif test =='PyRosetta.documentation':  return py_rosetta4_documentation('MinSizeRel', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.conda.Debug':          return pyrosetta_conda_release('Debug',          repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.conda.Release':        return pyrosetta_conda_release('Release',        repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.conda.MinSizeRel':     return pyrosetta_conda_release('MinSizeRel',     repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+    elif test =='PyRosetta.conda.RelWithDebInfo': return pyrosetta_conda_release('RelWithDebInfo', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
+
+    elif test =='PyRosetta.documentation':  return pyrosetta_documentation('MinSizeRel', repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
 
     elif test =='ui': return ui_release(repository_root, working_dir, platform, config=config, hpc_driver=hpc_driver, verbose=verbose, debug=debug)
 

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -1132,7 +1132,7 @@ def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, 
         os.makedirs(working_dir_release_path)
 
         conda_build_command_line = f'{conda.activate_base} && conda build purge && conda build --no-locking --quiet {recipe_dir} --output-folder {working_dir_release_path}' # --channel conda-forge
-        if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 80'
+        #if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 80'
         conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
 
         m = re_module.search(r"rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)


### PR DESCRIPTION
- Add script to support releasing Rosetta binary build as Conda package for Linux, Mac and Mac-m1 platforms.
- minor release cleanup