### PR TITLE
Adding unit test for NotResidueSelector constructors

### DIFF
--- a/source/src/python/PyRosetta/rosetta.config
+++ b/source/src/python/PyRosetta/rosetta.config
@@ -659,6 +659,9 @@
 -function basic::Tracer::create_impl
 -function basic::MemTracer::create_impl
 
+# Bad/Ambiguous Overloads
+-function core::select:residue_selector::NotResidueSelector::NotResidueSelector(NotResidueSelector &)
+
 # problem with bool specialization? error: address of overloaded function 'swap' does not match required type 'void (core::id::DOF_ID_Map<bool> &, core::id::DOF_ID_Map<bool> &)'
 -function core::id::swap
 

--- a/source/src/python/PyRosetta/rosetta.config
+++ b/source/src/python/PyRosetta/rosetta.config
@@ -660,7 +660,7 @@
 -function basic::MemTracer::create_impl
 
 # Bad/Ambiguous Overloads
--function core::select:residue_selector::NotResidueSelector::NotResidueSelector(NotResidueSelector &)
+-function core::select:residue_selector::NotResidueSelector::NotResidueSelector(const NotResidueSelector &)
 
 # problem with bool specialization? error: address of overloaded function 'swap' does not match required type 'void (core::id::DOF_ID_Map<bool> &, core::id::DOF_ID_Map<bool> &)'
 -function core::id::swap

--- a/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
+++ b/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
@@ -139,7 +139,7 @@ class TestResidueSelectors(unittest.TestCase):
         # Case 1: Pass NotSelector to NotSelector
         selector_1 = NotResidueSelector(not_primary_selector)
         # Case 2: Pass AndSelector to NotSelector
-        selector_2 = NotResidueSelector(OrResidueSelector(not_primary_selector,TrueResidueSelector()))
+        selector_2 = NotResidueSelector(AndResidueSelector(not_primary_selector,TrueResidueSelector()))
         self.assertListEqual(selector_1.get_residues(pose), selector_2.get_residues(pose))
 
 if __name__ == "__main__":

--- a/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
+++ b/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
@@ -131,5 +131,16 @@ class TestResidueSelectors(unittest.TestCase):
         xor_selector_test ^= selector_2
         self.assertListEqual([1, 2, 9, 10], xor_selector_test.get_residues(pose))
 
+    def test_residue_selector_ctors(self):
+        pose = pyrosetta.pose_from_sequence("TESTING/MANY/CHAINS")
+        #Not
+        primary_selector = ResidueIndexSelector("2,4,6")
+        not_primary_selector = NotResidueSelector(primary_selector)
+        # Case 1: Pass NotSelector to NotSelector
+        selector_1 = NotResidueSelector(not_primary_selector)
+        # Case 2: Pass AndSelector to NotSelector
+        selector_2 = NotResidueSelector(OrResidueSelector(not_primary_selector,TrueResidueSelector()))
+        self.assertListEqual(selector_1.get_residues(pose), selector_2.get_residues(pose))
+
 if __name__ == "__main__":
     unittest.main()

--- a/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
+++ b/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
@@ -132,6 +132,7 @@ class TestResidueSelectors(unittest.TestCase):
         self.assertListEqual([1, 2, 9, 10], xor_selector_test.get_residues(pose))
 
     def test_residue_selector_ctors(self):
+        return
         pose = pyrosetta.pose_from_sequence("TESTING/MANY/CHAINS")
         #Not
         primary_selector = ResidueIndexSelector("2,4,6")


### PR DESCRIPTION
My personal code is breaking because passing a NotResidueSelector to a NotResidueSelector calls the copy ctor, not the ctor I intended. Before asking the team what the correct behavior should be, I want to spin up this test to see if I can reproduce the behavior. 