### PR TITLE
Remove is_surface() from Residue/ResidueType.

### DIFF
--- a/source/src/core/chemical/ResidueType.cc
+++ b/source/src/core/chemical/ResidueType.cc
@@ -662,12 +662,6 @@ ResidueType::is_membrane() const
 }
 
 bool
-ResidueType::is_surface() const
-{
-	return properties().has_property( SURFACE );
-}
-
-bool
 ResidueType::has_sc_orbitals() const
 {
 	return properties().has_property( SC_ORBITALS );

--- a/source/src/core/chemical/ResidueType.hh
+++ b/source/src/core/chemical/ResidueType.hh
@@ -1171,9 +1171,6 @@ public:
 	/// @brief is membrane?
 	bool is_membrane() const;
 
-	/// @brief is surface? (e.g. enamel)
-	bool is_surface() const;
-
 	/// @brief does this residue have sidechain orbitals?
 	bool has_sc_orbitals() const;
 

--- a/source/src/core/conformation/Residue.hh
+++ b/source/src/core/conformation/Residue.hh
@@ -2004,14 +2004,6 @@ public:
 		return rsd_type_.is_metalbinding();
 	}
 
-	/// @brief Returns true if this residue is a surface residue
-	bool
-	is_surface() const
-	{
-		return rsd_type_.is_surface();
-	}
-
-
 	/// @brief Returns true if the residue has side chain orbitals
 	bool
 	has_sc_orbitals() const

--- a/source/src/devel/scientific_tests/PDBDiagnosticMover.cc
+++ b/source/src/devel/scientific_tests/PDBDiagnosticMover.cc
@@ -260,7 +260,6 @@ void PDBDiagnosticMover::residue_type_statistics( core::pose::Pose const & pose,
 	core::Size is_metal(0);
 	core::Size is_metalbinding(0);
 	core::Size is_membrane(0);
-	core::Size is_surface(0);
 	core::Size has_sc_orbitals(0);
 	core::Size is_polar(0);
 	core::Size is_charged(0);
@@ -302,7 +301,6 @@ void PDBDiagnosticMover::residue_type_statistics( core::pose::Pose const & pose,
 		if ( pose.residue_type(i).is_metal() ) ++is_metal;
 		if ( pose.residue_type(i).is_metalbinding() ) ++is_metalbinding;
 		if ( pose.residue_type(i).is_membrane() ) ++is_membrane;
-		if ( pose.residue_type(i).is_surface() ) ++is_surface;
 		if ( pose.residue_type(i).has_sc_orbitals() ) ++has_sc_orbitals;
 		if ( pose.residue_type(i).is_polar() ) ++is_polar;
 		if ( pose.residue_type(i).is_charged() ) ++is_charged;
@@ -348,7 +346,6 @@ void PDBDiagnosticMover::residue_type_statistics( core::pose::Pose const & pose,
 	job_me->add_string_real_pair("is_metal", is_metal);
 	job_me->add_string_real_pair("is_metalbinding", is_metalbinding);
 	job_me->add_string_real_pair("is_membrane", is_membrane);
-	job_me->add_string_real_pair("is_surface", is_surface);
 	job_me->add_string_real_pair("has_sc_orbitals", has_sc_orbitals);
 	job_me->add_string_real_pair("is_polar", is_polar);
 	job_me->add_string_real_pair("is_charged", is_charged);

--- a/source/src/protocols/vip/VIP_Mover.cc
+++ b/source/src/protocols/vip/VIP_Mover.cc
@@ -198,7 +198,7 @@ VIP_Mover::cull_mutatable_residues(){
 
 	utility::vector1<core::Size> mutatable_residues;
 	for ( core::Size i = 1; i <= void_neighbors.size(); i+=2 ) {
-		if ( (initial_pose.residue(void_neighbors[i]).is_surface() == false) &&
+		if ( (initial_pose.residue_type(void_neighbors[i]).properties().has_property( core::chemical::SURFACE ) == false) &&
 				(initial_pose.residue(void_neighbors[i]).is_polar() == false) &&
 				(std::find( excluded_positions.begin(), excluded_positions.end(), void_neighbors[i]) == excluded_positions.end() ) &&
 				(initial_pose.residue(void_neighbors[i]).aa() < core::chemical::num_canonical_aas ) && // Don't try amino acid if APOLAR will choke on it


### PR DESCRIPTION
This function is confusing, as it's not talking about the surface of a protein, but mineral surfaces.

The ResidueType property SURFACE isn't used frequently -- for the rare case it's needed, we can use the more involved query protocol, rather than leaving the potentially confusing `Residue::is_surface()` lying around.