### PR TITLE
Add debug printing for inline residue selector parsing logic.

### DIFF
--- a/source/src/core/select/residue_selector/AndResidueSelector.cc
+++ b/source/src/core/select/residue_selector/AndResidueSelector.cc
@@ -171,6 +171,18 @@ std::string AndResidueSelector::class_name() {
 	return "And";
 }
 
+std::string
+AndResidueSelector::debug_string() const {
+	std::string retval = "<" + get_name() + " >\n";
+	for ( auto const & selector: selectors_ ) {
+		for ( auto const & substring: utility::split_by_newlines( selector->debug_string() ) ) {
+			retval += "\t" + substring + "\n";
+		}
+	}
+	retval += "</" + get_name() + " >\n";
+	return retval;
+}
+
 void
 AndResidueSelector::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) {
 	utility::tag::AttributeList attributes;

--- a/source/src/core/select/residue_selector/AndResidueSelector.hh
+++ b/source/src/core/select/residue_selector/AndResidueSelector.hh
@@ -101,6 +101,9 @@ public: //Functions needed for the citation manager
 	/// @brief Provide the citation.
 	void provide_citation_info(basic::citation_manager::CitationCollectionList & ) const override;
 
+	std::string
+	debug_string() const override;
+
 private: // data members
 
 	std::list< ResidueSelectorCOP > selectors_;

--- a/source/src/core/select/residue_selector/NotResidueSelector.cc
+++ b/source/src/core/select/residue_selector/NotResidueSelector.cc
@@ -29,6 +29,7 @@
 
 // Utility Headers
 #include <utility/tag/Tag.hh>
+#include <utility/string_util.hh>
 #include <utility/tag/XMLSchemaGeneration.hh>
 
 // C++ headers
@@ -168,6 +169,16 @@ NotResidueSelectorCreator::keyname() const {
 void
 NotResidueSelectorCreator::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) const {
 	NotResidueSelector::provide_xml_schema( xsd );
+}
+
+std::string
+NotResidueSelector::debug_string() const {
+	std::string retval = "<" + get_name() + " >\n";
+	for ( auto const & substring: utility::split_by_newlines( selector_->debug_string() ) ) {
+		retval += "\t" + substring + "\n";
+	}
+	retval += "</" + get_name() + " >\n";
+	return retval;
 }
 
 

--- a/source/src/core/select/residue_selector/NotResidueSelector.hh
+++ b/source/src/core/select/residue_selector/NotResidueSelector.hh
@@ -74,6 +74,9 @@ public:
 	*/
 	void set_residue_selector(ResidueSelectorCOP selector);
 
+	std::string
+	debug_string() const override;
+
 public: //Functions needed for the citation manager
 
 	/// @brief Provide the citation.

--- a/source/src/core/select/residue_selector/OrResidueSelector.cc
+++ b/source/src/core/select/residue_selector/OrResidueSelector.cc
@@ -169,6 +169,18 @@ std::string OrResidueSelector::class_name() {
 	return "Or";
 }
 
+std::string
+OrResidueSelector::debug_string() const {
+	std::string retval = "<" + get_name() + " >\n";
+	for ( auto const & selector: selectors_ ) {
+		for ( auto const & substring: utility::split_by_newlines( selector->debug_string() ) ) {
+			retval += "\t" + substring + "\n";
+		}
+	}
+	retval += "</" + get_name() + " >\n";
+	return retval;
+}
+
 void
 OrResidueSelector::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) {
 	utility::tag::AttributeList attributes;

--- a/source/src/core/select/residue_selector/OrResidueSelector.hh
+++ b/source/src/core/select/residue_selector/OrResidueSelector.hh
@@ -83,6 +83,9 @@ public:
 	*/
 	void apply_or_to_subset(ResidueSubset const & newSubset, ResidueSubset & existingSubset) const;
 
+	std::string
+	debug_string() const override;
+
 public: //Functions needed for the citation manager
 
 	/// @brief Provide the citation.

--- a/source/src/core/select/residue_selector/ResidueSelector.cc
+++ b/source/src/core/select/residue_selector/ResidueSelector.cc
@@ -53,6 +53,11 @@ ResidueSelector::selection_positions( core::pose::Pose const & pose ) const {
 	return residue_selector::selection_positions( apply( pose ) );
 }
 
+std::string
+ResidueSelector::debug_string() const {
+	return "<" + get_name() + " />\n";
+}
+
 } //namespace residue_selector
 } //namespace select
 } //namespace core

--- a/source/src/core/select/residue_selector/ResidueSelector.hh
+++ b/source/src/core/select/residue_selector/ResidueSelector.hh
@@ -82,6 +82,12 @@ public:
 	utility::vector1< core::Size >
 	selection_positions( core::pose::Pose const & pose ) const;
 
+	/// @brief Provide a string representation of the ResidueSelector
+	/// This is intended mainly for debugging, and may not contain all the information about the selector
+	virtual
+	std::string
+	debug_string() const;
+
 public: //Functions needed for the citation manager
 
 	/// @brief Provide citations to the passed CitationCollectionList

--- a/source/src/core/select/residue_selector/util.cc
+++ b/source/src/core/select/residue_selector/util.cc
@@ -437,6 +437,9 @@ get_residue_selector( std::string const & selector_name, basic::datacache::DataM
 			TR << "Attempting to parse selector logic" << std::endl;
 			SelectorLogicParser parser;
 			selector =  parser.parse_string_to_residue_selector( data, selector_name );
+			if ( TR.Debug.visible() ) {
+				TR.Debug << "Parsed inline selector logic as:\n" << selector->debug_string() << std::endl;
+			}
 		}
 	} catch ( utility::excn::Exception & e ) {
 		std::stringstream error_msg;


### PR DESCRIPTION
There was some discussion (by e.g. @nannemdp) that the inline logic for ResidueSelectors doesn't always do the same thing as the separate AND/OR/NOT selectors do. This PR adds a rudimentary nested residue selector printing facility, and enables it with debug output on the core.select.residue_selector.util tracer when parsing inline logic.

It's primarily for debug purposes, and may or may not be useful in practice. (I didn't see any evidence of mis-parsing in the example under question.)
