### PR TITLE
Add saving of the beautification diff to the test server.

### DIFF
--- a/tests/benchmark/tests/code_quality.py
+++ b/tests/benchmark/tests/code_quality.py
@@ -470,6 +470,8 @@ def run_beautification_test(rosetta_dir, working_dir, platform, config, hpc_driv
 
     if res:
         state, output = _S_failed_, 'Some of the source code looks ugly!!! Script test_all_files_already_beautiful.py output:\n' + o
+        res_diff, diff = execute('Generating patch file for changes', 'cd {}/source && git diff'.format(rosetta_dir), return_="tuple")
+        with open(working_dir+'/full_diff.txt', 'w') as f: f.write(diff)
     else:
         state = _S_passed_
 

--- a/tests/benchmark/tests/code_quality.py
+++ b/tests/benchmark/tests/code_quality.py
@@ -470,8 +470,8 @@ def run_beautification_test(rosetta_dir, working_dir, platform, config, hpc_driv
 
     if res:
         state, output = _S_failed_, 'Some of the source code looks ugly!!! Script test_all_files_already_beautiful.py output:\n' + o
-        res_diff, diff = execute('Generating patch file for changes', 'cd {}/source && git diff'.format(rosetta_dir), return_="tuple")
-        with open(working_dir+'/full_diff.txt', 'w') as f: f.write(diff)
+        res_diff, diff = execute('Generating patch file for changes', 'cd {}/source && git --no-pager diff'.format(rosetta_dir), return_="tuple")
+        with open(working_dir+'/full_diff.patch', 'w') as f: f.write(diff)
     else:
         state = _S_passed_
 


### PR DESCRIPTION
From a comment by @JackMaguire in #197, we should be able to save the full diff of the beautification test output, and present it on the benchmark server in the `Test files:  file-tree-view 」「 file-list-view 」` entries.