### PR TITLE
PyRosetta update

### DIFF
--- a/source/src/python/PyRosetta/build.py
+++ b/source/src/python/PyRosetta/build.py
@@ -492,7 +492,7 @@ def generate_rosetta_cmake_files(rosetta_source_path, prefix):
 
     all_libs.sort(key=key, reverse=True)
 
-    if Options.skip_namespaces:
+    if Options.skip_namespaces >= 0:
         for l in all_libs[:]:
             if (5 - Options.skip_namespaces ) - int(key(l)[0]) < 0: all_libs.remove(l)
 

--- a/source/src/python/PyRosetta/rosetta.config
+++ b/source/src/python/PyRosetta/rosetta.config
@@ -659,7 +659,7 @@
 -function basic::Tracer::create_impl
 -function basic::MemTracer::create_impl
 
-# Bad/Ambiguous Overloads
+# Bad/Ambiguous Overloads, see test T121_core.ResidueSelector.test_residue_selector_ctors for a test case
 -function core::select:residue_selector::NotResidueSelector::NotResidueSelector(const NotResidueSelector &)
 
 # problem with bool specialization? error: address of overloaded function 'swap' does not match required type 'void (core::id::DOF_ID_Map<bool> &, core::id::DOF_ID_Map<bool> &)'

--- a/source/src/python/PyRosetta/rosetta.config
+++ b/source/src/python/PyRosetta/rosetta.config
@@ -659,8 +659,9 @@
 -function basic::Tracer::create_impl
 -function basic::MemTracer::create_impl
 
-# Bad/Ambiguous Overloads, see test T121_core.ResidueSelector.test_residue_selector_ctors for a test case
--function core::select:residue_selector::NotResidueSelector::NotResidueSelector(const NotResidueSelector &)
+# Bad/Ambiguous Overloads of copy-constructor, see test T121_core.ResidueSelector.test_residue_selector_ctors for a test case
+-function core::select::residue_selector::NotResidueSelector::NotResidueSelector(const class core::select::residue_selector::NotResidueSelector &)
+
 
 # problem with bool specialization? error: address of overloaded function 'swap' does not match required type 'void (core::id::DOF_ID_Map<bool> &, core::id::DOF_ID_Map<bool> &)'
 -function core::id::swap

--- a/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
+++ b/source/src/python/PyRosetta/src/test/T121_core.ResidueSelector.py
@@ -33,7 +33,7 @@ class TestResidueSelectors(unittest.TestCase):
         chA = ChainSelector("A")
         chB = ChainSelector("B")
         chC = ChainSelector("C")
-        
+
         # Test AndResidueSelector
         chA_and_chB = AndResidueSelector(chA, chB)
         chA_and_chB_test = chA & chB
@@ -120,7 +120,7 @@ class TestResidueSelectors(unittest.TestCase):
 
         # Test in-place OrResidueSelector
         chA_or_chC = OrResidueSelector(chA, chC)
-        chA_or_chC_test = chA 
+        chA_or_chC_test = chA
         chA_or_chC_test |= chC
         self.assertListEqual(chA_or_chC.get_residues(pose), chA_or_chC_test.get_residues(pose))
 
@@ -132,7 +132,6 @@ class TestResidueSelectors(unittest.TestCase):
         self.assertListEqual([1, 2, 9, 10], xor_selector_test.get_residues(pose))
 
     def test_residue_selector_ctors(self):
-        return
         pose = pyrosetta.pose_from_sequence("TESTING/MANY/CHAINS")
         #Not
         primary_selector = ResidueIndexSelector("2,4,6")


### PR DESCRIPTION
* enable test_residue_selector_ctors test
* update Binder to enable option to skip copy constructors
