### PR TITLE
Bugfix for RosettaCM and branched glycans

### DIFF
--- a/source/src/core/conformation/util.cc
+++ b/source/src/core/conformation/util.cc
@@ -71,2643 +71,2643 @@ static basic::Tracer TR( "core.conformation.util" );
 
 
 namespace core {
-	namespace conformation {
+namespace conformation {
 
-		void
-			orient_residue_for_ideal_bond(
-					Residue & moving_rsd,
-					chemical::ResidueConnection const & moving_connection,
-					Residue const & fixed_rsd,
-					chemical::ResidueConnection const & fixed_connection,
-					Conformation const & conformation,
-					bool lookup_bond_length
-					)
-			{
+void
+orient_residue_for_ideal_bond(
+	Residue & moving_rsd,
+	chemical::ResidueConnection const & moving_connection,
+	Residue const & fixed_rsd,
+	chemical::ResidueConnection const & fixed_connection,
+	Conformation const & conformation,
+	bool lookup_bond_length
+)
+{
 
-				// confirm that both connections are defined entirely by atoms internal to their residues,
-				// so we don't need the conformation info (which might not be correct for the moving_rsd if we
-				// are in the process of adding it to the conformation)
-				//
-				runtime_assert( moving_connection.icoor().is_internal() && fixed_connection.icoor().is_internal() );
+	// confirm that both connections are defined entirely by atoms internal to their residues,
+	// so we don't need the conformation info (which might not be correct for the moving_rsd if we
+	// are in the process of adding it to the conformation)
+	//
+	runtime_assert( moving_connection.icoor().is_internal() && fixed_connection.icoor().is_internal() );
 
-				// a1 ---  a2  --- (a3)
-				//
-				//  (b2) ---  b3  --- b4
-				//
-				// a3 and b2 are the pseudo-atoms built from their respective residues using the ideal geometry in the
-				// corresponding ResidueConnection objects
-				//
-				Vector
-					a1(  fixed_connection.icoor().stub_atom2().xyz(  fixed_rsd, conformation ) ),
-					b4( moving_connection.icoor().stub_atom2().xyz( moving_rsd, conformation ) ),
+	// a1 ---  a2  --- (a3)
+	//
+	//  (b2) ---  b3  --- b4
+	//
+	// a3 and b2 are the pseudo-atoms built from their respective residues using the ideal geometry in the
+	// corresponding ResidueConnection objects
+	//
+	Vector
+		a1(  fixed_connection.icoor().stub_atom2().xyz(  fixed_rsd, conformation ) ),
+		b4( moving_connection.icoor().stub_atom2().xyz( moving_rsd, conformation ) ),
 
-					a2(  fixed_rsd.xyz(  fixed_connection.atomno() ) ),
-					b3( moving_rsd.xyz( moving_connection.atomno() ) ),
+		a2(  fixed_rsd.xyz(  fixed_connection.atomno() ) ),
+		b3( moving_rsd.xyz( moving_connection.atomno() ) ),
 
-					a3(  fixed_connection.icoor().build(  fixed_rsd, conformation ) ),
-					b2( moving_connection.icoor().build( moving_rsd, conformation ) );
+		a3(  fixed_connection.icoor().build(  fixed_rsd, conformation ) ),
+		b2( moving_connection.icoor().build( moving_rsd, conformation ) );
 
-				// we want to move b2 to align with a2 and b3 to align with a3. Torsion about the a2->a3 bond
-				// (ie the inter-residue bond) determined by atoms a1 and b4 (torsion set to 0 by default).
+	// we want to move b2 to align with a2 and b3 to align with a3. Torsion about the a2->a3 bond
+	// (ie the inter-residue bond) determined by atoms a1 and b4 (torsion set to 0 by default).
 
-				core::Size fixed_rsd_atom_type_index = fixed_rsd.atom_type_index(fixed_connection.atomno());
-				core::Size moving_rsd_atom_type_index = moving_rsd.atom_type_index(moving_connection.atomno());
-				if ( lookup_bond_length ) {
-					if ( TR.visible() ) {
-						TR << "moving atom_type_index " << moving_rsd_atom_type_index<< std::endl;
-						TR << "fixed atom_type_index " << fixed_rsd_atom_type_index<< std::endl;
-					}
+	core::Size fixed_rsd_atom_type_index = fixed_rsd.atom_type_index(fixed_connection.atomno());
+	core::Size moving_rsd_atom_type_index = moving_rsd.atom_type_index(moving_connection.atomno());
+	if ( lookup_bond_length ) {
+		if ( TR.visible() ) {
+			TR << "moving atom_type_index " << moving_rsd_atom_type_index<< std::endl;
+			TR << "fixed atom_type_index " << fixed_rsd_atom_type_index<< std::endl;
+		}
 
-					// Real bond_length= lookup_bond_length(fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
-					core::chemical::ChemicalManager *cm= core::chemical::ChemicalManager::get_instance();
-					core::chemical::IdealBondLengthSetCOP ideal_bond_lengths( cm->ideal_bond_length_set( core::chemical::FA_STANDARD ) );
+		// Real bond_length= lookup_bond_length(fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
+		core::chemical::ChemicalManager *cm= core::chemical::ChemicalManager::get_instance();
+		core::chemical::IdealBondLengthSetCOP ideal_bond_lengths( cm->ideal_bond_length_set( core::chemical::FA_STANDARD ) );
 
-					Real bond_length= ideal_bond_lengths->get_bond_length( fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
-					Vector old_bond= a3-a2;
-					Vector new_bond= old_bond;
-					// new_bond.normalize(2);
-					new_bond.normalize(bond_length);
-					Vector offset = new_bond - old_bond;
-
-
-					a3 += offset;
-					//b2 -= offset;
-				}
+		Real bond_length= ideal_bond_lengths->get_bond_length( fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
+		Vector old_bond= a3-a2;
+		Vector new_bond= old_bond;
+		// new_bond.normalize(2);
+		new_bond.normalize(bond_length);
+		Vector offset = new_bond - old_bond;
 
 
-				kinematics::Stub A( a3, a2, a1 ), B( b3, b2, b4 );
+		a3 += offset;
+		//b2 -= offset;
+	}
 
-				for ( Size i=1; i<= moving_rsd.natoms(); ++i ) {
-					Vector global = A.local2global( B.global2local( moving_rsd.xyz(i)));
-					//global.z(global.z() -1.1);
-					moving_rsd.set_xyz(i, global );
-				}
 
-				Vector global_action_coord= A.local2global( B.global2local( moving_rsd.actcoord() ));
-				//global_action_coord.z(global_action_coord.z() -1.1);
-				//global_action_coord-=.47;
-				moving_rsd.actcoord() = global_action_coord;
+	kinematics::Stub A( a3, a2, a1 ), B( b3, b2, b4 );
 
+	for ( Size i=1; i<= moving_rsd.natoms(); ++i ) {
+		Vector global = A.local2global( B.global2local( moving_rsd.xyz(i)));
+		//global.z(global.z() -1.1);
+		moving_rsd.set_xyz(i, global );
+	}
+
+	Vector global_action_coord= A.local2global( B.global2local( moving_rsd.actcoord() ));
+	//global_action_coord.z(global_action_coord.z() -1.1);
+	//global_action_coord-=.47;
+	moving_rsd.actcoord() = global_action_coord;
+
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+void
+insert_ideal_mainchain_bonds(
+	Size const seqpos,
+	Conformation & conformation
+)
+{
+	using namespace id;
+
+	Residue const & rsd( conformation.residue( seqpos ) );
+
+	// create a mini-conformation with
+	ConformationOP idl_op( new Conformation() );
+	Conformation & idl = *idl_op;
+	{
+		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+		idl.append_residue_by_bond( *idl_rsd );
+	}
+
+	int idl_pos(1);
+
+	// intra-residue mainchain bonds and angles
+	Size const nbb( rsd.n_mainchain_atoms() );
+	runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+	for ( Size i=2; i<= nbb; ++i ) {
+		AtomID
+			bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
+			bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
+			bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
+			bb2 ( rsd.mainchain_atom(  i),  seqpos );
+
+		// bond length
+		conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
+
+		if ( i<nbb ) {
+			AtomID
+				bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
+				bb3 ( rsd.mainchain_atom(i+1),  seqpos );
+
+			// bond angle
+			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+		}
+	}
+
+	if ( seqpos>1 && rsd.is_polymer() && !rsd.is_lower_terminus() ) {
+		ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
+		idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+		idl_pos = 2;
+
+		Size const nbb_prev( prev_rsd->n_mainchain_atoms() );
+		AtomID
+			bb1_idl( prev_rsd->mainchain_atom( nbb_prev ), idl_pos-1 ),
+			bb1 ( prev_rsd->mainchain_atom( nbb_prev ),  seqpos-1 ),
+			bb2_idl( rsd.mainchain_atom( 1 ), idl_pos ),
+			bb2 ( rsd.mainchain_atom( 1 ),  seqpos ),
+			bb3_idl( rsd.mainchain_atom( 2 ), idl_pos ),
+			bb3 ( rsd.mainchain_atom( 2 ),  seqpos );
+		conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+	}
+
+	if ( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() ) {
+		ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
+		idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
+
+		AtomID
+			bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
+			bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
+			bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
+			bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
+			bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
+			bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 );
+
+		// bond angle
+		conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+
+		// bond length
+		conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+	}
+
+
+}
+
+/// @details  Just sets the two bond angles and the bond length between seqpos and seqpos+1
+
+void
+insert_ideal_bonds_at_polymer_junction(
+	Size const seqpos,
+	Conformation & conformation
+)
+{
+	using namespace id;
+
+	Residue const & rsd( conformation.residue( seqpos ) );
+	runtime_assert( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() );
+
+	if ( TR.Warning.visible() && conformation.fold_tree().is_cutpoint( seqpos ) ) {
+		TR.Warning << "insert_ideal_bonds_at_polymer_junction: seqpos (" << seqpos << ") is a foldtree cutpoint, " <<
+			"returning!" << std::endl;
+	}
+
+	// create a mini-conformation with ideal bond lengths and angles
+	ConformationOP idl_op( new Conformation() );
+	Conformation & idl = *idl_op;
+	{
+		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+		idl.append_residue_by_bond( *idl_rsd );
+	}
+
+	int idl_pos(1);
+
+	Size const nbb( rsd.n_mainchain_atoms() );
+	runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+
+	ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
+	idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true /* append with ideal geometry */ );
+
+	AtomID
+		bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
+		bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
+		bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
+		bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
+		bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
+		bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 ),
+		bb4_idl( next_rsd->mainchain_atom( 2 ), idl_pos+1 ),
+		bb4 ( next_rsd->mainchain_atom( 2 ),  seqpos+1 );
+
+	// bond angle
+	conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+
+	// bond length
+	conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+
+	// bond angle
+	conformation.set_bond_angle( bb2, bb3, bb4, idl.bond_angle( bb2_idl, bb3_idl, bb4_idl ) );
+
+	// fix up atoms that depend on the atoms across the bond for their torsion offsets
+	conformation.rebuild_polymer_bond_dependent_atoms( seqpos );
+
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+void
+idealize_position(
+	Size const seqpos,
+	Conformation & conformation
+)
+{
+	using namespace id;
+
+	runtime_assert( seqpos > 0 );
+	runtime_assert( conformation.size() >= seqpos );
+	runtime_assert( conformation.size() > 0 );
+	Residue const & rsd( conformation.residue( seqpos ) );
+
+	//// create a mini-conformation with completely ideal residue ( and nbrs, if appropriate )
+
+	ConformationOP idl_op( new Conformation() );
+	Conformation & idl = *idl_op;
+	{
+		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+		idl.append_residue_by_bond( *idl_rsd );
+	}
+
+	int idl_pos(1);
+	bool lower_connect( false ), upper_connect( false );
+
+	if ( rsd.is_polymer() ) {
+		// add polymer nbrs?
+		if ( rsd.is_carbohydrate() ) {
+			if ( seqpos > 1 && !rsd.is_lower_terminus() ) {
+				lower_connect = true;
+				core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( rsd ) );
+				ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( parent_res_seqpos ).type() ) );
+				idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+				idl_pos = 2;
 			}
 
-
-		///////////////////////////////////////////////////////////////////////////////////////
-		void
-			insert_ideal_mainchain_bonds(
-					Size const seqpos,
-					Conformation & conformation
-					)
-			{
-				using namespace id;
-
-				Residue const & rsd( conformation.residue( seqpos ) );
-
-				// create a mini-conformation with
-				ConformationOP idl_op( new Conformation() );
-				Conformation & idl = *idl_op;
-				{
-					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-					idl.append_residue_by_bond( *idl_rsd );
-				}
-
-				int idl_pos(1);
-
-				// intra-residue mainchain bonds and angles
-				Size const nbb( rsd.n_mainchain_atoms() );
-				runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
-				for ( Size i=2; i<= nbb; ++i ) {
-					AtomID
-						bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
-						bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
-						bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
-						bb2 ( rsd.mainchain_atom(  i),  seqpos );
-
-					// bond length
-					conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
-
-					if ( i<nbb ) {
-						AtomID
-							bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
-							bb3 ( rsd.mainchain_atom(i+1),  seqpos );
-
-						// bond angle
-						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-					}
-				}
-
-				if ( seqpos>1 && rsd.is_polymer() && !rsd.is_lower_terminus() ) {
-					ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
-					idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
-					idl_pos = 2;
-
-					Size const nbb_prev( prev_rsd->n_mainchain_atoms() );
-					AtomID
-						bb1_idl( prev_rsd->mainchain_atom( nbb_prev ), idl_pos-1 ),
-						bb1 ( prev_rsd->mainchain_atom( nbb_prev ),  seqpos-1 ),
-						bb2_idl( rsd.mainchain_atom( 1 ), idl_pos ),
-						bb2 ( rsd.mainchain_atom( 1 ),  seqpos ),
-						bb3_idl( rsd.mainchain_atom( 2 ), idl_pos ),
-						bb3 ( rsd.mainchain_atom( 2 ),  seqpos );
-					conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-				}
-
-				if ( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() ) {
-					ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-					idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
-
-					AtomID
-						bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
-						bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
-						bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
-						bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
-						bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
-						bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 );
-
-					// bond angle
-					conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-
-					// bond length
-					conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
-				}
-
-
+			if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
+				upper_connect = true;
+				core::Size child_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_mainchain_child( rsd ) );
+				ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( child_res_seqpos ).type() ) );
+				idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
+			}
+		} else {
+			if ( seqpos > 1 && !rsd.is_lower_terminus() && !conformation.fold_tree().is_cutpoint( seqpos-1 ) ) {
+				lower_connect = true;
+				ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
+				idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+				idl_pos = 2;
 			}
 
-		/// @details  Just sets the two bond angles and the bond length between seqpos and seqpos+1
-
-		void
-			insert_ideal_bonds_at_polymer_junction(
-					Size const seqpos,
-					Conformation & conformation
-					)
-			{
-				using namespace id;
-
-				Residue const & rsd( conformation.residue( seqpos ) );
-				runtime_assert( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() );
-
-				if ( TR.Warning.visible() && conformation.fold_tree().is_cutpoint( seqpos ) ) {
-					TR.Warning << "insert_ideal_bonds_at_polymer_junction: seqpos (" << seqpos << ") is a foldtree cutpoint, " <<
-						"returning!" << std::endl;
-				}
-
-				// create a mini-conformation with ideal bond lengths and angles
-				ConformationOP idl_op( new Conformation() );
-				Conformation & idl = *idl_op;
-				{
-					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-					idl.append_residue_by_bond( *idl_rsd );
-				}
-
-				int idl_pos(1);
-
-				Size const nbb( rsd.n_mainchain_atoms() );
-				runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
-
+			if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
+				upper_connect = true;
 				ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-				idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true /* append with ideal geometry */ );
+				idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
+			}
+		}
+	}
+	//// now set the torsion angles in the ideal conformation... This is to prepare for replacing rsd with
+	//// the idealized version
 
+	// chi angles
+	for ( Size i=1; i<= rsd.nchi(); ++i ) {
+		idl.set_torsion( TorsionID( idl_pos, CHI, i ), rsd.chi( i ) );
+	}
+	// mainchain torsions, if polymer residue
+	if ( rsd.is_polymer() ) {
+		Size const nbb( rsd.n_mainchain_atoms() );
+		for ( Size i=1; i<= nbb; ++i ) {
+			//if ( ( !lower_connect && i == 1 ) || ( !upper_connect && i >= nbb-1 ) ) continue;
+			idl.set_torsion( TorsionID( idl_pos, BB, i ), rsd.mainchain_torsion( i ) );
+		}
+	}
+
+
+	//// now we copy the mainchain bond geometry from ideal conf into the conf to be idealized
+	if ( rsd.is_polymer() ) {
+
+		// intra-residue mainchain bonds and angles
+		Size const nbb( rsd.n_mainchain_atoms() );
+		runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+		for ( Size i=2; i<= nbb; ++i ) {
+			AtomID
+				bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
+				bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
+				bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
+				bb2 ( rsd.mainchain_atom(  i),  seqpos );
+
+			// bond length
+			conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
+
+			if ( i<nbb ) {
 				AtomID
-					bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
-					bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
-					bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
-					bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
-					bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
-					bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 ),
-					bb4_idl( next_rsd->mainchain_atom( 2 ), idl_pos+1 ),
-					bb4 ( next_rsd->mainchain_atom( 2 ),  seqpos+1 );
+					bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
+					bb3 ( rsd.mainchain_atom(i+1),  seqpos );
 
 				// bond angle
 				conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-
-				// bond length
-				conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
-
-				// bond angle
-				conformation.set_bond_angle( bb2, bb3, bb4, idl.bond_angle( bb2_idl, bb3_idl, bb4_idl ) );
-
-				// fix up atoms that depend on the atoms across the bond for their torsion offsets
-				conformation.rebuild_polymer_bond_dependent_atoms( seqpos );
-
 			}
-
-
-		///////////////////////////////////////////////////////////////////////////////////////
-		void
-			idealize_position(
-					Size const seqpos,
-					Conformation & conformation
-					)
-			{
-				using namespace id;
-
-				runtime_assert( seqpos > 0 );
-				runtime_assert( conformation.size() >= seqpos );
-				runtime_assert( conformation.size() > 0 );
-				Residue const & rsd( conformation.residue( seqpos ) );
-
-				//// create a mini-conformation with completely ideal residue ( and nbrs, if appropriate )
-
-				ConformationOP idl_op( new Conformation() );
-				Conformation & idl = *idl_op;
-				{
-					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-					idl.append_residue_by_bond( *idl_rsd );
-				}
-
-				int idl_pos(1);
-				bool lower_connect( false ), upper_connect( false );
-
-				if ( rsd.is_polymer() ) {
-					// add polymer nbrs?
-					if (rsd.is_carbohydrate()){
-						if ( seqpos > 1 && !rsd.is_lower_terminus()) {
-							lower_connect = true;
-							core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( rsd ) );
-							ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( parent_res_seqpos ).type() ) );
-							idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
-							idl_pos = 2;
-						}
-
-						if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
-							upper_connect = true;
-							core::Size child_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_mainchain_child( rsd ) );
-							ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( child_res_seqpos ).type() ) );
-							idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
-						}
-					}else{
-						if ( seqpos > 1 && !rsd.is_lower_terminus() && !conformation.fold_tree().is_cutpoint( seqpos-1 ) ) {
-							lower_connect = true;
-							ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
-							idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
-							idl_pos = 2;
-						}
-
-						if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
-							upper_connect = true;
-							ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-							idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
-						}
-					}
-				}
-				//// now set the torsion angles in the ideal conformation... This is to prepare for replacing rsd with
-				//// the idealized version
-
-				// chi angles
-				for ( Size i=1; i<= rsd.nchi(); ++i ) {
-					idl.set_torsion( TorsionID( idl_pos, CHI, i ), rsd.chi( i ) );
-				}
-				// mainchain torsions, if polymer residue
-				if ( rsd.is_polymer() ) {
-					Size const nbb( rsd.n_mainchain_atoms() );
-					for ( Size i=1; i<= nbb; ++i ) {
-						//if ( ( !lower_connect && i == 1 ) || ( !upper_connect && i >= nbb-1 ) ) continue;
-						idl.set_torsion( TorsionID( idl_pos, BB, i ), rsd.mainchain_torsion( i ) );
-					}
-				}
-
-
-				//// now we copy the mainchain bond geometry from ideal conf into the conf to be idealized
-				if ( rsd.is_polymer() ) {
-
-					// intra-residue mainchain bonds and angles
-					Size const nbb( rsd.n_mainchain_atoms() );
-					runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
-					for ( Size i=2; i<= nbb; ++i ) {
-						AtomID
-							bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
-							bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
-							bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
-							bb2 ( rsd.mainchain_atom(  i),  seqpos );
-
-						// bond length
-						conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
-
-						if ( i<nbb ) {
-							AtomID
-								bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
-								bb3 ( rsd.mainchain_atom(i+1),  seqpos );
-
-							// bond angle
-							conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-						}
-					}
-
-					if ( lower_connect ) {
-						Residue const & prev_rsd( idl.residue( idl_pos-1 ) );
-
-						Size const nbb_prev( prev_rsd.n_mainchain_atoms() );
-						AtomID
-							bb1_idl( prev_rsd.mainchain_atom( nbb_prev ), idl_pos-1 ),
-							bb1 ( prev_rsd.mainchain_atom( nbb_prev ),  seqpos-1 ),
-							bb2_idl(   rsd.mainchain_atom(  1 ), idl_pos   ),
-							bb2 (   rsd.mainchain_atom(  1 ),  seqpos   ),
-							bb3_idl(   rsd.mainchain_atom(  2 ), idl_pos   ),
-							bb3 (   rsd.mainchain_atom(  2 ),  seqpos   );
-						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-					}
-
-					if ( upper_connect ) {
-						Residue const & next_rsd( idl.residue( idl_pos+1 ) );
-
-						AtomID
-							bb1_idl(   rsd.mainchain_atom( nbb-1 ), idl_pos   ),
-							bb1 (   rsd.mainchain_atom( nbb-1 ),  seqpos   ),
-							bb2_idl(   rsd.mainchain_atom( nbb   ), idl_pos   ),
-							bb2 (   rsd.mainchain_atom( nbb   ),  seqpos   ),
-							bb3_idl( next_rsd.mainchain_atom(  1 ), idl_pos+1 ),
-							bb3 ( next_rsd.mainchain_atom(  1 ),  seqpos+1 );
-
-						// bond angle
-						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-
-						// bond length
-						conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
-					}
-				} // rsd.is_polymer()
-
-
-				//// now we orient the ideal residue onto the existing residue and replace it
-				ResidueOP idl_rsd( idl.residue( idl_pos ).clone() );
-
-				// EXTREMELY SUBTLE DANGEROUS THING ABOUT HAVING Residue const &'s lying around:
-				// if we put "rsd" in place of conformation.residue( seqpos ) below, this will not behave properly.
-				// that's because the xyz's in rsd don't get updated properly to reflect the changes to the conformation
-				// a "refold" is only triggered by another call to conformation.residue
-				// May want to consider making Residue smarter about this kind of thing, ie knowing its from a
-				// Conformation... acting as an observer... could get pretty tricky though...
-				//
-				idl_rsd->orient_onto_residue( conformation.residue( seqpos ) ); // can't use rsd here!
-				conformation.replace_residue( seqpos, *idl_rsd, false );
-
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////////////
-		// NOTE: conformation is needed for polymer neighbours
-		// @author Barak 07/2009
-		bool
-			is_ideal_position(
-					Size const seqpos,
-					Conformation const & conf,
-					Real theta_epsilon,
-					Real D_epsilon
-					)
-			{
-				using namespace core::kinematics;
-				runtime_assert( conf.size() >= seqpos  &&  seqpos >= 1 );
-
-				Residue const rsd( conf.residue( seqpos ) );
-
-				// I. Create mini-conformations for both idealized and original residue + nbrs, if appropriate )
-				ConformationOP miniconf_op( new Conformation() );
-				Conformation & miniconf = *miniconf_op;
-				ConformationOP miniconf_idl_op( new Conformation() );
-				Conformation & miniconf_idl = *miniconf_idl_op;
-				{
-					miniconf.append_residue_by_bond( rsd );
-					ResidueOP prsd_idl( ResidueFactory::create_residue( rsd.type() ) );
-					miniconf_idl.append_residue_by_bond( *prsd_idl );
-				}
-				// add polymer nbrs if needed
-				int seqpos_miniconf(1);
-				//bool lower_connect( false ), upper_connect( false );
-				if ( rsd.is_polymer() ) {
-					// prepending previous neighbour
-					if ( seqpos > 1 && !rsd.is_lower_terminus() && !conf.fold_tree().is_cutpoint( seqpos-1 ) ) {
-						//lower_connect = true;  // set but never used ~Labonte
-						seqpos_miniconf = 2; // pushed forward by prependedq residue
-						Residue const & prev_rsd = conf.residue( seqpos-1 );
-						miniconf.safely_prepend_polymer_residue_before_seqpos // TODO: safely is probably unneeded here, verify this point
-							( prev_rsd, 1, false /*build_ideal_geom*/);
-						ResidueOP pprev_rsd_idl( ResidueFactory::create_residue( prev_rsd.type() ) );
-						miniconf_idl.safely_prepend_polymer_residue_before_seqpos
-							( *pprev_rsd_idl, 1, true /*build_ideal_geom*/);
-					}
-					// appending next neighbour
-					if ( seqpos < conf.size() && !rsd.is_upper_terminus() && !conf.fold_tree().is_cutpoint( seqpos ) ) {
-						//upper_connect = true;  // set but never used ~Labonte
-						Residue const & next_rsd = conf.residue( seqpos+1 );
-						miniconf.safely_append_polymer_residue_after_seqpos
-							( next_rsd, seqpos_miniconf, false /*build_ideal_geom*/ );
-						ResidueOP pnext_rsd_idl( ResidueFactory::create_residue( next_rsd.type() ) );
-						miniconf_idl.safely_append_polymer_residue_after_seqpos
-							( *pnext_rsd_idl, seqpos_miniconf, true /*build_ideal_geom*/ );
-					}
-				}
-
-
-				// II. Compare angle and length of all residue bonded atoms in the new mini-conformations
-				for ( Size atom = 1, atom_end = miniconf.residue( seqpos_miniconf ).natoms();
-						atom <= atom_end;
-						++atom ) {
-					id::AtomID aid(atom, seqpos_miniconf);
-					if ( miniconf.atom_tree().atom(aid).is_jump() ) { // skip non-bonded atoms
-						continue;
-					}
-					id::DOF_ID dof_theta(aid, id::THETA); // bond angle
-					id::DOF_ID dof_D(aid, id::D); // bond length
-					if ( ! numeric::equal_by_epsilon(
-								miniconf.dof( dof_theta ), miniconf_idl.dof( dof_theta ), theta_epsilon ) ) {
-						if ( TR.visible() ) {
-							TR << "Non-ideal residue detected: "
-								<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
-								<< " Ideal theta=" << miniconf_idl.dof( dof_theta)
-								<< ", Inspected theta=" << miniconf.dof( dof_theta )
-								<< " (in Radians)"
-								<< std::endl;
-						}
-						return false;
-					}
-					if ( ! numeric::equal_by_epsilon(
-								miniconf.dof( dof_D), miniconf_idl.dof (dof_D), D_epsilon ) ) {
-						if ( TR.visible() ) {
-							TR << "Non-ideal residue detected: "
-								<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
-								<< " Ideal D=" << miniconf_idl.dof( dof_D)
-								<< ", Inspected D=" << miniconf.dof( dof_D )
-								<< std::endl;
-						}
-						return false;
-					}
-				}
-
-				return true;
-			}
-
-
-		/// @brief  Fills coords of target_rsd with coords from source_rsd of same atom_name, rebuilds others.
-		/// @details  If preserve_only_sidechain_dihedrals is true, then this function only copies mainchain coordinates,
-		/// and rebuilds all sidechain coordinates from scratch, setting side-chain dihedrals based on the source residue.
-		/// Otherwise, if false, it copies all the atoms that it can from the source residue, then rebuilds the rest.
-		/// @author Vikram K. Mulligan (vmullig@uw.edu)
-		void
-			copy_residue_coordinates_and_rebuild_missing_atoms(
-					Residue const & source_rsd,
-					Residue & target_rsd,
-					Conformation const & conformation,
-					bool const preserve_only_sidechain_dihedrals
-					) {
-				target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-				target_rsd.chain ( source_rsd.chain () );
-
-				if ( preserve_only_sidechain_dihedrals ) { //If we're keeping only the sidechain dihedral information
-					Size const natoms(target_rsd.natoms());
-					bool any_missing(false);
-					utility::vector1< bool > missing( natoms, false );
-					Size const to_preserve = source_rsd.type().first_sidechain_atom() >= source_rsd.type().natoms() ? source_rsd.type().first_sidechain_atom() : source_rsd.n_mainchain_atoms();
-
-					for ( Size ia=1; ia<=natoms; ++ia ) { //Loop through all atoms
-						std::string const & atom_name( target_rsd.atom_name(ia) );
-						if ( ia <= to_preserve && source_rsd.has( atom_name ) ) {
-							target_rsd.atom(ia).xyz( source_rsd.atom(atom_name).xyz() );
-						} else {
-							if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
-							any_missing=true;
-							missing[ia]=true;
-						}
-					}
-					if ( any_missing ) {
-						target_rsd.fill_missing_atoms( missing, conformation );
-					}
-
-					//Set side-chain dihedrals
-					for ( core::Size i=1, imax=std::min( target_rsd.nchi(), source_rsd.nchi() ); i<=imax; ++i ) { //Loop through all shared chi angles
-						target_rsd.set_chi(i, source_rsd.chi(i)); //Set side-chain dihedral.
-					}
-
-				} else { //If we're trying to keep the sidechain atom position information
-					copy_residue_coordinates_and_rebuild_missing_atoms( source_rsd, target_rsd, conformation );
-				}
-				return;
-			}
-
-
-		/// @details  For building variant residues, eg
-		/// @note  Need conformation for context in case we have to rebuild atoms, eg backbone H
-		void
-			copy_residue_coordinates_and_rebuild_missing_atoms(
-					Residue const & source_rsd,
-					Residue & target_rsd,
-					Conformation const & conformation
-					)
-			{
-				target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-				target_rsd.chain ( source_rsd.chain () );
-
-				Size const natoms( target_rsd.natoms() );
-
-				utility::vector1< bool > missing( natoms, false );
-				bool any_missing( false );
-
-				for ( Size i=1; i<= natoms; ++i ) {
-					std::string const & atom_name( target_rsd.atom_name(i) );
-					if ( source_rsd.has( atom_name ) ) {
-						target_rsd.atom( i ).xyz( source_rsd.atom( atom_name ).xyz() );
-					} else {
-						if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
-						any_missing = true;
-						missing[i] = true;
-					}
-				}
-
-				if ( any_missing ) {
-					target_rsd.fill_missing_atoms( missing, conformation );
-				}
-
-			}
-
-		/// @brief  Fills coords of target_rsd with coords from source_rsd using the provided mapping, rebuilds others
-		/// The mapping is indexed by target_rsd atom index, giving source_rsd index or zero for not present.
-		void
-			copy_residue_coordinates_and_rebuild_missing_atoms(
-					Residue const & source_rsd,
-					Residue & target_rsd,
-					utility::vector1< core::Size > const & mapping,
-					Conformation const & conformation
-					) {
-				Size const natoms( target_rsd.natoms() );
-
-				utility::vector1< bool > missing( natoms, false );
-				bool any_missing( false );
-
-				for ( Size i=1; i<= natoms; ++i ) {
-					if ( mapping.size() >= i && mapping[i] != 0 ) {
-						target_rsd.atom( i ).xyz( source_rsd.atom( mapping[i] ).xyz() );
-					} else {
-						TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' <<
-							target_rsd.atom_name(i) << std::endl;
-						any_missing = true;
-						missing[i] = true;
-					}
-				}
-
-				if ( any_missing ) {
-					target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-					target_rsd.chain ( source_rsd.chain () );
-					target_rsd.fill_missing_atoms( missing, conformation );
-				}
-			}
-
-		/// @details  Helper function for below
-		std::ostream &
-			print_atom( id::AtomID const & id, Conformation const & conf, std::ostream & os )
-			{
-				Residue const & rsd( conf.residue(id.rsd() ) );
-				os << rsd.atom_name( id.atomno() ) << " (" << id.atomno() << ") " << rsd.name() << ' ' << rsd.seqpos();
-				return os;
-			}
-
-		/// @brief Given two residues, check that they are compatible types to be connected via a cutpoint.
-		/// @author Vikram K. Mulligan (vmullig@uw.edu).
-		void
-			check_good_cutpoint_neighbour(
-					core::conformation::Residue const &thisres,
-					core::conformation::Residue const &other_res
-					) {
-				core::chemical::ResidueType const &thistype( thisres.type() );
-				runtime_assert_string_msg(
-						thistype.is_alpha_aa() || thistype.is_beta_aa() || thistype.is_gamma_aa() ||
-						thistype.is_sri() || thistype.has_property(core::chemical::TRIAZOLE_LINKER) ||
-						thistype.is_peptoid() || thistype.is_carbohydrate() || thistype.is_NA() || thistype.is_oligourea() ||
-						thistype.is_aramid()
-						|| thistype.has_property( chemical::TNA ) ,
-						"Error in core::conformation::check_good_cutpoint_neighbour(): The selected residue is neither an alpha-, beta-, or gamma-amino acid, nor a peptoid, nor a sugar, nor a nucleic acid, nor an oligourea.  Nevertheless, it has a cutpoint variant type.  This should not be possible."
-						);
-
-				if ( thistype.is_carbohydrate() ) {
-					//JASON JASON JASON if ever you need cutpoints between sugar and something else, this is
-					//one spot to make a change.  -VKM
-					runtime_assert_string_msg(
-							other_res.type().is_carbohydrate(),
-							"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a carbohydrate via a cutpoint is not itself a carbohydrate."
-							);
-				} else if ( thistype.is_NA() ) {
-					//AMW TODO: Andy, if ever you need RNA to connect to something other than RNA (or DNA) via a cutpoint, this is
-					//one place to make a change.  -VKM
-					runtime_assert_string_msg(
-							other_res.type().is_polymer(),
-							"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a nucleic acid via a cutpoint is not itself a DNA or RNA residue."
-							);
-				} else {
-					runtime_assert_string_msg(
-							other_res.type().is_alpha_aa() || other_res.type().is_beta_aa() || other_res.type().is_gamma_aa() || other_res.type().is_peptoid() || other_res.type().is_oligourea() || other_res.type().is_aramid() || other_res.type().is_RNA() || other_res.type().has_property( chemical::TNA ),
-							"Error in core::conformation::check_good_cutpoint_neighbour(): The connected residue is neither a peptoid, nor an oligourea, nor an alpha-, beta-, or gamma-amino acid."
-							);
-				}
-			}
-
-		/// @brief Given a conformation and a position that may or may not be CUTPOINT_UPPER or CUTPOINT_LOWER, determine whether this
-		/// position has either of these variant types, and if it does, determine whether it's connected to anything.  If it is,
-		/// update the C-OVL1-OVL2 bond lengths and bond angle (for CUTPOINT_LOWER) or OVU1-N bond length (for CUTPOINT_UPPER) to
-		/// match any potentially non-ideal geometry in the residue to which it's bonded.
-		/// @details Requires a little bit of special-casing for gamma-amino acids.  Throws an exception if the residue to which
-		/// a CUTPOINT_LOWER is bonded does not have an "N" and a "CA" or "C4".  Safe to call repeatedly, or if cutpoint variant
-		/// types are absent; in these cases, the function does nothing.
-		/// @note By default, this function calls itself again once on residues to which this residue is connected, to update their
-		/// geometry.  Set recurse=false to disable this.
-		/// @author Vikram K. Mulligan (vmullig@uw.edu).
-		void
-			update_cutpoint_virtual_atoms_if_connected(
-					core::conformation::Conformation & conf,
-					core::Size const cutpoint_res,
-					bool recurse /*= true*/
-					) {
-				core::conformation::Residue const &thisres( conf.residue(cutpoint_res) );
-				if ( thisres.is_RNA() ) return;
-				if ( !thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) && !thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) return; //Do nothing if no upper or lower cutpoint type.
-
-				if ( thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) ) {
-					core::Size const other_res_index( thisres.connected_residue_at_upper() ); //The residue to which I'm connected at my upper connection.
-					if ( other_res_index != 0 ) {
-						core::conformation::Residue const & other_res( conf.residue(other_res_index) );
-						check_good_cutpoint_neighbour( thisres, other_res );
-						core::Real const dist1( other_res.lower_connect().icoor().d() ); //Distance from LOWER to N.
-						core::Real const angle2( other_res.lower_connect().icoor().theta() ); //Note that this is Pi-bondangle, in radians.
-						core::Real const dist2( other_res.xyz( other_res.lower_connect().icoor().stub_atom1().atomno() ).distance( other_res.xyz( other_res.lower_connect().icoor().stub_atom2().atomno() ) ) ); //Distance from N to CA (or N to C4 in gamma-aas).
-
-						core::chemical::AtomICoor const & ovl1_icoor ( thisres.icoor(thisres.atom_index("OVL1")) );
-						core::chemical::AtomICoor ovl1_new_icoor("OVL1", ovl1_icoor.phi(), ovl1_icoor.theta(),
-								dist1, thisres.atom_name( ovl1_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom3().atomno() ), thisres.type());
-						conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL1"), cutpoint_res), ovl1_new_icoor.build( thisres, conf ) );
-
-						if ( !thisres.type().is_carbohydrate() && !other_res.type().is_carbohydrate() ) { //JASON JASON JASON -- this is the other special-case thing for carbohydrates.  -VKM
-							core::chemical::AtomICoor const & ovl2_icoor ( thisres.icoor(thisres.atom_index("OVL2")) );
-							core::chemical::AtomICoor ovl2_new_icoor("OVL2", ovl2_icoor.phi(), angle2,
-									dist2, thisres.atom_name( ovl2_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom3().atomno() ), thisres.type());
-							conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL2"), cutpoint_res), ovl2_new_icoor.build( thisres, conf ) );
-						}
-
-						if ( recurse ) {
-							update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
-						}
-					}
-				}
-				if ( thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) {
-					core::Size const other_res_index( thisres.connected_residue_at_lower() ); //The residue to which I'm connected at my lower connection.
-					if ( other_res_index != 0 ) {
-						core::conformation::Residue const & other_res( conf.residue(other_res_index) );
-						check_good_cutpoint_neighbour( thisres, other_res );
-						core::Real const dist1( other_res.upper_connect().icoor().d() ); //Distance from UPPER to C.
-
-						core::chemical::AtomICoor const & ovu1_icoor ( thisres.icoor(thisres.atom_index("OVU1")) );
-						core::chemical::AtomICoor ovu1_new_icoor("OVU1", ovu1_icoor.phi(), ovu1_icoor.theta(), dist1,
-								thisres.atom_name( ovu1_icoor.stub_atom1().atomno() ),
-								thisres.atom_name( ovu1_icoor.stub_atom2().atomno() ),
-								ovu1_icoor.stub_atom3().atomno() == 0 ? "LOWER" : thisres.atom_name( ovu1_icoor.stub_atom3().atomno() ), //In some cases, the third stub atom is the lower connection.
-								thisres.type()
-								);
-						conf.set_xyz( core::id::AtomID(thisres.atom_index("OVU1"), cutpoint_res), ovu1_new_icoor.build(thisres, conf ) );
-
-						if ( recurse ) {
-							update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
-						}
-					}
-				}
-				conf.update_actcoord( cutpoint_res );
-			}
-
-		void
-			show_atom_tree(
-					kinematics::tree::Atom const & atom,
-					Conformation const & conf, std::ostream & os
-					) {
-				os << "ATOM "; print_atom( atom.id(), conf, os ) << std::endl;
-				os << "CHILDREN: ";
-				for ( Size i=0; i< atom.n_children(); ++i ) {
-					print_atom( atom.child(i)->id(), conf, os ) << ' ';
-				}
-				os << std::endl;
-				for ( Size i=0; i< atom.n_children(); ++i ) {
-					show_atom_tree( *atom.child(i), conf, os );
-				}
-			}
-
-		/// helper function for residue replacement/residuetype switching
-		/// @note  Will call new_rsd->fill_missing_atoms if the new residue has atoms
-		/// that the old one doesn't
-
-		void
-			replace_conformation_residue_copying_existing_coordinates(
-					conformation::Conformation & conformation,
-					Size const seqpos,
-					chemical::ResidueType const & new_rsd_type
-					)
-			{
-
-				Residue const & old_rsd( conformation.residue( seqpos ) );
-				ResidueOP new_rsd( ResidueFactory::create_residue( new_rsd_type ) );
-				conformation::copy_residue_coordinates_and_rebuild_missing_atoms( old_rsd, *new_rsd, conformation );
-				conformation.replace_residue( seqpos, *new_rsd, false );
-
-			}
-
-
-		/// @details E.g., make a terminus variant, and replace the original in pose.
-		/// @note This copies any atoms in common between old and new residues, rebuilding the others.
-		void
-			add_variant_type_to_conformation_residue(
-					conformation::Conformation & conformation,
-					chemical::VariantType const variant_type,
-					Size const seqpos )
-			{
-				Residue const & old_rsd( conformation.residue( seqpos ) );
-
-				// the type of the desired variant residue
-				chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
-				chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_added( old_rsd.type(), variant_type ) );
-
-				core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
-			}
-
-
-		/// @details E.g., remove a terminus variant, and replace the original in pose.
-		/// @note This copies any atoms in common between old and new residues, rebuilding the others.
-		void
-			remove_variant_type_from_conformation_residue(
-					conformation::Conformation & conformation,
-					chemical::VariantType const variant_type,
-					Size const seqpos )
-			{
-				Residue const & old_rsd( conformation.residue( seqpos ) );
-
-				// the type of the desired variant residue
-				chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
-				chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_removed( old_rsd.type(), variant_type ) );
-
-				core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		void
-			add_lower_terminus_type_to_conformation_residue(
-					conformation::Conformation & conformation,
-					Size const seqpos
-					)
-			{
-				core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		void
-			remove_lower_terminus_type_from_conformation_residue(
-					conformation::Conformation & conformation,
-					Size const seqpos
-					)
-			{
-				remove_variant_type_from_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
-				remove_variant_type_from_conformation_residue( conformation, chemical::LOWERTERM_TRUNC_VARIANT, seqpos );
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		void
-			add_upper_terminus_type_to_conformation_residue(
-					conformation::Conformation & conformation,
-					Size const seqpos
-					)
-			{
-				core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		void
-			remove_upper_terminus_type_from_conformation_residue(
-					conformation::Conformation & conformation,
-					Size const seqpos
-					)
-			{
-				remove_variant_type_from_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
-				remove_variant_type_from_conformation_residue( conformation, chemical::UPPERTERM_TRUNC_VARIANT, seqpos );
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @details  Build an atom-tree from a fold-tree and a set of residues
-		/// atoms in the tree are allocated with new (on the heap) and held in owning pointers in atom_pointer
-		/// @note  atom_pointer is cleared at the beginning and then filled with AtomOPs to all the atoms
-
-
-		void
-			build_tree(
-					kinematics::FoldTree const & fold_tree,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomPointer2D & atom_pointer
-					)
-			{
-				using conformation::Residue;
-
-				// note -- we clear atom_pointer
-				atom_pointer.clear();
-				atom_pointer.resize( residues.size() );
-
-				// build first atom. make it a "JumpAtom"
-				{
-					int const start_pos( fold_tree.root() );
-					Residue const & rsd( *(residues[start_pos]) );
-
-					build_residue_tree( residues, rsd, fold_tree, atom_pointer[ start_pos ] );
-
-				}
-
-				// traverse tree, build edges
-				for ( auto const & it : fold_tree ) {
-
-					if ( it.is_jump() ) {
-						build_jump_edge( it, residues, atom_pointer );
-
-					} else if ( it.label() == kinematics::Edge::PEPTIDE ) {
-						// build a peptide edge
-						build_polymer_edge( it, residues, atom_pointer );
-
-					} else if ( it.label() == kinematics::Edge::CHEMICAL ) {
-						build_chemical_edge( it, residues, atom_pointer );
-
-					} else {
-						if ( TR.Error.visible() ) {
-							TR.Error << "Failed to identify kinematics::Edge label in core/kinematics/util.cc::build_tree()" << std::endl;
-							TR.Error << "Label = " << it.label() << std::endl;
-						}
-						utility_exit();
-					}
-				}
-
-				// now guarantee that jump stubs are residue-internal if desired
-				for ( auto const & it : fold_tree ) {
-					if ( it.is_jump() && it.keep_stub_in_residue() ) {
-						promote_sameresidue_child_of_jump_atom( it, residues, atom_pointer );
-					}
-				}
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @details root_atomno is the root for the sub atom-tree of this edge.
-		/// anchor_atomno is the entry point of this sub atom-tree into the main atom-tree.
-
-		void
-			build_jump_edge(
-					kinematics::Edge const & edge,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomPointer2D & atom_pointer
-					)
-			{
-				debug_assert( edge.is_jump() );
-
-				int const estart  ( edge.start() );
-				int const estop   ( edge.stop () );
-
-				// these may have been set in the edge
-				Size anchor_atomno, root_atomno;
-				get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
-
-				// get the anchor atom
-				kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
-				debug_assert( anchor_atom );
-
-				// build the new residue
-				build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], true /*Jump*/ );
-
-				// now wire in the new residue connection
-				anchor_atom->insert_atom( atom_pointer[ id::AtomID( root_atomno, estop ) ] );
-
-
-				//  std::cout << "build_jump_edge: " << edge << ' ' <<  estop << ' ' << root_atomno << ' ' <<
-				//   estart << ' ' << anchor_atomno << std::endl;
-
-				//  std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
-				//  anchor_atom->show();
-				// debug_assert( anchor_atom->id() == AtomID( anchor_atomno, estart ) );
-				//  std::cout << "TREE AFTER END: " << edge << std::endl;
-
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @details assumes that the start residue of edge has already been built. Traverse
-		///the polymer edge residue by residue and after building sub atom-tree for this residue,
-		///attaches the edge's subtree to the anchor_atom in the previous residue.
-		///
-		void
-			build_polymer_edge(
-					kinematics::Edge const & edge,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomPointer2D & atom_pointer
-					)
-			{
-				int const start( edge.start() );
-				int const stop ( edge.stop() );
-				int const dir  ( edge.polymer_direction() );
-
-				debug_assert( dir == 1 || dir == -1 );
-
-				//id::AtomID first_anchor;
-				for ( int pos=start+dir; pos != stop + dir; pos += dir ) {
-					runtime_assert( pos > 0 );
-					conformation::Residue const & rsd( *residues[pos] );
-					int const anchor_pos( pos-dir );
-					Size anchor_atomno, root_atomno;
-					get_anchor_and_root_atoms( *residues[ anchor_pos ], rsd, edge, anchor_atomno, root_atomno );
-
-					// build the new residue tree, fill in the atom_pointer array
-					build_residue_tree( root_atomno, rsd, atom_pointer[pos], false /*Jump*/ );
-
-					kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, anchor_pos ) ) );
-					kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno,  pos ) ) );
-					debug_assert( anchor_atom && root_atom );
-					anchor_atom->insert_atom( root_atom );
-					//std::cout << "build_polymer_edge: " << edge << ' ' <<  pos << ' ' << root_atomno << ' ' <<
-					//   anchor_pos << ' ' << anchor_atomno << std::endl;
-					//  if ( pos == start+dir ) first_anchor = AtomID( anchor_atomno, anchor_pos );
-				}
-				//  if ( start != stop ) {
-				//   std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
-				//   atom_pointer[ first_anchor ]->show();
-				//   std::cout << "TREE AFTER END: " << edge << std::endl;
-				//  }
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @details assumes that the start residue of edge has already been built. Traverse
-		///the chemical edge residue by residue and after building sub atom-tree for this residue,
-		///attaches the edge's subtree to the anchor_atom in the previous residue.
-		///
-		void
-			build_chemical_edge(
-					kinematics::Edge const & edge,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomPointer2D & atom_pointer
-					)
-			{
-
-				int const estart  ( edge.start() );
-				int const estop   ( edge.stop () );
-
-				// these may have been set in the edge
-				Size anchor_atomno, root_atomno;
-				get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
-
-				build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], false /*Jump*/ );
-
-				// get the anchor atom
-				kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
-				kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno, estop  ) ) );
-				debug_assert( anchor_atom && root_atom );
-
-				anchor_atom->insert_atom( root_atom );
-			}
-
-		/////////////////////////////////////////////////////////////////////////////
-		///\brief get the root atom for building residue atom-tree given the folding direction "dir"
-		int
-			get_root_atomno(
-					conformation::Residue const & rsd,
-					int const dir // +1, -1, or "dir_jump"
-					)
-			{
-				// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
-				// in the fold_tree ( ==> residue should be a polymer type? )
-				int const forward( 1 );
-				int const backward( -1 );
-
-				if ( dir == forward ) {
-					// N for proteins, P for DNA
-					if ( rsd.is_polymer() ) {
-						if ( rsd.is_lower_terminus() && rsd.mainchain_atoms().size() > 0 ) {
-							// this is a little strange to be folding through a terminal residue but kinematics doesn't
-							// have to correlate perfectly with chemical
-							return rsd.mainchain_atom(1);
-						} else {
-							return rsd.lower_connect_atom(); //mainchain_atoms()[1];
-						}
-					} else {
-						return get_root_atomno( rsd, kinematics::dir_jump );
-					}
-				} else if ( dir == backward ) {
-					if ( rsd.is_polymer() ) {
-						if ( rsd.is_upper_terminus() && rsd.mainchain_atoms().size() > 0 ) {
-							// this is a little strange to be folding through a terminal residue but kinematics doesn't
-							// have to correlate perfectly with chemical
-							return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
-						} else {
-							// C for proteins, O3' for DNA
-							return rsd.upper_connect_atom(); //mainchain_atoms()[ rsd.mainchain_atoms().size() ];
-						}
-					} else {
-						return get_root_atomno( rsd, kinematics::dir_jump );
-					}
-				} else {
-					debug_assert( dir == kinematics::dir_jump );
-					// default for jumps, use the N-terminal attachment?
-					if ( rsd.mainchain_atoms().empty() ) {
-						// For non-polymeric ligands, match the ICOOR root.
-						// (This should minimize issues with matching trees.)
-						return rsd.type().root_atom();
-					} else if ( rsd.type().has_variant_type( chemical::N_ACETYLATION ) ) {
-						return 1; // awful hack! want N-CA-C triad to stay put when one of these residues is at root.
-					} else {
-						// PB 10/29/07 - changing to use an interior mainchain atom
-						//
-						// old choice of mainchain_atoms()[1] meant that changing omega of jump_pos-1 would propagate
-						// C-terminal to jump_pos, which is bad for loop modeling where the usual assumption was that
-						// we can use loop_begin-1 and loop_end+1 as jump points
-						//
-						Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
-						Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
-						return rsd.mainchain_atoms()[ mainchain_index ];
-					}
-				}
-			}
-
-		/// @details  Determine which atom to use as the root of the root residue in the atomtree.
-		/// It is sometimes useful to be able to control the atom chosen as the root of the atomtree, eg in graphics.
-		/// The logic below uses atom_info stored in the foldtree for jump edges emanating from the root residue
-		/// to override the default atom (if the root residue is a jump_point and said atom_info exists)
-
-
-		Size
-			get_root_residue_root_atomno(
-					conformation::Residue const & rsd,
-					kinematics::FoldTree const & fold_tree
-					)
-			{
-				if ( !rsd.type().is_polymer() ) return 1;
-
-
-				Size const seqpos( rsd.seqpos() );
-				debug_assert( seqpos == Size( fold_tree.root() ) ); // need to refactor foldtree to use Size instead of int
-
-				Size root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
-
-				if ( fold_tree.is_jump_point( seqpos ) ) {
-					for ( Size i=1; i<= fold_tree.num_jump(); ++i ) {
-						kinematics::Edge const & edge( fold_tree.jump_edge( i ) );
-						if ( seqpos == Size(edge.start()) && edge.has_atom_info() ) {
-							root_atomno = rsd.atom_index( edge.upstream_atom() );
-							break;
-						}
-					}
-				}
-				return root_atomno;
-			}
-
-		/// @details  A wrapper function to build an atom-tree for a residue. Uses information from the foldtree to
-		/// find the proper root atom if it is not defined, and determine the direction in which to build the residue.
-		/// The goal of this function is to allow the Conformation to rebuild parts of the AtomTree in a way that is
-		/// compatible with what would be built if we erased the entire atomtree and rebuilt it using the foldtree.
-		/// Also used to build the atomtree for the root residue when we are building the atomtree from scratch.
-
-		void
-			build_residue_tree(
-					conformation::ResidueCOPs const & residues,
-					conformation::Residue const & rsd,
-					kinematics::FoldTree const & fold_tree,
-					kinematics::AtomPointer1D & atom_ptr
-					)
-			{
-				// determine root_atomno and whether root_atom is a jump_atom
-
-				bool root_atom_is_jump_atom( false );
-				Size root_atomno(0);
-
-				Size const seqpos( rsd.seqpos() );
-
-				if ( seqpos == fold_tree.root() ) {
-					root_atom_is_jump_atom = true;
-
-					root_atomno = get_root_residue_root_atomno( rsd, fold_tree );
-
-				} else {
-					// seqpos is not the root of the fold_tree
-					kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) ); // the edge that builds seqpos
-
-					if ( edge.is_peptide() ) {
-						// peptide edge
-						root_atomno = get_root_atomno( rsd, edge.polymer_direction() ); // the default setting
-					} else if ( edge.is_jump() ) {
-						// jump edge
-						root_atom_is_jump_atom = true;
-						if ( edge.has_atom_info() ) {
-							root_atomno = rsd.atom_index( edge.downstream_atom() );
-						} else {
-							root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
-						}
-					} else {
-						//// chemical edge -- atomnumbers of connections should be programmed in
-						//debug_assert( edge.has_atom_info() );
-						//root_atomno = rsd.atom_index( edge.downstream_atom() );
-						// Connection atoms are not always present in the edge, but might be;  else use defaults.
-						int const estart  ( edge.start() );
-						int const estop   ( edge.stop () );
-						Size anchor_atno, root_atno;
-						get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atno, root_atno );
-						root_atomno = (int) root_atno; // stupid Size/int confusion...
-					}
-				}
-				debug_assert( root_atomno );
-
-				// now call the main build_residue_tree function
-				build_residue_tree( root_atomno, rsd, atom_ptr, root_atom_is_jump_atom );
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @brief Check if this atom neighbor has been black-listed ("CUT_BOND" in params file).
-		bool
-			check_good_neighbor( Size const & atom_index, utility::vector1< Size > const & cut_nbrs ) {
-				for ( Size kk=1; kk<=cut_nbrs.size(); ++kk )  {
-					if ( cut_nbrs[kk] == atom_index ) return false;
-				}
-				return true;
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @brief is atom2 the last atom of our chi angle ?
-		inline
-			bool
-			chi_continuation(
-					Size const atom1, // current atom
-					Size const atom2, // potential nbr
-					utility::vector1< utility::vector1< Size > > const & chi_atoms
-					)
-			{
-				int const nchi( chi_atoms.size() );
-
-				for ( int i=1; i<= nchi; ++i ) {
-					utility::vector1< Size > const & atoms( chi_atoms[i] );
-					if ( atom1 == atoms[2] &&
-							atom2 == atoms[1] ) return true;
-
-					if ( atom1 == atoms[3] &&
-							atom2 == atoms[4] ) return true;
-				}
-				return false;
-
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @brief would we be breaking into a chi angle by adding atom2 to the tree now?
-		inline
-			bool
-			chi_interruption(
-					Size const atom1, // current atom
-					Size const atom2, // potential nbr
-					utility::vector1< utility::vector1< Size > > const & chi_atoms,
-					utility::vector1< bool > const & is_done
-					)
-			{
-				int const nchi( chi_atoms.size() );
-
-				//not an interruption if atom1 and atom2 delineate a chi angle.
-				for ( int i=1; i<= nchi; ++i ) {
-					utility::vector1< Size > const & atoms( chi_atoms[i] );
-
-					if ( atom2 == atoms[2] &&
-							( atom1 == atoms[1] || atom1 == atoms[3] ) ) return false;
-
-					if ( atom2 == atoms[3] &&
-							( atom1 == atoms[2] || atom1 == atoms[4] ) ) return false;
-				}
-
-
-				for ( int i=1; i<= nchi; ++i ) {
-					utility::vector1< Size > const & atoms( chi_atoms[i] );
-
-					if ( atom2 == atoms[2] &&
-							atom1 != atoms[1] &&
-							atom1 != atoms[3] ) return true;
-
-					if ( atom2 == atoms[3] &&
-							atom1 != atoms[2] &&
-							atom1 != atoms[4] ) return true;
-
-					if ( (atom2 == atoms[1] && is_done[ atoms[4] ]) ||
-							(atom2 == atoms[4] && is_done[ atoms[1] ]) ) return true;
-
-				}
-				return false;
-
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @brief simply fill the "links" by adding, for each atom, its bonded neighbors
-		void
-			setup_links_simple(
-					conformation::Residue const & rsd,
-					kinematics::Links & links
-					)
-			{
-				int const natoms( rsd.natoms() );
-
-				links.clear();
-				links.resize( natoms );
-
-				for ( int atomno1=1; atomno1<= natoms; ++atomno1 ) {
-					utility::vector1< Size > const & nbrs( rsd.nbrs( atomno1 ) );
-					utility::vector1< Size > const & cut_nbrs( rsd.cut_bond_neighbor( atomno1 ) );
-					for ( Size jj=1; jj<= nbrs.size(); ++jj ) {
-						if ( !check_good_neighbor( nbrs[jj], cut_nbrs ) ) continue;
-						links[ atomno1 ].push_back( nbrs[jj] );
-					}
-				}
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		// called recursively
-
-		// Rule I -- dont enter a chi angle in the middle (atoms 2 or 3 ),
-		//     and don't enter a chi angle from one side if the other side's atoms have already been added to the tree
-		//
-		//
-		// Rule II -- if you're atom 2 and atom 1 hasn't been done, put that first
-		//   likewise for atoms 3 and 4
-		//
-		// Rule III -- mainchain atoms 1st, tiebreaking by rule II
-		//
-		// Rule IV -- heavyatoms before hydrogens, subject to other three rules
-		//
-		/// @brief set correct order for how atoms are linked to each other.
-		///
-		/// this function is called recursively.
-		/// @li atom1 is the root of links at the current level.
-		/// @li full_links store information about UNORDERED bonded neighbors for each atom in this residue.
-		/// @li is_done indicates which atoms have already been linked.
-		/// @li is_mainchain, is_chi, is_hydrogen and chi atoms are self explanatory
-		/// @li new_links store information about ORDERED bonded neighbors (links) for each atom in this residue.
-		void
-			setup_atom_links(
-					int const atom1,
-					kinematics::Links const & full_links,
-					utility::vector1< bool > & is_done,
-					utility::vector1< bool > const & is_mainchain,
-					utility::vector1< bool > const & is_chi,
-					utility::vector1< bool > const & is_hydrogen,
-					utility::vector1< utility::vector1< Size > > const & chi_atoms,
-					kinematics::Links & new_links
-					)
-			{
-				is_done[atom1] = true;
-
-				utility::vector1< Size > const & full_l( full_links[atom1] );
-				utility::vector1< Size >    &  new_l(  new_links[atom1] );
-
-				debug_assert( new_l.empty() );
-
-				Size const n_nbrs( full_l.size() );
-
-				if ( n_nbrs == 1 ) {
-					Size const nbr( full_l[1] );
-					if ( !is_done[nbr] ) {
-						// special case -- we have no choice but to add this guy otherwise setup will fail
-						new_l.push_back( nbr );
-						setup_atom_links( nbr, full_links, is_done, is_mainchain, is_chi, is_hydrogen, chi_atoms, new_links );
-					}
-					return;
-				}
-
-				// top priority -- within a chi angle, and mainchain
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-
-					if ( is_mainchain[ atom2 ] && is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-				// next priority -- mainchain
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-
-					if ( is_mainchain[ atom2 ] ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-				// next priority -- within a chi angle and heavy.
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-
-					if ( is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) && !is_hydrogen[ atom2 ] ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-				// next priority -- any heavy atom chi?
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-
-					if ( is_chi[ atom2 ] && !is_hydrogen[ atom2 ] ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-
-				// next priority -- any chi -- could be hydrogen
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-
-					if ( is_chi[ atom2 ] ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-				// next priority -- heavyatoms
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-					if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
-					if ( !is_hydrogen[ atom2 ] ) {
-						new_l.push_back( atom2 );
-						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-								is_hydrogen, chi_atoms, new_links );
-					}
-				}
-
-
-				// lowest priority -- hydrogens
-				for ( Size i=1; i<= n_nbrs; ++i ) {
-					int const atom2( full_l[i] );
-					if ( is_done[ atom2 ] ) continue;
-					if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
-					new_l.push_back( atom2 );
-					setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-							is_hydrogen, chi_atoms, new_links );
-				}
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		/// @brief given the root_atomno, set up rules for how other atoms are linked for this residue
-		///a wrapper function calling setup_atom_links recursively .
-		void
-			setup_links(
-					conformation::Residue const & rsd,
-					int const root_atomno,
-					kinematics::Links & links
-					)
-			{
-				using BVec = utility::vector1<bool>;
-
-				//////////////////////////////////
-				// get the full list of atom nbrs:
-				kinematics::Links full_links;
-
-				setup_links_simple( rsd, full_links );
-
-				// natoms
-				Size const natoms( rsd.natoms() );
-
-				////////////////
-				// chi atoms
-				BVec is_chi( natoms, false ); // vector bool
-				utility::vector1< utility::vector1< Size > > const & chi_atoms
-					( rsd.chi_atoms() );
-				for ( Size i=1; i<= chi_atoms.size(); ++i ) {
-					for ( int j=1; j<= 4; ++j ) {
-						is_chi[ chi_atoms[i][j] ] = true;
-					}
-				}
-
-
-				//////////////////
-				// mainchain atoms
-				BVec is_mainchain( natoms, false ); // vector bool
-				utility::vector1< Size > const & mainchain( rsd.mainchain_atoms() );
-				for ( Size i=1; i<= mainchain.size(); ++i ) {
-					is_mainchain[ mainchain[i] ] = true;
-				}
-				if ( rsd.has_variant_type( chemical::CUTPOINT_LOWER ) ) {
-					is_mainchain[ rsd.atom_index( "OVL1" ) ] = true;
-					if ( rsd.has( "OVL2" ) ) {
-						is_mainchain[ rsd.atom_index( "OVL2" ) ] = true;
-					}
-				}
-				if ( rsd.has_variant_type( chemical::CUTPOINT_UPPER ) ) {
-					is_mainchain[ rsd.atom_index( "OVU1" ) ] = true;
-				}
-
-				////////////
-				// hydrogens
-				BVec is_hydrogen( natoms, false );
-				for ( Size i=1; i<= natoms; ++i ) {
-					is_hydrogen[i] = rsd.atom_type(i).is_hydrogen();
-				}
-
-
-				links.clear();
-				links.resize( natoms );
-
-				BVec is_done( natoms, false ); // keep track of what's done
-				setup_atom_links( root_atomno, full_links, is_done, is_mainchain,  is_chi,
-						is_hydrogen, chi_atoms, links );
-
-
-				// check for an atom that wasn't added
-				for ( Size i=1; i<= natoms; ++i ) {
-					if ( !is_done[ i ] ) {
-						if ( TR.Error.visible() ) {
-							TR.Error << "Unable to setup links for residue " << std::endl;
-							for ( Size j=1; j<= natoms; ++j ) {
-								TR.Error << rsd.atom_name(j) << ' ' << is_done[j] << ' ' << is_mainchain[j] << ' ' << is_chi[j] << ' ' <<
-									is_hydrogen[j] << std::endl;
-							}
-						}
-						utility_exit();
-					}
-				}
-			}
-
-
-		///////////////////////////////////////////////////////////////////////////////
-		///\brief set up a local atom-tree for a residue from the defined root atom.
-		void
-			build_residue_tree(
-					int const root_atomno,
-					conformation::Residue const & rsd,
-					kinematics::AtomPointer1D & atom_ptr,
-					bool const root_is_jump_atom
-					)
-			{
-				Size const natoms( rsd.natoms() );
-
-				atom_ptr.clear();
-				atom_ptr.resize( natoms ); // default C-TOR for AtomOP is 0 initialized
-
-				// setup the atom nbrs so that the tree will match the desired torsion
-				// angles
-				kinematics::Links links;
-				setup_links( rsd, root_atomno, links );
-
-				// now build the residue atom-tree using the recursive function add_atom
-				kinematics::add_atom( root_atomno, rsd.seqpos(), links, atom_ptr, root_is_jump_atom );
-
-				// fill in the coordinates from the residue into the atomtree
-				for ( Size i=1; i<= natoms; ++i ) {
-					atom_ptr[i]->xyz( rsd.atom(i).xyz() );
-				}
-			}
-
-		/// @details  Get the incoming connection and all outgoing connections from a residue
-
-		void
-			get_residue_connections(
-					conformation::Residue const & new_rsd,
-					kinematics::FoldTree const & fold_tree,
-					conformation::ResidueCOPs const & residues,
-					id::BondID & new_rsd_in,
-					utility::vector1< id::BondID > & new_rsd_out
-					)
-			{
-
-				Size const seqpos( new_rsd.seqpos() );
-
-				// setup incoming connection
-				if ( fold_tree.is_root( seqpos ) ) {
-					new_rsd_in.atom1 = id::AtomID::BOGUS_ATOM_ID();
-					new_rsd_in.atom2 = id::AtomID( get_root_residue_root_atomno( new_rsd, fold_tree ), seqpos );
-				} else {
-					Size anchor_atomno, root_atomno, anchor_pos;
-					kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
-					if ( edge.is_polymer() ) anchor_pos = seqpos - edge.polymer_direction();
-					else anchor_pos = edge.start();
-					get_anchor_and_root_atoms( *residues[ anchor_pos ], new_rsd, edge, anchor_atomno, root_atomno );
-					new_rsd_in.atom1 = id::AtomID( anchor_atomno, anchor_pos );
-					new_rsd_in.atom2 = id::AtomID( root_atomno, seqpos );
-				}
-
-
-				// setup the outgoing connections
-				new_rsd_out.clear();
-				utility::vector1< kinematics::Edge > const outgoing_edges( fold_tree.get_outgoing_edges( seqpos ) );
-				for ( auto const & outgoing_edge : outgoing_edges ) {
-					Size anchor_atomno, root_atomno;
-					Size const root_pos( ( outgoing_edge.is_polymer() ) ? seqpos + outgoing_edge.polymer_direction() : outgoing_edge.stop() );
-					get_anchor_and_root_atoms( new_rsd, *residues[ root_pos ], outgoing_edge, anchor_atomno, root_atomno );
-					new_rsd_out.push_back( id::BondID( id::AtomID( anchor_atomno, seqpos ), id::AtomID( root_atomno, root_pos ) ) );
-				}
-			}
-
-
-		/// @details  Helper function for conformation routines.
-		/// Uses fold_tree to deduce the incoming/outgoing connections for the new residue and the old residue
-		/// We want it to be the case that the tree we get after this call is the same one that we would have gotten
-		/// by calling build_tree
-		void
-			replace_residue_in_atom_tree(
-					conformation::Residue const & new_rsd,
-					//conformation::Residue const & old_rsd,
-					kinematics::FoldTree const & fold_tree,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomTree & atom_tree
-					)
-			{
-				id::BondID new_rsd_in;
-				utility::vector1< id::BondID > new_rsd_out;
-
-				get_residue_connections( new_rsd, fold_tree, residues, new_rsd_in, new_rsd_out );
-
-				// build the new atoms
-				kinematics::AtomPointer1D new_atoms;
-				build_residue_tree( residues, new_rsd, fold_tree, new_atoms );
-
-				// now replace the atoms
-				atom_tree.replace_residue_subtree( new_rsd_in, new_rsd_out, new_atoms );
-
-				// preserve same-residue jump status if necessary
-				if ( fold_tree.is_jump_point( new_rsd.seqpos() ) && !fold_tree.is_root( new_rsd.seqpos() ) ) {
-					kinematics::Edge const & edge( fold_tree.get_residue_edge( new_rsd.seqpos() ) );
-					if ( edge.is_jump() && edge.keep_stub_in_residue() ) {
-						promote_sameresidue_child_of_jump_atom( edge, residues, atom_tree );
-					}
-				}
-			}
-
-		/// @brief  Inserts/ appends new residue subtree into an existing atomtree
-		/// @note  The foldtree must already have been changed to reflect the new residue
-		/// @note  The residues array should already have been inserted into
-		/// @note  The sequence position of the new residue is deduced from new_rsd.seqpos()
-		/// @note  This function handles renumbering of the atomtree if necessary
-		void
-			insert_residue_into_atom_tree(
-					conformation::Residue const & new_rsd,
-					kinematics::FoldTree const & fold_tree,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomTree & atom_tree
-					)
-			{
-
-				Size const seqpos( new_rsd.seqpos() );
-				Size const nres( fold_tree.nres() );
-				Size const old_nres( atom_tree.size() );
-				debug_assert( nres == residues.size() && seqpos <= nres && old_nres == nres-1 );
-
-				/////////////////////////////////
-				// setup for renumbering atomtree
-				utility::vector1< int > old2new( old_nres, 0 );
-				for ( Size i=1; i<= old_nres; ++i ) {
-					if ( i< seqpos ) old2new[i] = i;
-					else old2new[i] = i+1;
-				}
-
-				// renumber the atomtree, fold_tree
-				atom_tree.update_sequence_numbering( nres, old2new );
-				debug_assert( atom_tree.size() == nres );
-
-				replace_residue_in_atom_tree( new_rsd, fold_tree, residues, atom_tree );
-
-			}
-
-
-		/// @details  Get the atom-index of the atom to which the residue at position seqpos should be anchored in
-		/// constructing the atomtree.
-
-		int
-			get_anchor_atomno( conformation::Residue const & anchor_rsd, Size const seqpos, kinematics::FoldTree const & fold_tree )
-			{
-				int anchor_atomno(0);
-				debug_assert( seqpos != (Size)fold_tree.root() );
-
-				kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
-
-				if ( edge.is_jump() ) {
-					// jump edge
-					debug_assert( (seqpos == (Size)edge.stop()) && ((Size)anchor_rsd.seqpos() == (Size)edge.start()) );
-					if ( edge.has_atom_info() ) {
-						anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-					} else {
-						anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
-					}
-				} else if ( edge.is_peptide() ) {
-					// peptide edge
-					int const dir( edge.polymer_direction() );
-					debug_assert( anchor_rsd.seqpos() == seqpos-dir );
-					anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
-				} else {
-					// chemical edge
-					debug_assert( seqpos == static_cast< Size >( edge.stop() ) && anchor_rsd.seqpos() == static_cast< Size >( edge.start() ) && edge.has_atom_info() );
-					anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-				}
-				debug_assert( anchor_atomno );
-				return anchor_atomno;
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		int
-			get_anchor_atomno(
-					conformation::Residue const & rsd,
-					int const dir // forward(1), backward(-1), or "dir_jump"
-					)
-			{
-				// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
-				// in the fold_tree ( ==> residue should be a polymer type? )
-				int const forward( 1 ), backward( -1 );
-
-				if ( dir == forward ) {
-					// C for proteins, O3' for DNA
-					if ( rsd.is_polymer() ) {
-						if ( rsd.is_upper_terminus() ) {
-							// this is a little strange to be folding through a terminal residue but kinematics doesn't
-							// have to correlate perfectly with chemical
-							return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
-						} else {
-							return rsd.upper_connect_atom();
-						}
-					} else {
-						return get_anchor_atomno( rsd, kinematics::dir_jump );
-					}
-				} else if ( dir == backward ) {
-					// N for proteins, P for DNA
-					if ( rsd.is_polymer() ) {
-						if ( rsd.is_lower_terminus() ) {
-							// this is a little strange to be folding through a terminal residue but kinematics doesn't
-							// have to correlate perfectly with chemical
-							return rsd.mainchain_atom(1);
-						} else {
-							return rsd.lower_connect_atom();
-						}
-					} else {
-						return get_anchor_atomno( rsd, kinematics::dir_jump );
-					}
-
-				} else {
-					debug_assert( dir == kinematics::dir_jump );
-					// default for jumps, use the N-terminal attachment?
-					if ( rsd.mainchain_atoms().empty() ) {
-						// SHORT TERM HACK -- need to add some logic for root atomno
-						return 1;
-					} else {
-						// PB 10/29/07 - changing to use an interior mainchain atom
-						Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
-						Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
-						return rsd.mainchain_atoms()[ mainchain_index ];
-						//return rsd.mainchain_atoms()[1];
-					}
-				}
-			}
-
-		/// @details  Determines the anchor and root atom indices based on residue types and the foldtree edge.
-
-		void
-			get_anchor_and_root_atoms(
-					conformation::Residue const & anchor_rsd,
-					conformation::Residue const & root_rsd,
-					kinematics::Edge const & edge,
-					Size & anchor_atomno,
-					Size & root_atomno
-					)
-			{
-				// AMW: There are some ugly special cases for pdb_GAI here. That's
-				// because the edges weren't getting good atom indices on them, I think?
-				// In any case, this function isn't called in tight loops, so we are ok.
-
-				ASSERT_ONLY(Size const anchor_pos( anchor_rsd.seqpos() ););
-				ASSERT_ONLY(Size const root_pos( root_rsd.seqpos() ););
-
-				if ( edge.is_polymer() ) {
-					// POLYMER EDGE
-					int const dir( edge.polymer_direction() );
-					debug_assert( dir == 1 || dir == -1 );
-					debug_assert( root_pos == anchor_pos + dir );
-					anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
-					root_atomno   = get_root_atomno  (   root_rsd, dir );
-				} else {
-					debug_assert( anchor_pos == Size(edge.start()) && root_pos == Size(edge.stop()) );
-					if ( edge.has_atom_info() ) {
-						// JUMP OR CHEMICAL W/ ATOM INFO
-						if ( anchor_rsd.type().name() == "pdb_GAI" ||
-								anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
-						else anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-						if ( root_rsd.type().name() == "pdb_GAI" ||
-								anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
-						else root_atomno   =   root_rsd.atom_index( edge.downstream_atom() );
-					} else {
-						if ( edge.is_jump() ) {
-							// JUMP EDGE
-							if ( anchor_rsd.type().name() == "pdb_GAI" ||
-									anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
-							else anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
-							if ( root_rsd.type().name() == "pdb_GAI" ||
-									anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
-							else root_atomno   =   get_root_atomno(   root_rsd, kinematics::dir_jump );
-						} else if ( edge.is_chemical_bond() ) {
-							// CHEMICAL EDGE
-							get_chemical_root_and_anchor_atomnos( anchor_rsd, root_rsd, anchor_atomno, root_atomno );
-						} else {
-							utility_exit_with_message( "Unrecognized edge type!" );
-						}
-					}
-				}
-				return;
-			}
-
-
-		// this code assumed we were also being passed old_rsd:
-		// optionally debug some things before making atom_tree call
-		/**if ( debug ) {
-			BondID old_rsd_in;
-			vector1< BondID > old_rsd_out;
-			get_residue_connections( old_rsd, fold_tree, residues, old_rsd_in, old_rsd_out );
-			debug_assert( new_rsd_in.atom1 == old_rsd_in.atom1 && new_rsd_out.size() == old_rsd_out.size() );
-			for ( Size i=1; i<= new_rsd_out.size(); ++i ) {
-			debug_assert( new_rsd_out[i].atom2 == old_rsd_out[i].atom2 );
-			}
-			}**/
-
-
-		///////////////////////////////////////////////////////////////////////////////
-
-		void
-			promote_sameresidue_child_of_jump_atom(
-					kinematics::Edge const & edge,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomTree & atom_tree
-					)
-			{
-				debug_assert( edge.is_jump() );
-				Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
-				get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
-				atom_tree.promote_sameresidue_nonjump_child( id::AtomID( root_atomno, root_pos ) );
-			}
-
-
-		void
-			promote_sameresidue_child_of_jump_atom(
-					kinematics::Edge const & edge,
-					conformation::ResidueCOPs const & residues,
-					kinematics::AtomPointer2D const & atom_pointer
-					)
-			{
-				debug_assert( edge.is_jump() );
-				Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
-				get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
-				kinematics::tree::AtomOP root_atom( atom_pointer[ id::AtomID( root_atomno, root_pos ) ] );
-				debug_assert( root_atom->is_jump() );
-				kinematics::tree::AtomOP same_residue_child( nullptr );
-				for ( Size i=0; i< root_atom->n_nonjump_children(); ++i ) {
-					kinematics::tree::AtomOP child( atom_pointer[ root_atom->get_nonjump_atom( i )->id() ] ); // want nonconst, use atom_pointer
-					if ( Size(child->id().rsd()) == root_pos ) {
-						same_residue_child = child;
-						break;
-					}
-				}
-				if ( same_residue_child ) {
-					debug_assert( !same_residue_child->is_jump() );
-					root_atom->delete_atom( same_residue_child );
-					root_atom->insert_atom( same_residue_child );
-				} else {
-					if ( TR.Warning.visible() ) TR.Warning << "Unable to keep stub in residue: jump_atom has no non-jump, same-residue children!" << std::endl;
-				}
-			}
-
-		void
-			get_chemical_root_and_anchor_atomnos(
-					conformation::Residue const & rsd_anchor,
-					conformation::Residue const & rsd_root,
-					Size & anchor_atom_no,
-					Size & root_atom_no
-					)
-			{
-				debug_assert( rsd_anchor.is_bonded( rsd_root ) );
-
-				Size first_connection_id = rsd_anchor.connections_to_residue( rsd_root )[ 1 ];
-				chemical::ResConnID first_connection = rsd_anchor.connect_map( first_connection_id );
-				anchor_atom_no = rsd_anchor.residue_connection( first_connection_id ).atomno();
-				root_atom_no = rsd_root.residue_connection( first_connection.connid() ).atomno();
-			}
-
-		///////////////////////////////////////////////////////////////////////////////
-		//
-		// right now, this is used by the pose to setup a mapping which is
-		// passed in to the atomtree when replacing one residue with another
-		//
-		//
-		// maybe the behavior should really be to identify atoms with the same
-		// name in the two residues and map them...
-		//
-		// oh well, this will work for rewiring backbone connections properly;
-		// basically the atomtree will use this mapping when it is replacing
-		// the atoms of rsd1 with the subtree formed by the atoms of rsd2
-		// for this to work, all outgoing connections from the rsd1 atoms have
-		// to have their rsd1-atom represented in this map, so the atomtree
-		// knows where to attach the child when rsd2 is put in.
-
-
-		/// @details only map by atom number, not by identity currently.
-		void
-			setup_corresponding_atoms(
-					id::AtomID_Map< id::AtomID > & atom_map,
-					conformation::Residue const & rsd1,
-					conformation::Residue const & rsd2
-					)
-			{
-
-				// PB -- this whole function is going to go away soon, so I'm not really worried about all the hacks
-
-				int const seqpos1( rsd1.seqpos() );
-				int const seqpos2( rsd2.seqpos() );
-
-				utility::vector1< Size > const &
-					mainchain1( rsd1.mainchain_atoms() ),
-					mainchain2( rsd2.mainchain_atoms() );
-
-				debug_assert( mainchain1.size() == mainchain2.size() );
-
-				// special case for virtual residues -- fpd
-				if ( mainchain1.size() == 0 &&
-						rsd1.type().name3() == "XXX" && rsd2.type().name3() == "XXX" ) {
-					debug_assert( rsd1.atoms().size() == rsd2.atoms().size() );
-
-					for ( Size i=1, i_end = rsd1.atoms().size(); i<= i_end; ++i ) {
-						atom_map.set( id::AtomID( i, seqpos1 ), id::AtomID( i, seqpos2 ) );
-					}
-				} else {
-					for ( Size i=1, i_end = mainchain1.size(); i<= i_end; ++i ) {
-						atom_map.set( id::AtomID( mainchain1[i], seqpos1 ),
-								id::AtomID( mainchain2[i], seqpos2 ) );
-					}
-					if ( rsd1.is_DNA() && rsd2.is_DNA() ) {
-						// special case for dna-dna jumps anchored at sidechain atoms
-						for ( Size i=1; i<= 4; ++i ) {
-							atom_map.set( id::AtomID( rsd1.chi_atoms(1)[i], seqpos1 ),
-									id::AtomID( rsd2.chi_atoms(1)[i], seqpos2 ) );
-						}
-					}
-
-					if ( rsd1.is_RNA() && rsd2.is_RNA() ) {
-						// By the way, this is a total hack AND SHOULD NOT BE CHECKED IN
-						// BEFORE CONSULTING WITH PHIL! -- rhiju
-						// special case for rna-rna jumps anchored at sidechain atoms
-						if ( rsd1.name1() == rsd2.name1() ) {
-							for ( Size i=1; i<= rsd1.natoms(); ++i ) {
-								atom_map.set( id::AtomID( i, seqpos1 ),
-										id::AtomID( i, seqpos2 ) );
-							}
-						}
-					}
-
-				}
-
-				/// Now include atoms involved in residue connections, since these might be anchor points for the atomtree
-				for ( Size connid=1; connid<= rsd1.n_possible_residue_connections() && connid <= rsd2.n_possible_residue_connections(); ++connid ) {
-					Size const atom1( rsd1.type().residue_connection( connid ).atomno() );
-					Size const atom2( rsd2.type().residue_connection( connid ).atomno() );
-					if ( rsd1.atom_name( atom1 ) == rsd2.atom_name( atom2 ) ) {
-						atom_map.set( id::AtomID( atom1, seqpos1 ), id::AtomID( atom2, seqpos2 ) );
-					}
-				}
-			}
-
-		/// @brief Switch the disulfide state of a disulfide-forming residue (e.g. CYS->CYD or CYD->CYS or
-		/// DCYD->DCYS or DCYS->DCYD or whatnot).
-		/// @param[in] index Position of the residue to replace.
-		/// @param[in] cys_type_name3 The 3-letter name of the cys type to use: e.g. CYS
-		///  or CYD.  DEPRECATED and kept only for backward-compatibility.
-		/// @param[inout] conf The conformation to modify
-		/// @details Substitutes a residue with the given cys type, keeping as many of
-		///  the existing atom positions as possible.  If the original residue has a
-		///  disulfide variant it will be removed, otherwise a disulfide variant will
-		///  be added.  Should work with any ResidueTypeSet that has the proper
-		///  disulfide variants.  If the replacement fails for any reason a warning
-		///  will be printed.
-		/// @return true if the replacement was successful, false otherwise.
-		bool change_cys_state(
-				Size const index,
-				std::string const & cys_type_name3, //Deprecated.
-				Conformation & conf
-				) {
-
-			bool removing(false);
-
-			// Cache information on old residue.
-			core::chemical::ResidueType const & old_type( conf.residue_type( index ) );
-			chemical::ResidueTypeSetCOP residue_type_set = conf.residue_type_set_for_conf( old_type.mode() );
-
-			// make sure we're working on a disulfide-forming type.
-			if ( ( ! old_type.is_sidechain_thiol() ) && ( ! old_type.is_disulfide_bonded() ) ) {
-				if ( TR.Warning.visible() ) TR.Warning << "change_cys_state() was called on non-cys-like residue " << index << ", skipping!" << std::endl;
-				return false;
-			}
-
-			// Track the variant types of the old residue type.  We want the
-			// new residue to have the same variant type as the old.
-			utility::vector1< std::string > variant_types = old_type.properties().get_list_of_variants();
-
-			// check and handle disulfide state
-			if ( old_type.has_variant_type( chemical::DISULFIDE ) ) {
-				// if the old residue has DISULFIDE variant type then we are removing a
-				// disulfide, so remove the variant type from the list
-				variant_types.erase( std::find( variant_types.begin(), variant_types.end(), "DISULFIDE" ) );
-				removing = true;
-				//TR << "We just erased the DISULFIDE variant type as desired, since we are going from rn " << rn << " to thiol type " << std::endl;
-
-			} else /*If it does not have the DISULFIDE variant type*/ {
-				//TR << "We just added the DISULFIDE variant type as desired, since we are going from rn " << rn << " to disulfide type " << std::endl;
-				variant_types.push_back( "DISULFIDE" ); //chemical::DISULFIDE ); // creating a disulfide
-				removing = false;
-			}
-
-			// The following is for backward-compatibility only, for functions that would request CYD when the residue was already CYD or whatnot.
-			if ( cys_type_name3=="CYS" && !removing /*not removing if disulfide variant not found*/ ) return true; //If we're asked for a cys and we already have a cys, do nothing.
-			else if ( cys_type_name3=="CYD" && removing /*removing if the disulfide variant was found*/ ) return true; //Similarly, if we're asked for a cyd and we already have a cyd, do nothing.
-
-			// Get the residue type of the desired new residue type.
-			chemical::ResidueTypeCOP replacement_type( residue_type_set->get_representative_type_name3( old_type.name3(), variant_types ) );
-			if ( replacement_type ) {
-				Residue const & res = conf.residue(index);
-				ResidueOP new_res = ResidueFactory::create_residue( *replacement_type, res, conf );
-				copy_residue_coordinates_and_rebuild_missing_atoms( res, *new_res, conf );
-				conf.replace_residue( index, *new_res, false );
-				return true;
-			}
-
-
-			// If we are here then a residue type match wasn't found; issue error message.
-			if ( TR.Error.visible() ) TR.Error << "Couldn't find a " << (removing ? "disulfide-free" : "disulfide-bonded")  << " equivalent for residue " << old_type.name3() << index << "." <<std::endl;
-
-			return false;
 		}
 
-		id::NamedAtomID
-			atom_id_to_named_atom_id(
-					id::AtomID const & atom_id,
-					conformation::Residue const & rsd
-					){
-				std::string atom_name;
-				Size rsd_id;
-				if ( atom_id.atomno() <= rsd.atoms().size() ) {
-					atom_name = rsd.atom_name( atom_id.atomno() );
-					rsd_id = atom_id.rsd();
-				} else {
-					if ( TR.Error.visible() ) TR.Error << "Can't resolve atom_id " << atom_id << std::endl;
-					rsd_id = 0;
-					atom_name ="";
+		if ( lower_connect ) {
+			Residue const & prev_rsd( idl.residue( idl_pos-1 ) );
+
+			Size const nbb_prev( prev_rsd.n_mainchain_atoms() );
+			AtomID
+				bb1_idl( prev_rsd.mainchain_atom( nbb_prev ), idl_pos-1 ),
+				bb1 ( prev_rsd.mainchain_atom( nbb_prev ),  seqpos-1 ),
+				bb2_idl(   rsd.mainchain_atom(  1 ), idl_pos   ),
+				bb2 (   rsd.mainchain_atom(  1 ),  seqpos   ),
+				bb3_idl(   rsd.mainchain_atom(  2 ), idl_pos   ),
+				bb3 (   rsd.mainchain_atom(  2 ),  seqpos   );
+			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+		}
+
+		if ( upper_connect ) {
+			Residue const & next_rsd( idl.residue( idl_pos+1 ) );
+
+			AtomID
+				bb1_idl(   rsd.mainchain_atom( nbb-1 ), idl_pos   ),
+				bb1 (   rsd.mainchain_atom( nbb-1 ),  seqpos   ),
+				bb2_idl(   rsd.mainchain_atom( nbb   ), idl_pos   ),
+				bb2 (   rsd.mainchain_atom( nbb   ),  seqpos   ),
+				bb3_idl( next_rsd.mainchain_atom(  1 ), idl_pos+1 ),
+				bb3 ( next_rsd.mainchain_atom(  1 ),  seqpos+1 );
+
+			// bond angle
+			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+
+			// bond length
+			conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+		}
+	} // rsd.is_polymer()
+
+
+	//// now we orient the ideal residue onto the existing residue and replace it
+	ResidueOP idl_rsd( idl.residue( idl_pos ).clone() );
+
+	// EXTREMELY SUBTLE DANGEROUS THING ABOUT HAVING Residue const &'s lying around:
+	// if we put "rsd" in place of conformation.residue( seqpos ) below, this will not behave properly.
+	// that's because the xyz's in rsd don't get updated properly to reflect the changes to the conformation
+	// a "refold" is only triggered by another call to conformation.residue
+	// May want to consider making Residue smarter about this kind of thing, ie knowing its from a
+	// Conformation... acting as an observer... could get pretty tricky though...
+	//
+	idl_rsd->orient_onto_residue( conformation.residue( seqpos ) ); // can't use rsd here!
+	conformation.replace_residue( seqpos, *idl_rsd, false );
+
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+// NOTE: conformation is needed for polymer neighbours
+// @author Barak 07/2009
+bool
+is_ideal_position(
+	Size const seqpos,
+	Conformation const & conf,
+	Real theta_epsilon,
+	Real D_epsilon
+)
+{
+	using namespace core::kinematics;
+	runtime_assert( conf.size() >= seqpos  &&  seqpos >= 1 );
+
+	Residue const rsd( conf.residue( seqpos ) );
+
+	// I. Create mini-conformations for both idealized and original residue + nbrs, if appropriate )
+	ConformationOP miniconf_op( new Conformation() );
+	Conformation & miniconf = *miniconf_op;
+	ConformationOP miniconf_idl_op( new Conformation() );
+	Conformation & miniconf_idl = *miniconf_idl_op;
+	{
+		miniconf.append_residue_by_bond( rsd );
+		ResidueOP prsd_idl( ResidueFactory::create_residue( rsd.type() ) );
+		miniconf_idl.append_residue_by_bond( *prsd_idl );
+	}
+	// add polymer nbrs if needed
+	int seqpos_miniconf(1);
+	//bool lower_connect( false ), upper_connect( false );
+	if ( rsd.is_polymer() ) {
+		// prepending previous neighbour
+		if ( seqpos > 1 && !rsd.is_lower_terminus() && !conf.fold_tree().is_cutpoint( seqpos-1 ) ) {
+			//lower_connect = true;  // set but never used ~Labonte
+			seqpos_miniconf = 2; // pushed forward by prependedq residue
+			Residue const & prev_rsd = conf.residue( seqpos-1 );
+			miniconf.safely_prepend_polymer_residue_before_seqpos // TODO: safely is probably unneeded here, verify this point
+				( prev_rsd, 1, false /*build_ideal_geom*/);
+			ResidueOP pprev_rsd_idl( ResidueFactory::create_residue( prev_rsd.type() ) );
+			miniconf_idl.safely_prepend_polymer_residue_before_seqpos
+				( *pprev_rsd_idl, 1, true /*build_ideal_geom*/);
+		}
+		// appending next neighbour
+		if ( seqpos < conf.size() && !rsd.is_upper_terminus() && !conf.fold_tree().is_cutpoint( seqpos ) ) {
+			//upper_connect = true;  // set but never used ~Labonte
+			Residue const & next_rsd = conf.residue( seqpos+1 );
+			miniconf.safely_append_polymer_residue_after_seqpos
+				( next_rsd, seqpos_miniconf, false /*build_ideal_geom*/ );
+			ResidueOP pnext_rsd_idl( ResidueFactory::create_residue( next_rsd.type() ) );
+			miniconf_idl.safely_append_polymer_residue_after_seqpos
+				( *pnext_rsd_idl, seqpos_miniconf, true /*build_ideal_geom*/ );
+		}
+	}
+
+
+	// II. Compare angle and length of all residue bonded atoms in the new mini-conformations
+	for ( Size atom = 1, atom_end = miniconf.residue( seqpos_miniconf ).natoms();
+			atom <= atom_end;
+			++atom ) {
+		id::AtomID aid(atom, seqpos_miniconf);
+		if ( miniconf.atom_tree().atom(aid).is_jump() ) { // skip non-bonded atoms
+			continue;
+		}
+		id::DOF_ID dof_theta(aid, id::THETA); // bond angle
+		id::DOF_ID dof_D(aid, id::D); // bond length
+		if ( ! numeric::equal_by_epsilon(
+				miniconf.dof( dof_theta ), miniconf_idl.dof( dof_theta ), theta_epsilon ) ) {
+			if ( TR.visible() ) {
+				TR << "Non-ideal residue detected: "
+					<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
+					<< " Ideal theta=" << miniconf_idl.dof( dof_theta)
+					<< ", Inspected theta=" << miniconf.dof( dof_theta )
+					<< " (in Radians)"
+					<< std::endl;
+			}
+			return false;
+		}
+		if ( ! numeric::equal_by_epsilon(
+				miniconf.dof( dof_D), miniconf_idl.dof (dof_D), D_epsilon ) ) {
+			if ( TR.visible() ) {
+				TR << "Non-ideal residue detected: "
+					<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
+					<< " Ideal D=" << miniconf_idl.dof( dof_D)
+					<< ", Inspected D=" << miniconf.dof( dof_D )
+					<< std::endl;
+			}
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/// @brief  Fills coords of target_rsd with coords from source_rsd of same atom_name, rebuilds others.
+/// @details  If preserve_only_sidechain_dihedrals is true, then this function only copies mainchain coordinates,
+/// and rebuilds all sidechain coordinates from scratch, setting side-chain dihedrals based on the source residue.
+/// Otherwise, if false, it copies all the atoms that it can from the source residue, then rebuilds the rest.
+/// @author Vikram K. Mulligan (vmullig@uw.edu)
+void
+copy_residue_coordinates_and_rebuild_missing_atoms(
+	Residue const & source_rsd,
+	Residue & target_rsd,
+	Conformation const & conformation,
+	bool const preserve_only_sidechain_dihedrals
+) {
+	target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+	target_rsd.chain ( source_rsd.chain () );
+
+	if ( preserve_only_sidechain_dihedrals ) { //If we're keeping only the sidechain dihedral information
+		Size const natoms(target_rsd.natoms());
+		bool any_missing(false);
+		utility::vector1< bool > missing( natoms, false );
+		Size const to_preserve = source_rsd.type().first_sidechain_atom() >= source_rsd.type().natoms() ? source_rsd.type().first_sidechain_atom() : source_rsd.n_mainchain_atoms();
+
+		for ( Size ia=1; ia<=natoms; ++ia ) { //Loop through all atoms
+			std::string const & atom_name( target_rsd.atom_name(ia) );
+			if ( ia <= to_preserve && source_rsd.has( atom_name ) ) {
+				target_rsd.atom(ia).xyz( source_rsd.atom(atom_name).xyz() );
+			} else {
+				if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
+				any_missing=true;
+				missing[ia]=true;
+			}
+		}
+		if ( any_missing ) {
+			target_rsd.fill_missing_atoms( missing, conformation );
+		}
+
+		//Set side-chain dihedrals
+		for ( core::Size i=1, imax=std::min( target_rsd.nchi(), source_rsd.nchi() ); i<=imax; ++i ) { //Loop through all shared chi angles
+			target_rsd.set_chi(i, source_rsd.chi(i)); //Set side-chain dihedral.
+		}
+
+	} else { //If we're trying to keep the sidechain atom position information
+		copy_residue_coordinates_and_rebuild_missing_atoms( source_rsd, target_rsd, conformation );
+	}
+	return;
+}
+
+
+/// @details  For building variant residues, eg
+/// @note  Need conformation for context in case we have to rebuild atoms, eg backbone H
+void
+copy_residue_coordinates_and_rebuild_missing_atoms(
+	Residue const & source_rsd,
+	Residue & target_rsd,
+	Conformation const & conformation
+)
+{
+	target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+	target_rsd.chain ( source_rsd.chain () );
+
+	Size const natoms( target_rsd.natoms() );
+
+	utility::vector1< bool > missing( natoms, false );
+	bool any_missing( false );
+
+	for ( Size i=1; i<= natoms; ++i ) {
+		std::string const & atom_name( target_rsd.atom_name(i) );
+		if ( source_rsd.has( atom_name ) ) {
+			target_rsd.atom( i ).xyz( source_rsd.atom( atom_name ).xyz() );
+		} else {
+			if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
+			any_missing = true;
+			missing[i] = true;
+		}
+	}
+
+	if ( any_missing ) {
+		target_rsd.fill_missing_atoms( missing, conformation );
+	}
+
+}
+
+/// @brief  Fills coords of target_rsd with coords from source_rsd using the provided mapping, rebuilds others
+/// The mapping is indexed by target_rsd atom index, giving source_rsd index or zero for not present.
+void
+copy_residue_coordinates_and_rebuild_missing_atoms(
+	Residue const & source_rsd,
+	Residue & target_rsd,
+	utility::vector1< core::Size > const & mapping,
+	Conformation const & conformation
+) {
+	Size const natoms( target_rsd.natoms() );
+
+	utility::vector1< bool > missing( natoms, false );
+	bool any_missing( false );
+
+	for ( Size i=1; i<= natoms; ++i ) {
+		if ( mapping.size() >= i && mapping[i] != 0 ) {
+			target_rsd.atom( i ).xyz( source_rsd.atom( mapping[i] ).xyz() );
+		} else {
+			TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' <<
+				target_rsd.atom_name(i) << std::endl;
+			any_missing = true;
+			missing[i] = true;
+		}
+	}
+
+	if ( any_missing ) {
+		target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+		target_rsd.chain ( source_rsd.chain () );
+		target_rsd.fill_missing_atoms( missing, conformation );
+	}
+}
+
+/// @details  Helper function for below
+std::ostream &
+print_atom( id::AtomID const & id, Conformation const & conf, std::ostream & os )
+{
+	Residue const & rsd( conf.residue(id.rsd() ) );
+	os << rsd.atom_name( id.atomno() ) << " (" << id.atomno() << ") " << rsd.name() << ' ' << rsd.seqpos();
+	return os;
+}
+
+/// @brief Given two residues, check that they are compatible types to be connected via a cutpoint.
+/// @author Vikram K. Mulligan (vmullig@uw.edu).
+void
+check_good_cutpoint_neighbour(
+	core::conformation::Residue const &thisres,
+	core::conformation::Residue const &other_res
+) {
+	core::chemical::ResidueType const &thistype( thisres.type() );
+	runtime_assert_string_msg(
+		thistype.is_alpha_aa() || thistype.is_beta_aa() || thistype.is_gamma_aa() ||
+		thistype.is_sri() || thistype.has_property(core::chemical::TRIAZOLE_LINKER) ||
+		thistype.is_peptoid() || thistype.is_carbohydrate() || thistype.is_NA() || thistype.is_oligourea() ||
+		thistype.is_aramid()
+		|| thistype.has_property( chemical::TNA ) ,
+		"Error in core::conformation::check_good_cutpoint_neighbour(): The selected residue is neither an alpha-, beta-, or gamma-amino acid, nor a peptoid, nor a sugar, nor a nucleic acid, nor an oligourea.  Nevertheless, it has a cutpoint variant type.  This should not be possible."
+	);
+
+	if ( thistype.is_carbohydrate() ) {
+		//JASON JASON JASON if ever you need cutpoints between sugar and something else, this is
+		//one spot to make a change.  -VKM
+		runtime_assert_string_msg(
+			other_res.type().is_carbohydrate(),
+			"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a carbohydrate via a cutpoint is not itself a carbohydrate."
+		);
+	} else if ( thistype.is_NA() ) {
+		//AMW TODO: Andy, if ever you need RNA to connect to something other than RNA (or DNA) via a cutpoint, this is
+		//one place to make a change.  -VKM
+		runtime_assert_string_msg(
+			other_res.type().is_polymer(),
+			"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a nucleic acid via a cutpoint is not itself a DNA or RNA residue."
+		);
+	} else {
+		runtime_assert_string_msg(
+			other_res.type().is_alpha_aa() || other_res.type().is_beta_aa() || other_res.type().is_gamma_aa() || other_res.type().is_peptoid() || other_res.type().is_oligourea() || other_res.type().is_aramid() || other_res.type().is_RNA() || other_res.type().has_property( chemical::TNA ),
+			"Error in core::conformation::check_good_cutpoint_neighbour(): The connected residue is neither a peptoid, nor an oligourea, nor an alpha-, beta-, or gamma-amino acid."
+		);
+	}
+}
+
+/// @brief Given a conformation and a position that may or may not be CUTPOINT_UPPER or CUTPOINT_LOWER, determine whether this
+/// position has either of these variant types, and if it does, determine whether it's connected to anything.  If it is,
+/// update the C-OVL1-OVL2 bond lengths and bond angle (for CUTPOINT_LOWER) or OVU1-N bond length (for CUTPOINT_UPPER) to
+/// match any potentially non-ideal geometry in the residue to which it's bonded.
+/// @details Requires a little bit of special-casing for gamma-amino acids.  Throws an exception if the residue to which
+/// a CUTPOINT_LOWER is bonded does not have an "N" and a "CA" or "C4".  Safe to call repeatedly, or if cutpoint variant
+/// types are absent; in these cases, the function does nothing.
+/// @note By default, this function calls itself again once on residues to which this residue is connected, to update their
+/// geometry.  Set recurse=false to disable this.
+/// @author Vikram K. Mulligan (vmullig@uw.edu).
+void
+update_cutpoint_virtual_atoms_if_connected(
+	core::conformation::Conformation & conf,
+	core::Size const cutpoint_res,
+	bool recurse /*= true*/
+) {
+	core::conformation::Residue const &thisres( conf.residue(cutpoint_res) );
+	if ( thisres.is_RNA() ) return;
+	if ( !thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) && !thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) return; //Do nothing if no upper or lower cutpoint type.
+
+	if ( thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) ) {
+		core::Size const other_res_index( thisres.connected_residue_at_upper() ); //The residue to which I'm connected at my upper connection.
+		if ( other_res_index != 0 ) {
+			core::conformation::Residue const & other_res( conf.residue(other_res_index) );
+			check_good_cutpoint_neighbour( thisres, other_res );
+			core::Real const dist1( other_res.lower_connect().icoor().d() ); //Distance from LOWER to N.
+			core::Real const angle2( other_res.lower_connect().icoor().theta() ); //Note that this is Pi-bondangle, in radians.
+			core::Real const dist2( other_res.xyz( other_res.lower_connect().icoor().stub_atom1().atomno() ).distance( other_res.xyz( other_res.lower_connect().icoor().stub_atom2().atomno() ) ) ); //Distance from N to CA (or N to C4 in gamma-aas).
+
+			core::chemical::AtomICoor const & ovl1_icoor ( thisres.icoor(thisres.atom_index("OVL1")) );
+			core::chemical::AtomICoor ovl1_new_icoor("OVL1", ovl1_icoor.phi(), ovl1_icoor.theta(),
+				dist1, thisres.atom_name( ovl1_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom3().atomno() ), thisres.type());
+			conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL1"), cutpoint_res), ovl1_new_icoor.build( thisres, conf ) );
+
+			if ( !thisres.type().is_carbohydrate() && !other_res.type().is_carbohydrate() ) { //JASON JASON JASON -- this is the other special-case thing for carbohydrates.  -VKM
+				core::chemical::AtomICoor const & ovl2_icoor ( thisres.icoor(thisres.atom_index("OVL2")) );
+				core::chemical::AtomICoor ovl2_new_icoor("OVL2", ovl2_icoor.phi(), angle2,
+					dist2, thisres.atom_name( ovl2_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom3().atomno() ), thisres.type());
+				conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL2"), cutpoint_res), ovl2_new_icoor.build( thisres, conf ) );
+			}
+
+			if ( recurse ) {
+				update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+			}
+		}
+	}
+	if ( thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) {
+		core::Size const other_res_index( thisres.connected_residue_at_lower() ); //The residue to which I'm connected at my lower connection.
+		if ( other_res_index != 0 ) {
+			core::conformation::Residue const & other_res( conf.residue(other_res_index) );
+			check_good_cutpoint_neighbour( thisres, other_res );
+			core::Real const dist1( other_res.upper_connect().icoor().d() ); //Distance from UPPER to C.
+
+			core::chemical::AtomICoor const & ovu1_icoor ( thisres.icoor(thisres.atom_index("OVU1")) );
+			core::chemical::AtomICoor ovu1_new_icoor("OVU1", ovu1_icoor.phi(), ovu1_icoor.theta(), dist1,
+				thisres.atom_name( ovu1_icoor.stub_atom1().atomno() ),
+				thisres.atom_name( ovu1_icoor.stub_atom2().atomno() ),
+				ovu1_icoor.stub_atom3().atomno() == 0 ? "LOWER" : thisres.atom_name( ovu1_icoor.stub_atom3().atomno() ), //In some cases, the third stub atom is the lower connection.
+				thisres.type()
+			);
+			conf.set_xyz( core::id::AtomID(thisres.atom_index("OVU1"), cutpoint_res), ovu1_new_icoor.build(thisres, conf ) );
+
+			if ( recurse ) {
+				update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+			}
+		}
+	}
+	conf.update_actcoord( cutpoint_res );
+}
+
+void
+show_atom_tree(
+	kinematics::tree::Atom const & atom,
+	Conformation const & conf, std::ostream & os
+) {
+	os << "ATOM "; print_atom( atom.id(), conf, os ) << std::endl;
+	os << "CHILDREN: ";
+	for ( Size i=0; i< atom.n_children(); ++i ) {
+		print_atom( atom.child(i)->id(), conf, os ) << ' ';
+	}
+	os << std::endl;
+	for ( Size i=0; i< atom.n_children(); ++i ) {
+		show_atom_tree( *atom.child(i), conf, os );
+	}
+}
+
+/// helper function for residue replacement/residuetype switching
+/// @note  Will call new_rsd->fill_missing_atoms if the new residue has atoms
+/// that the old one doesn't
+
+void
+replace_conformation_residue_copying_existing_coordinates(
+	conformation::Conformation & conformation,
+	Size const seqpos,
+	chemical::ResidueType const & new_rsd_type
+)
+{
+
+	Residue const & old_rsd( conformation.residue( seqpos ) );
+	ResidueOP new_rsd( ResidueFactory::create_residue( new_rsd_type ) );
+	conformation::copy_residue_coordinates_and_rebuild_missing_atoms( old_rsd, *new_rsd, conformation );
+	conformation.replace_residue( seqpos, *new_rsd, false );
+
+}
+
+
+/// @details E.g., make a terminus variant, and replace the original in pose.
+/// @note This copies any atoms in common between old and new residues, rebuilding the others.
+void
+add_variant_type_to_conformation_residue(
+	conformation::Conformation & conformation,
+	chemical::VariantType const variant_type,
+	Size const seqpos )
+{
+	Residue const & old_rsd( conformation.residue( seqpos ) );
+
+	// the type of the desired variant residue
+	chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
+	chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_added( old_rsd.type(), variant_type ) );
+
+	core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
+}
+
+
+/// @details E.g., remove a terminus variant, and replace the original in pose.
+/// @note This copies any atoms in common between old and new residues, rebuilding the others.
+void
+remove_variant_type_from_conformation_residue(
+	conformation::Conformation & conformation,
+	chemical::VariantType const variant_type,
+	Size const seqpos )
+{
+	Residue const & old_rsd( conformation.residue( seqpos ) );
+
+	// the type of the desired variant residue
+	chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
+	chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_removed( old_rsd.type(), variant_type ) );
+
+	core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+void
+add_lower_terminus_type_to_conformation_residue(
+	conformation::Conformation & conformation,
+	Size const seqpos
+)
+{
+	core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void
+remove_lower_terminus_type_from_conformation_residue(
+	conformation::Conformation & conformation,
+	Size const seqpos
+)
+{
+	remove_variant_type_from_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
+	remove_variant_type_from_conformation_residue( conformation, chemical::LOWERTERM_TRUNC_VARIANT, seqpos );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void
+add_upper_terminus_type_to_conformation_residue(
+	conformation::Conformation & conformation,
+	Size const seqpos
+)
+{
+	core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void
+remove_upper_terminus_type_from_conformation_residue(
+	conformation::Conformation & conformation,
+	Size const seqpos
+)
+{
+	remove_variant_type_from_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
+	remove_variant_type_from_conformation_residue( conformation, chemical::UPPERTERM_TRUNC_VARIANT, seqpos );
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @details  Build an atom-tree from a fold-tree and a set of residues
+/// atoms in the tree are allocated with new (on the heap) and held in owning pointers in atom_pointer
+/// @note  atom_pointer is cleared at the beginning and then filled with AtomOPs to all the atoms
+
+
+void
+build_tree(
+	kinematics::FoldTree const & fold_tree,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomPointer2D & atom_pointer
+)
+{
+	using conformation::Residue;
+
+	// note -- we clear atom_pointer
+	atom_pointer.clear();
+	atom_pointer.resize( residues.size() );
+
+	// build first atom. make it a "JumpAtom"
+	{
+		int const start_pos( fold_tree.root() );
+		Residue const & rsd( *(residues[start_pos]) );
+
+		build_residue_tree( residues, rsd, fold_tree, atom_pointer[ start_pos ] );
+
+	}
+
+	// traverse tree, build edges
+	for ( auto const & it : fold_tree ) {
+
+		if ( it.is_jump() ) {
+			build_jump_edge( it, residues, atom_pointer );
+
+		} else if ( it.label() == kinematics::Edge::PEPTIDE ) {
+			// build a peptide edge
+			build_polymer_edge( it, residues, atom_pointer );
+
+		} else if ( it.label() == kinematics::Edge::CHEMICAL ) {
+			build_chemical_edge( it, residues, atom_pointer );
+
+		} else {
+			if ( TR.Error.visible() ) {
+				TR.Error << "Failed to identify kinematics::Edge label in core/kinematics/util.cc::build_tree()" << std::endl;
+				TR.Error << "Label = " << it.label() << std::endl;
+			}
+			utility_exit();
+		}
+	}
+
+	// now guarantee that jump stubs are residue-internal if desired
+	for ( auto const & it : fold_tree ) {
+		if ( it.is_jump() && it.keep_stub_in_residue() ) {
+			promote_sameresidue_child_of_jump_atom( it, residues, atom_pointer );
+		}
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @details root_atomno is the root for the sub atom-tree of this edge.
+/// anchor_atomno is the entry point of this sub atom-tree into the main atom-tree.
+
+void
+build_jump_edge(
+	kinematics::Edge const & edge,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomPointer2D & atom_pointer
+)
+{
+	debug_assert( edge.is_jump() );
+
+	int const estart  ( edge.start() );
+	int const estop   ( edge.stop () );
+
+	// these may have been set in the edge
+	Size anchor_atomno, root_atomno;
+	get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
+
+	// get the anchor atom
+	kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
+	debug_assert( anchor_atom );
+
+	// build the new residue
+	build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], true /*Jump*/ );
+
+	// now wire in the new residue connection
+	anchor_atom->insert_atom( atom_pointer[ id::AtomID( root_atomno, estop ) ] );
+
+
+	//  std::cout << "build_jump_edge: " << edge << ' ' <<  estop << ' ' << root_atomno << ' ' <<
+	//   estart << ' ' << anchor_atomno << std::endl;
+
+	//  std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
+	//  anchor_atom->show();
+	// debug_assert( anchor_atom->id() == AtomID( anchor_atomno, estart ) );
+	//  std::cout << "TREE AFTER END: " << edge << std::endl;
+
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @details assumes that the start residue of edge has already been built. Traverse
+///the polymer edge residue by residue and after building sub atom-tree for this residue,
+///attaches the edge's subtree to the anchor_atom in the previous residue.
+///
+void
+build_polymer_edge(
+	kinematics::Edge const & edge,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomPointer2D & atom_pointer
+)
+{
+	int const start( edge.start() );
+	int const stop ( edge.stop() );
+	int const dir  ( edge.polymer_direction() );
+
+	debug_assert( dir == 1 || dir == -1 );
+
+	//id::AtomID first_anchor;
+	for ( int pos=start+dir; pos != stop + dir; pos += dir ) {
+		runtime_assert( pos > 0 );
+		conformation::Residue const & rsd( *residues[pos] );
+		int const anchor_pos( pos-dir );
+		Size anchor_atomno, root_atomno;
+		get_anchor_and_root_atoms( *residues[ anchor_pos ], rsd, edge, anchor_atomno, root_atomno );
+
+		// build the new residue tree, fill in the atom_pointer array
+		build_residue_tree( root_atomno, rsd, atom_pointer[pos], false /*Jump*/ );
+
+		kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, anchor_pos ) ) );
+		kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno,  pos ) ) );
+		debug_assert( anchor_atom && root_atom );
+		anchor_atom->insert_atom( root_atom );
+		//std::cout << "build_polymer_edge: " << edge << ' ' <<  pos << ' ' << root_atomno << ' ' <<
+		//   anchor_pos << ' ' << anchor_atomno << std::endl;
+		//  if ( pos == start+dir ) first_anchor = AtomID( anchor_atomno, anchor_pos );
+	}
+	//  if ( start != stop ) {
+	//   std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
+	//   atom_pointer[ first_anchor ]->show();
+	//   std::cout << "TREE AFTER END: " << edge << std::endl;
+	//  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @details assumes that the start residue of edge has already been built. Traverse
+///the chemical edge residue by residue and after building sub atom-tree for this residue,
+///attaches the edge's subtree to the anchor_atom in the previous residue.
+///
+void
+build_chemical_edge(
+	kinematics::Edge const & edge,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomPointer2D & atom_pointer
+)
+{
+
+	int const estart  ( edge.start() );
+	int const estop   ( edge.stop () );
+
+	// these may have been set in the edge
+	Size anchor_atomno, root_atomno;
+	get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
+
+	build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], false /*Jump*/ );
+
+	// get the anchor atom
+	kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
+	kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno, estop  ) ) );
+	debug_assert( anchor_atom && root_atom );
+
+	anchor_atom->insert_atom( root_atom );
+}
+
+/////////////////////////////////////////////////////////////////////////////
+///\brief get the root atom for building residue atom-tree given the folding direction "dir"
+int
+get_root_atomno(
+	conformation::Residue const & rsd,
+	int const dir // +1, -1, or "dir_jump"
+)
+{
+	// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
+	// in the fold_tree ( ==> residue should be a polymer type? )
+	int const forward( 1 );
+	int const backward( -1 );
+
+	if ( dir == forward ) {
+		// N for proteins, P for DNA
+		if ( rsd.is_polymer() ) {
+			if ( rsd.is_lower_terminus() && rsd.mainchain_atoms().size() > 0 ) {
+				// this is a little strange to be folding through a terminal residue but kinematics doesn't
+				// have to correlate perfectly with chemical
+				return rsd.mainchain_atom(1);
+			} else {
+				return rsd.lower_connect_atom(); //mainchain_atoms()[1];
+			}
+		} else {
+			return get_root_atomno( rsd, kinematics::dir_jump );
+		}
+	} else if ( dir == backward ) {
+		if ( rsd.is_polymer() ) {
+			if ( rsd.is_upper_terminus() && rsd.mainchain_atoms().size() > 0 ) {
+				// this is a little strange to be folding through a terminal residue but kinematics doesn't
+				// have to correlate perfectly with chemical
+				return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
+			} else {
+				// C for proteins, O3' for DNA
+				return rsd.upper_connect_atom(); //mainchain_atoms()[ rsd.mainchain_atoms().size() ];
+			}
+		} else {
+			return get_root_atomno( rsd, kinematics::dir_jump );
+		}
+	} else {
+		debug_assert( dir == kinematics::dir_jump );
+		// default for jumps, use the N-terminal attachment?
+		if ( rsd.mainchain_atoms().empty() ) {
+			// For non-polymeric ligands, match the ICOOR root.
+			// (This should minimize issues with matching trees.)
+			return rsd.type().root_atom();
+		} else if ( rsd.type().has_variant_type( chemical::N_ACETYLATION ) ) {
+			return 1; // awful hack! want N-CA-C triad to stay put when one of these residues is at root.
+		} else {
+			// PB 10/29/07 - changing to use an interior mainchain atom
+			//
+			// old choice of mainchain_atoms()[1] meant that changing omega of jump_pos-1 would propagate
+			// C-terminal to jump_pos, which is bad for loop modeling where the usual assumption was that
+			// we can use loop_begin-1 and loop_end+1 as jump points
+			//
+			Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
+			Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
+			return rsd.mainchain_atoms()[ mainchain_index ];
+		}
+	}
+}
+
+/// @details  Determine which atom to use as the root of the root residue in the atomtree.
+/// It is sometimes useful to be able to control the atom chosen as the root of the atomtree, eg in graphics.
+/// The logic below uses atom_info stored in the foldtree for jump edges emanating from the root residue
+/// to override the default atom (if the root residue is a jump_point and said atom_info exists)
+
+
+Size
+get_root_residue_root_atomno(
+	conformation::Residue const & rsd,
+	kinematics::FoldTree const & fold_tree
+)
+{
+	if ( !rsd.type().is_polymer() ) return 1;
+
+
+	Size const seqpos( rsd.seqpos() );
+	debug_assert( seqpos == Size( fold_tree.root() ) ); // need to refactor foldtree to use Size instead of int
+
+	Size root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
+
+	if ( fold_tree.is_jump_point( seqpos ) ) {
+		for ( Size i=1; i<= fold_tree.num_jump(); ++i ) {
+			kinematics::Edge const & edge( fold_tree.jump_edge( i ) );
+			if ( seqpos == Size(edge.start()) && edge.has_atom_info() ) {
+				root_atomno = rsd.atom_index( edge.upstream_atom() );
+				break;
+			}
+		}
+	}
+	return root_atomno;
+}
+
+/// @details  A wrapper function to build an atom-tree for a residue. Uses information from the foldtree to
+/// find the proper root atom if it is not defined, and determine the direction in which to build the residue.
+/// The goal of this function is to allow the Conformation to rebuild parts of the AtomTree in a way that is
+/// compatible with what would be built if we erased the entire atomtree and rebuilt it using the foldtree.
+/// Also used to build the atomtree for the root residue when we are building the atomtree from scratch.
+
+void
+build_residue_tree(
+	conformation::ResidueCOPs const & residues,
+	conformation::Residue const & rsd,
+	kinematics::FoldTree const & fold_tree,
+	kinematics::AtomPointer1D & atom_ptr
+)
+{
+	// determine root_atomno and whether root_atom is a jump_atom
+
+	bool root_atom_is_jump_atom( false );
+	Size root_atomno(0);
+
+	Size const seqpos( rsd.seqpos() );
+
+	if ( seqpos == fold_tree.root() ) {
+		root_atom_is_jump_atom = true;
+
+		root_atomno = get_root_residue_root_atomno( rsd, fold_tree );
+
+	} else {
+		// seqpos is not the root of the fold_tree
+		kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) ); // the edge that builds seqpos
+
+		if ( edge.is_peptide() ) {
+			// peptide edge
+			root_atomno = get_root_atomno( rsd, edge.polymer_direction() ); // the default setting
+		} else if ( edge.is_jump() ) {
+			// jump edge
+			root_atom_is_jump_atom = true;
+			if ( edge.has_atom_info() ) {
+				root_atomno = rsd.atom_index( edge.downstream_atom() );
+			} else {
+				root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
+			}
+		} else {
+			//// chemical edge -- atomnumbers of connections should be programmed in
+			//debug_assert( edge.has_atom_info() );
+			//root_atomno = rsd.atom_index( edge.downstream_atom() );
+			// Connection atoms are not always present in the edge, but might be;  else use defaults.
+			int const estart  ( edge.start() );
+			int const estop   ( edge.stop () );
+			Size anchor_atno, root_atno;
+			get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atno, root_atno );
+			root_atomno = (int) root_atno; // stupid Size/int confusion...
+		}
+	}
+	debug_assert( root_atomno );
+
+	// now call the main build_residue_tree function
+	build_residue_tree( root_atomno, rsd, atom_ptr, root_atom_is_jump_atom );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Check if this atom neighbor has been black-listed ("CUT_BOND" in params file).
+bool
+check_good_neighbor( Size const & atom_index, utility::vector1< Size > const & cut_nbrs ) {
+	for ( Size kk=1; kk<=cut_nbrs.size(); ++kk )  {
+		if ( cut_nbrs[kk] == atom_index ) return false;
+	}
+	return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief is atom2 the last atom of our chi angle ?
+inline
+bool
+chi_continuation(
+	Size const atom1, // current atom
+	Size const atom2, // potential nbr
+	utility::vector1< utility::vector1< Size > > const & chi_atoms
+)
+{
+	int const nchi( chi_atoms.size() );
+
+	for ( int i=1; i<= nchi; ++i ) {
+		utility::vector1< Size > const & atoms( chi_atoms[i] );
+		if ( atom1 == atoms[2] &&
+				atom2 == atoms[1] ) return true;
+
+		if ( atom1 == atoms[3] &&
+				atom2 == atoms[4] ) return true;
+	}
+	return false;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief would we be breaking into a chi angle by adding atom2 to the tree now?
+inline
+bool
+chi_interruption(
+	Size const atom1, // current atom
+	Size const atom2, // potential nbr
+	utility::vector1< utility::vector1< Size > > const & chi_atoms,
+	utility::vector1< bool > const & is_done
+)
+{
+	int const nchi( chi_atoms.size() );
+
+	//not an interruption if atom1 and atom2 delineate a chi angle.
+	for ( int i=1; i<= nchi; ++i ) {
+		utility::vector1< Size > const & atoms( chi_atoms[i] );
+
+		if ( atom2 == atoms[2] &&
+				( atom1 == atoms[1] || atom1 == atoms[3] ) ) return false;
+
+		if ( atom2 == atoms[3] &&
+				( atom1 == atoms[2] || atom1 == atoms[4] ) ) return false;
+	}
+
+
+	for ( int i=1; i<= nchi; ++i ) {
+		utility::vector1< Size > const & atoms( chi_atoms[i] );
+
+		if ( atom2 == atoms[2] &&
+				atom1 != atoms[1] &&
+				atom1 != atoms[3] ) return true;
+
+		if ( atom2 == atoms[3] &&
+				atom1 != atoms[2] &&
+				atom1 != atoms[4] ) return true;
+
+		if ( (atom2 == atoms[1] && is_done[ atoms[4] ]) ||
+				(atom2 == atoms[4] && is_done[ atoms[1] ]) ) return true;
+
+	}
+	return false;
+
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief simply fill the "links" by adding, for each atom, its bonded neighbors
+void
+setup_links_simple(
+	conformation::Residue const & rsd,
+	kinematics::Links & links
+)
+{
+	int const natoms( rsd.natoms() );
+
+	links.clear();
+	links.resize( natoms );
+
+	for ( int atomno1=1; atomno1<= natoms; ++atomno1 ) {
+		utility::vector1< Size > const & nbrs( rsd.nbrs( atomno1 ) );
+		utility::vector1< Size > const & cut_nbrs( rsd.cut_bond_neighbor( atomno1 ) );
+		for ( Size jj=1; jj<= nbrs.size(); ++jj ) {
+			if ( !check_good_neighbor( nbrs[jj], cut_nbrs ) ) continue;
+			links[ atomno1 ].push_back( nbrs[jj] );
+		}
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// called recursively
+
+// Rule I -- dont enter a chi angle in the middle (atoms 2 or 3 ),
+//     and don't enter a chi angle from one side if the other side's atoms have already been added to the tree
+//
+//
+// Rule II -- if you're atom 2 and atom 1 hasn't been done, put that first
+//   likewise for atoms 3 and 4
+//
+// Rule III -- mainchain atoms 1st, tiebreaking by rule II
+//
+// Rule IV -- heavyatoms before hydrogens, subject to other three rules
+//
+/// @brief set correct order for how atoms are linked to each other.
+///
+/// this function is called recursively.
+/// @li atom1 is the root of links at the current level.
+/// @li full_links store information about UNORDERED bonded neighbors for each atom in this residue.
+/// @li is_done indicates which atoms have already been linked.
+/// @li is_mainchain, is_chi, is_hydrogen and chi atoms are self explanatory
+/// @li new_links store information about ORDERED bonded neighbors (links) for each atom in this residue.
+void
+setup_atom_links(
+	int const atom1,
+	kinematics::Links const & full_links,
+	utility::vector1< bool > & is_done,
+	utility::vector1< bool > const & is_mainchain,
+	utility::vector1< bool > const & is_chi,
+	utility::vector1< bool > const & is_hydrogen,
+	utility::vector1< utility::vector1< Size > > const & chi_atoms,
+	kinematics::Links & new_links
+)
+{
+	is_done[atom1] = true;
+
+	utility::vector1< Size > const & full_l( full_links[atom1] );
+	utility::vector1< Size >    &  new_l(  new_links[atom1] );
+
+	debug_assert( new_l.empty() );
+
+	Size const n_nbrs( full_l.size() );
+
+	if ( n_nbrs == 1 ) {
+		Size const nbr( full_l[1] );
+		if ( !is_done[nbr] ) {
+			// special case -- we have no choice but to add this guy otherwise setup will fail
+			new_l.push_back( nbr );
+			setup_atom_links( nbr, full_links, is_done, is_mainchain, is_chi, is_hydrogen, chi_atoms, new_links );
+		}
+		return;
+	}
+
+	// top priority -- within a chi angle, and mainchain
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+
+		if ( is_mainchain[ atom2 ] && is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+	// next priority -- mainchain
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+
+		if ( is_mainchain[ atom2 ] ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+	// next priority -- within a chi angle and heavy.
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+
+		if ( is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) && !is_hydrogen[ atom2 ] ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+	// next priority -- any heavy atom chi?
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+
+		if ( is_chi[ atom2 ] && !is_hydrogen[ atom2 ] ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+
+	// next priority -- any chi -- could be hydrogen
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+
+		if ( is_chi[ atom2 ] ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+	// next priority -- heavyatoms
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+		if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
+		if ( !is_hydrogen[ atom2 ] ) {
+			new_l.push_back( atom2 );
+			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+				is_hydrogen, chi_atoms, new_links );
+		}
+	}
+
+
+	// lowest priority -- hydrogens
+	for ( Size i=1; i<= n_nbrs; ++i ) {
+		int const atom2( full_l[i] );
+		if ( is_done[ atom2 ] ) continue;
+		if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
+		new_l.push_back( atom2 );
+		setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+			is_hydrogen, chi_atoms, new_links );
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief given the root_atomno, set up rules for how other atoms are linked for this residue
+///a wrapper function calling setup_atom_links recursively .
+void
+setup_links(
+	conformation::Residue const & rsd,
+	int const root_atomno,
+	kinematics::Links & links
+)
+{
+	using BVec = utility::vector1<bool>;
+
+	//////////////////////////////////
+	// get the full list of atom nbrs:
+	kinematics::Links full_links;
+
+	setup_links_simple( rsd, full_links );
+
+	// natoms
+	Size const natoms( rsd.natoms() );
+
+	////////////////
+	// chi atoms
+	BVec is_chi( natoms, false ); // vector bool
+	utility::vector1< utility::vector1< Size > > const & chi_atoms
+		( rsd.chi_atoms() );
+	for ( Size i=1; i<= chi_atoms.size(); ++i ) {
+		for ( int j=1; j<= 4; ++j ) {
+			is_chi[ chi_atoms[i][j] ] = true;
+		}
+	}
+
+
+	//////////////////
+	// mainchain atoms
+	BVec is_mainchain( natoms, false ); // vector bool
+	utility::vector1< Size > const & mainchain( rsd.mainchain_atoms() );
+	for ( Size i=1; i<= mainchain.size(); ++i ) {
+		is_mainchain[ mainchain[i] ] = true;
+	}
+	if ( rsd.has_variant_type( chemical::CUTPOINT_LOWER ) ) {
+		is_mainchain[ rsd.atom_index( "OVL1" ) ] = true;
+		if ( rsd.has( "OVL2" ) ) {
+			is_mainchain[ rsd.atom_index( "OVL2" ) ] = true;
+		}
+	}
+	if ( rsd.has_variant_type( chemical::CUTPOINT_UPPER ) ) {
+		is_mainchain[ rsd.atom_index( "OVU1" ) ] = true;
+	}
+
+	////////////
+	// hydrogens
+	BVec is_hydrogen( natoms, false );
+	for ( Size i=1; i<= natoms; ++i ) {
+		is_hydrogen[i] = rsd.atom_type(i).is_hydrogen();
+	}
+
+
+	links.clear();
+	links.resize( natoms );
+
+	BVec is_done( natoms, false ); // keep track of what's done
+	setup_atom_links( root_atomno, full_links, is_done, is_mainchain,  is_chi,
+		is_hydrogen, chi_atoms, links );
+
+
+	// check for an atom that wasn't added
+	for ( Size i=1; i<= natoms; ++i ) {
+		if ( !is_done[ i ] ) {
+			if ( TR.Error.visible() ) {
+				TR.Error << "Unable to setup links for residue " << std::endl;
+				for ( Size j=1; j<= natoms; ++j ) {
+					TR.Error << rsd.atom_name(j) << ' ' << is_done[j] << ' ' << is_mainchain[j] << ' ' << is_chi[j] << ' ' <<
+						is_hydrogen[j] << std::endl;
 				}
-
-				return id::NamedAtomID( atom_name, rsd_id );
 			}
+			utility_exit();
+		}
+	}
+}
 
-		id::AtomID
-			named_atom_id_to_atom_id(
-					id::NamedAtomID const & named_atom_id,
-					conformation::Residue const & rsd
-					){
-				return id::AtomID( rsd.atom_index( named_atom_id.atom() ), named_atom_id.rsd() );
+
+///////////////////////////////////////////////////////////////////////////////
+///\brief set up a local atom-tree for a residue from the defined root atom.
+void
+build_residue_tree(
+	int const root_atomno,
+	conformation::Residue const & rsd,
+	kinematics::AtomPointer1D & atom_ptr,
+	bool const root_is_jump_atom
+)
+{
+	Size const natoms( rsd.natoms() );
+
+	atom_ptr.clear();
+	atom_ptr.resize( natoms ); // default C-TOR for AtomOP is 0 initialized
+
+	// setup the atom nbrs so that the tree will match the desired torsion
+	// angles
+	kinematics::Links links;
+	setup_links( rsd, root_atomno, links );
+
+	// now build the residue atom-tree using the recursive function add_atom
+	kinematics::add_atom( root_atomno, rsd.seqpos(), links, atom_ptr, root_is_jump_atom );
+
+	// fill in the coordinates from the residue into the atomtree
+	for ( Size i=1; i<= natoms; ++i ) {
+		atom_ptr[i]->xyz( rsd.atom(i).xyz() );
+	}
+}
+
+/// @details  Get the incoming connection and all outgoing connections from a residue
+
+void
+get_residue_connections(
+	conformation::Residue const & new_rsd,
+	kinematics::FoldTree const & fold_tree,
+	conformation::ResidueCOPs const & residues,
+	id::BondID & new_rsd_in,
+	utility::vector1< id::BondID > & new_rsd_out
+)
+{
+
+	Size const seqpos( new_rsd.seqpos() );
+
+	// setup incoming connection
+	if ( fold_tree.is_root( seqpos ) ) {
+		new_rsd_in.atom1 = id::AtomID::BOGUS_ATOM_ID();
+		new_rsd_in.atom2 = id::AtomID( get_root_residue_root_atomno( new_rsd, fold_tree ), seqpos );
+	} else {
+		Size anchor_atomno, root_atomno, anchor_pos;
+		kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
+		if ( edge.is_polymer() ) anchor_pos = seqpos - edge.polymer_direction();
+		else anchor_pos = edge.start();
+		get_anchor_and_root_atoms( *residues[ anchor_pos ], new_rsd, edge, anchor_atomno, root_atomno );
+		new_rsd_in.atom1 = id::AtomID( anchor_atomno, anchor_pos );
+		new_rsd_in.atom2 = id::AtomID( root_atomno, seqpos );
+	}
+
+
+	// setup the outgoing connections
+	new_rsd_out.clear();
+	utility::vector1< kinematics::Edge > const outgoing_edges( fold_tree.get_outgoing_edges( seqpos ) );
+	for ( auto const & outgoing_edge : outgoing_edges ) {
+		Size anchor_atomno, root_atomno;
+		Size const root_pos( ( outgoing_edge.is_polymer() ) ? seqpos + outgoing_edge.polymer_direction() : outgoing_edge.stop() );
+		get_anchor_and_root_atoms( new_rsd, *residues[ root_pos ], outgoing_edge, anchor_atomno, root_atomno );
+		new_rsd_out.push_back( id::BondID( id::AtomID( anchor_atomno, seqpos ), id::AtomID( root_atomno, root_pos ) ) );
+	}
+}
+
+
+/// @details  Helper function for conformation routines.
+/// Uses fold_tree to deduce the incoming/outgoing connections for the new residue and the old residue
+/// We want it to be the case that the tree we get after this call is the same one that we would have gotten
+/// by calling build_tree
+void
+replace_residue_in_atom_tree(
+	conformation::Residue const & new_rsd,
+	//conformation::Residue const & old_rsd,
+	kinematics::FoldTree const & fold_tree,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomTree & atom_tree
+)
+{
+	id::BondID new_rsd_in;
+	utility::vector1< id::BondID > new_rsd_out;
+
+	get_residue_connections( new_rsd, fold_tree, residues, new_rsd_in, new_rsd_out );
+
+	// build the new atoms
+	kinematics::AtomPointer1D new_atoms;
+	build_residue_tree( residues, new_rsd, fold_tree, new_atoms );
+
+	// now replace the atoms
+	atom_tree.replace_residue_subtree( new_rsd_in, new_rsd_out, new_atoms );
+
+	// preserve same-residue jump status if necessary
+	if ( fold_tree.is_jump_point( new_rsd.seqpos() ) && !fold_tree.is_root( new_rsd.seqpos() ) ) {
+		kinematics::Edge const & edge( fold_tree.get_residue_edge( new_rsd.seqpos() ) );
+		if ( edge.is_jump() && edge.keep_stub_in_residue() ) {
+			promote_sameresidue_child_of_jump_atom( edge, residues, atom_tree );
+		}
+	}
+}
+
+/// @brief  Inserts/ appends new residue subtree into an existing atomtree
+/// @note  The foldtree must already have been changed to reflect the new residue
+/// @note  The residues array should already have been inserted into
+/// @note  The sequence position of the new residue is deduced from new_rsd.seqpos()
+/// @note  This function handles renumbering of the atomtree if necessary
+void
+insert_residue_into_atom_tree(
+	conformation::Residue const & new_rsd,
+	kinematics::FoldTree const & fold_tree,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomTree & atom_tree
+)
+{
+
+	Size const seqpos( new_rsd.seqpos() );
+	Size const nres( fold_tree.nres() );
+	Size const old_nres( atom_tree.size() );
+	debug_assert( nres == residues.size() && seqpos <= nres && old_nres == nres-1 );
+
+	/////////////////////////////////
+	// setup for renumbering atomtree
+	utility::vector1< int > old2new( old_nres, 0 );
+	for ( Size i=1; i<= old_nres; ++i ) {
+		if ( i< seqpos ) old2new[i] = i;
+		else old2new[i] = i+1;
+	}
+
+	// renumber the atomtree, fold_tree
+	atom_tree.update_sequence_numbering( nres, old2new );
+	debug_assert( atom_tree.size() == nres );
+
+	replace_residue_in_atom_tree( new_rsd, fold_tree, residues, atom_tree );
+
+}
+
+
+/// @details  Get the atom-index of the atom to which the residue at position seqpos should be anchored in
+/// constructing the atomtree.
+
+int
+get_anchor_atomno( conformation::Residue const & anchor_rsd, Size const seqpos, kinematics::FoldTree const & fold_tree )
+{
+	int anchor_atomno(0);
+	debug_assert( seqpos != (Size)fold_tree.root() );
+
+	kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
+
+	if ( edge.is_jump() ) {
+		// jump edge
+		debug_assert( (seqpos == (Size)edge.stop()) && ((Size)anchor_rsd.seqpos() == (Size)edge.start()) );
+		if ( edge.has_atom_info() ) {
+			anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+		} else {
+			anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
+		}
+	} else if ( edge.is_peptide() ) {
+		// peptide edge
+		int const dir( edge.polymer_direction() );
+		debug_assert( anchor_rsd.seqpos() == seqpos-dir );
+		anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
+	} else {
+		// chemical edge
+		debug_assert( seqpos == static_cast< Size >( edge.stop() ) && anchor_rsd.seqpos() == static_cast< Size >( edge.start() ) && edge.has_atom_info() );
+		anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+	}
+	debug_assert( anchor_atomno );
+	return anchor_atomno;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int
+get_anchor_atomno(
+	conformation::Residue const & rsd,
+	int const dir // forward(1), backward(-1), or "dir_jump"
+)
+{
+	// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
+	// in the fold_tree ( ==> residue should be a polymer type? )
+	int const forward( 1 ), backward( -1 );
+
+	if ( dir == forward ) {
+		// C for proteins, O3' for DNA
+		if ( rsd.is_polymer() ) {
+			if ( rsd.is_upper_terminus() ) {
+				// this is a little strange to be folding through a terminal residue but kinematics doesn't
+				// have to correlate perfectly with chemical
+				return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
+			} else {
+				return rsd.upper_connect_atom();
 			}
+		} else {
+			return get_anchor_atomno( rsd, kinematics::dir_jump );
+		}
+	} else if ( dir == backward ) {
+		// N for proteins, P for DNA
+		if ( rsd.is_polymer() ) {
+			if ( rsd.is_lower_terminus() ) {
+				// this is a little strange to be folding through a terminal residue but kinematics doesn't
+				// have to correlate perfectly with chemical
+				return rsd.mainchain_atom(1);
+			} else {
+				return rsd.lower_connect_atom();
+			}
+		} else {
+			return get_anchor_atomno( rsd, kinematics::dir_jump );
+		}
 
-		id::NamedStubID
-			stub_id_to_named_stub_id(
-					id::StubID const & stub_id,
-					conformation::Residue const & rsd
-					){
-				using namespace core::id;
-				if ( stub_id.center().valid() ) {
-					return NamedStubID(
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.center() , rsd ) ),
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
-							);
-				} else {
-					return NamedStubID( // TODO does this make sense? if input stub is bad, what should be done?
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
-							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
-							);
+	} else {
+		debug_assert( dir == kinematics::dir_jump );
+		// default for jumps, use the N-terminal attachment?
+		if ( rsd.mainchain_atoms().empty() ) {
+			// SHORT TERM HACK -- need to add some logic for root atomno
+			return 1;
+		} else {
+			// PB 10/29/07 - changing to use an interior mainchain atom
+			Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
+			Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
+			return rsd.mainchain_atoms()[ mainchain_index ];
+			//return rsd.mainchain_atoms()[1];
+		}
+	}
+}
+
+/// @details  Determines the anchor and root atom indices based on residue types and the foldtree edge.
+
+void
+get_anchor_and_root_atoms(
+	conformation::Residue const & anchor_rsd,
+	conformation::Residue const & root_rsd,
+	kinematics::Edge const & edge,
+	Size & anchor_atomno,
+	Size & root_atomno
+)
+{
+	// AMW: There are some ugly special cases for pdb_GAI here. That's
+	// because the edges weren't getting good atom indices on them, I think?
+	// In any case, this function isn't called in tight loops, so we are ok.
+
+	ASSERT_ONLY(Size const anchor_pos( anchor_rsd.seqpos() ););
+	ASSERT_ONLY(Size const root_pos( root_rsd.seqpos() ););
+
+	if ( edge.is_polymer() ) {
+		// POLYMER EDGE
+		int const dir( edge.polymer_direction() );
+		debug_assert( dir == 1 || dir == -1 );
+		debug_assert( root_pos == anchor_pos + dir );
+		anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
+		root_atomno   = get_root_atomno  (   root_rsd, dir );
+	} else {
+		debug_assert( anchor_pos == Size(edge.start()) && root_pos == Size(edge.stop()) );
+		if ( edge.has_atom_info() ) {
+			// JUMP OR CHEMICAL W/ ATOM INFO
+			if ( anchor_rsd.type().name() == "pdb_GAI" ||
+					anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
+			else anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+			if ( root_rsd.type().name() == "pdb_GAI" ||
+					anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
+			else root_atomno   =   root_rsd.atom_index( edge.downstream_atom() );
+		} else {
+			if ( edge.is_jump() ) {
+				// JUMP EDGE
+				if ( anchor_rsd.type().name() == "pdb_GAI" ||
+						anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
+				else anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
+				if ( root_rsd.type().name() == "pdb_GAI" ||
+						anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
+				else root_atomno   =   get_root_atomno(   root_rsd, kinematics::dir_jump );
+			} else if ( edge.is_chemical_bond() ) {
+				// CHEMICAL EDGE
+				get_chemical_root_and_anchor_atomnos( anchor_rsd, root_rsd, anchor_atomno, root_atomno );
+			} else {
+				utility_exit_with_message( "Unrecognized edge type!" );
+			}
+		}
+	}
+	return;
+}
+
+
+// this code assumed we were also being passed old_rsd:
+// optionally debug some things before making atom_tree call
+/**if ( debug ) {
+BondID old_rsd_in;
+vector1< BondID > old_rsd_out;
+get_residue_connections( old_rsd, fold_tree, residues, old_rsd_in, old_rsd_out );
+debug_assert( new_rsd_in.atom1 == old_rsd_in.atom1 && new_rsd_out.size() == old_rsd_out.size() );
+for ( Size i=1; i<= new_rsd_out.size(); ++i ) {
+debug_assert( new_rsd_out[i].atom2 == old_rsd_out[i].atom2 );
+}
+}**/
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+void
+promote_sameresidue_child_of_jump_atom(
+	kinematics::Edge const & edge,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomTree & atom_tree
+)
+{
+	debug_assert( edge.is_jump() );
+	Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
+	get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
+	atom_tree.promote_sameresidue_nonjump_child( id::AtomID( root_atomno, root_pos ) );
+}
+
+
+void
+promote_sameresidue_child_of_jump_atom(
+	kinematics::Edge const & edge,
+	conformation::ResidueCOPs const & residues,
+	kinematics::AtomPointer2D const & atom_pointer
+)
+{
+	debug_assert( edge.is_jump() );
+	Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
+	get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
+	kinematics::tree::AtomOP root_atom( atom_pointer[ id::AtomID( root_atomno, root_pos ) ] );
+	debug_assert( root_atom->is_jump() );
+	kinematics::tree::AtomOP same_residue_child( nullptr );
+	for ( Size i=0; i< root_atom->n_nonjump_children(); ++i ) {
+		kinematics::tree::AtomOP child( atom_pointer[ root_atom->get_nonjump_atom( i )->id() ] ); // want nonconst, use atom_pointer
+		if ( Size(child->id().rsd()) == root_pos ) {
+			same_residue_child = child;
+			break;
+		}
+	}
+	if ( same_residue_child ) {
+		debug_assert( !same_residue_child->is_jump() );
+		root_atom->delete_atom( same_residue_child );
+		root_atom->insert_atom( same_residue_child );
+	} else {
+		if ( TR.Warning.visible() ) TR.Warning << "Unable to keep stub in residue: jump_atom has no non-jump, same-residue children!" << std::endl;
+	}
+}
+
+void
+get_chemical_root_and_anchor_atomnos(
+	conformation::Residue const & rsd_anchor,
+	conformation::Residue const & rsd_root,
+	Size & anchor_atom_no,
+	Size & root_atom_no
+)
+{
+	debug_assert( rsd_anchor.is_bonded( rsd_root ) );
+
+	Size first_connection_id = rsd_anchor.connections_to_residue( rsd_root )[ 1 ];
+	chemical::ResConnID first_connection = rsd_anchor.connect_map( first_connection_id );
+	anchor_atom_no = rsd_anchor.residue_connection( first_connection_id ).atomno();
+	root_atom_no = rsd_root.residue_connection( first_connection.connid() ).atomno();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// right now, this is used by the pose to setup a mapping which is
+// passed in to the atomtree when replacing one residue with another
+//
+//
+// maybe the behavior should really be to identify atoms with the same
+// name in the two residues and map them...
+//
+// oh well, this will work for rewiring backbone connections properly;
+// basically the atomtree will use this mapping when it is replacing
+// the atoms of rsd1 with the subtree formed by the atoms of rsd2
+// for this to work, all outgoing connections from the rsd1 atoms have
+// to have their rsd1-atom represented in this map, so the atomtree
+// knows where to attach the child when rsd2 is put in.
+
+
+/// @details only map by atom number, not by identity currently.
+void
+setup_corresponding_atoms(
+	id::AtomID_Map< id::AtomID > & atom_map,
+	conformation::Residue const & rsd1,
+	conformation::Residue const & rsd2
+)
+{
+
+	// PB -- this whole function is going to go away soon, so I'm not really worried about all the hacks
+
+	int const seqpos1( rsd1.seqpos() );
+	int const seqpos2( rsd2.seqpos() );
+
+	utility::vector1< Size > const &
+		mainchain1( rsd1.mainchain_atoms() ),
+		mainchain2( rsd2.mainchain_atoms() );
+
+	debug_assert( mainchain1.size() == mainchain2.size() );
+
+	// special case for virtual residues -- fpd
+	if ( mainchain1.size() == 0 &&
+			rsd1.type().name3() == "XXX" && rsd2.type().name3() == "XXX" ) {
+		debug_assert( rsd1.atoms().size() == rsd2.atoms().size() );
+
+		for ( Size i=1, i_end = rsd1.atoms().size(); i<= i_end; ++i ) {
+			atom_map.set( id::AtomID( i, seqpos1 ), id::AtomID( i, seqpos2 ) );
+		}
+	} else {
+		for ( Size i=1, i_end = mainchain1.size(); i<= i_end; ++i ) {
+			atom_map.set( id::AtomID( mainchain1[i], seqpos1 ),
+				id::AtomID( mainchain2[i], seqpos2 ) );
+		}
+		if ( rsd1.is_DNA() && rsd2.is_DNA() ) {
+			// special case for dna-dna jumps anchored at sidechain atoms
+			for ( Size i=1; i<= 4; ++i ) {
+				atom_map.set( id::AtomID( rsd1.chi_atoms(1)[i], seqpos1 ),
+					id::AtomID( rsd2.chi_atoms(1)[i], seqpos2 ) );
+			}
+		}
+
+		if ( rsd1.is_RNA() && rsd2.is_RNA() ) {
+			// By the way, this is a total hack AND SHOULD NOT BE CHECKED IN
+			// BEFORE CONSULTING WITH PHIL! -- rhiju
+			// special case for rna-rna jumps anchored at sidechain atoms
+			if ( rsd1.name1() == rsd2.name1() ) {
+				for ( Size i=1; i<= rsd1.natoms(); ++i ) {
+					atom_map.set( id::AtomID( i, seqpos1 ),
+						id::AtomID( i, seqpos2 ) );
 				}
 			}
+		}
 
-		id::StubID
-			named_stub_id_to_stub_id(
-					id::NamedStubID const & named_stub_id,
-					conformation::Residue const & rsd
-					){
-				using namespace core::id;
-				if ( named_stub_id.center().valid() ) {
-					return StubID(
-							AtomID( named_atom_id_to_atom_id( named_stub_id.center() , rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
-							);
-				} else {
-					return StubID( // TODO does this make sense? if input stub is bad, what should be done?
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
-							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
-							);
-				}
+	}
+
+	/// Now include atoms involved in residue connections, since these might be anchor points for the atomtree
+	for ( Size connid=1; connid<= rsd1.n_possible_residue_connections() && connid <= rsd2.n_possible_residue_connections(); ++connid ) {
+		Size const atom1( rsd1.type().residue_connection( connid ).atomno() );
+		Size const atom2( rsd2.type().residue_connection( connid ).atomno() );
+		if ( rsd1.atom_name( atom1 ) == rsd2.atom_name( atom2 ) ) {
+			atom_map.set( id::AtomID( atom1, seqpos1 ), id::AtomID( atom2, seqpos2 ) );
+		}
+	}
+}
+
+/// @brief Switch the disulfide state of a disulfide-forming residue (e.g. CYS->CYD or CYD->CYS or
+/// DCYD->DCYS or DCYS->DCYD or whatnot).
+/// @param[in] index Position of the residue to replace.
+/// @param[in] cys_type_name3 The 3-letter name of the cys type to use: e.g. CYS
+///  or CYD.  DEPRECATED and kept only for backward-compatibility.
+/// @param[inout] conf The conformation to modify
+/// @details Substitutes a residue with the given cys type, keeping as many of
+///  the existing atom positions as possible.  If the original residue has a
+///  disulfide variant it will be removed, otherwise a disulfide variant will
+///  be added.  Should work with any ResidueTypeSet that has the proper
+///  disulfide variants.  If the replacement fails for any reason a warning
+///  will be printed.
+/// @return true if the replacement was successful, false otherwise.
+bool change_cys_state(
+	Size const index,
+	std::string const & cys_type_name3, //Deprecated.
+	Conformation & conf
+) {
+
+	bool removing(false);
+
+	// Cache information on old residue.
+	core::chemical::ResidueType const & old_type( conf.residue_type( index ) );
+	chemical::ResidueTypeSetCOP residue_type_set = conf.residue_type_set_for_conf( old_type.mode() );
+
+	// make sure we're working on a disulfide-forming type.
+	if ( ( ! old_type.is_sidechain_thiol() ) && ( ! old_type.is_disulfide_bonded() ) ) {
+		if ( TR.Warning.visible() ) TR.Warning << "change_cys_state() was called on non-cys-like residue " << index << ", skipping!" << std::endl;
+		return false;
+	}
+
+	// Track the variant types of the old residue type.  We want the
+	// new residue to have the same variant type as the old.
+	utility::vector1< std::string > variant_types = old_type.properties().get_list_of_variants();
+
+	// check and handle disulfide state
+	if ( old_type.has_variant_type( chemical::DISULFIDE ) ) {
+		// if the old residue has DISULFIDE variant type then we are removing a
+		// disulfide, so remove the variant type from the list
+		variant_types.erase( std::find( variant_types.begin(), variant_types.end(), "DISULFIDE" ) );
+		removing = true;
+		//TR << "We just erased the DISULFIDE variant type as desired, since we are going from rn " << rn << " to thiol type " << std::endl;
+
+	} else /*If it does not have the DISULFIDE variant type*/ {
+		//TR << "We just added the DISULFIDE variant type as desired, since we are going from rn " << rn << " to disulfide type " << std::endl;
+		variant_types.push_back( "DISULFIDE" ); //chemical::DISULFIDE ); // creating a disulfide
+		removing = false;
+	}
+
+	// The following is for backward-compatibility only, for functions that would request CYD when the residue was already CYD or whatnot.
+	if ( cys_type_name3=="CYS" && !removing /*not removing if disulfide variant not found*/ ) return true; //If we're asked for a cys and we already have a cys, do nothing.
+	else if ( cys_type_name3=="CYD" && removing /*removing if the disulfide variant was found*/ ) return true; //Similarly, if we're asked for a cyd and we already have a cyd, do nothing.
+
+	// Get the residue type of the desired new residue type.
+	chemical::ResidueTypeCOP replacement_type( residue_type_set->get_representative_type_name3( old_type.name3(), variant_types ) );
+	if ( replacement_type ) {
+		Residue const & res = conf.residue(index);
+		ResidueOP new_res = ResidueFactory::create_residue( *replacement_type, res, conf );
+		copy_residue_coordinates_and_rebuild_missing_atoms( res, *new_res, conf );
+		conf.replace_residue( index, *new_res, false );
+		return true;
+	}
+
+
+	// If we are here then a residue type match wasn't found; issue error message.
+	if ( TR.Error.visible() ) TR.Error << "Couldn't find a " << (removing ? "disulfide-free" : "disulfide-bonded")  << " equivalent for residue " << old_type.name3() << index << "." <<std::endl;
+
+	return false;
+}
+
+id::NamedAtomID
+atom_id_to_named_atom_id(
+	id::AtomID const & atom_id,
+	conformation::Residue const & rsd
+){
+	std::string atom_name;
+	Size rsd_id;
+	if ( atom_id.atomno() <= rsd.atoms().size() ) {
+		atom_name = rsd.atom_name( atom_id.atomno() );
+		rsd_id = atom_id.rsd();
+	} else {
+		if ( TR.Error.visible() ) TR.Error << "Can't resolve atom_id " << atom_id << std::endl;
+		rsd_id = 0;
+		atom_name ="";
+	}
+
+	return id::NamedAtomID( atom_name, rsd_id );
+}
+
+id::AtomID
+named_atom_id_to_atom_id(
+	id::NamedAtomID const & named_atom_id,
+	conformation::Residue const & rsd
+){
+	return id::AtomID( rsd.atom_index( named_atom_id.atom() ), named_atom_id.rsd() );
+}
+
+id::NamedStubID
+stub_id_to_named_stub_id(
+	id::StubID const & stub_id,
+	conformation::Residue const & rsd
+){
+	using namespace core::id;
+	if ( stub_id.center().valid() ) {
+		return NamedStubID(
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.center() , rsd ) ),
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
+		);
+	} else {
+		return NamedStubID( // TODO does this make sense? if input stub is bad, what should be done?
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
+			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
+		);
+	}
+}
+
+id::StubID
+named_stub_id_to_stub_id(
+	id::NamedStubID const & named_stub_id,
+	conformation::Residue const & rsd
+){
+	using namespace core::id;
+	if ( named_stub_id.center().valid() ) {
+		return StubID(
+			AtomID( named_atom_id_to_atom_id( named_stub_id.center() , rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
+		);
+	} else {
+		return StubID( // TODO does this make sense? if input stub is bad, what should be done?
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
+			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
+		);
+	}
+}
+
+/// @brief Gets a disulfide-forming residue's partner in the disulfide bond.
+/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
+core::Size get_disulf_partner (
+	core::conformation::Conformation const &conformation,
+	core::Size const res_index
+) {
+	runtime_assert( res_index <= conformation.size() );
+	runtime_assert( conformation.residue( res_index ).type( ).is_disulfide_bonded() ) ;
+	std::string lcatom = conformation.residue(res_index).type( ).get_disulfide_atom_name();
+	Size const connect_atom( conformation.residue( res_index ).atom_index( lcatom ) );
+	Size other_res( 0 );
+	for ( core::Size conn = conformation.residue( res_index ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+		if ( static_cast<core::Size>( conformation.residue( res_index ).type().residue_connection(conn).atomno() ) == connect_atom ) {
+			other_res = conformation.residue( res_index ).connect_map( conn ).resid();
+			break;
+		}
+	}
+	if ( other_res == 0 ) {
+		if ( TR.Error.visible() ) TR.Error << "Residue " << res_index << " was disulfide bonded but had no partner" << std::endl;
+		utility_exit();
+	}
+	return other_res;
+}
+
+void break_all_disulfides(
+	core::conformation::Conformation &conformation
+) {
+	utility::vector1< std::pair<core::Size,core::Size> > disulfides;
+	disulfide_bonds( conformation, disulfides);
+	for ( auto const & pair: disulfides ) {
+		break_disulfide( conformation, pair.first, pair.second );
+	}
+}
+
+/// @brief Breaks a disulfide bond.
+/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
+void break_disulfide(
+	core::conformation::Conformation &conformation,
+	core::Size const res1,
+	core::Size const res2
+) {
+	runtime_assert( res1 <= conformation.size() && res2 <= conformation.size() );
+	runtime_assert( conformation.residue(res1).type().is_disulfide_bonded() && conformation.residue(res2).type().is_disulfide_bonded() );
+	runtime_assert_string_msg( get_disulf_partner( conformation, res1 ) == res2, "Error: cannot break a disulfide bond, because the residues in question are not bonded." );
+	bool result = change_cys_state( res1, "", conformation );
+	runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res1).name3());
+	result = change_cys_state( res2, "", conformation );
+	runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res2).name3());
+	return;
+}
+
+/// @brief Introduce cysteines at the specified location and define a
+///  disulfide bond between them.
+/// @details Does not do the repacking & minimization required to place the
+///  disulfide correctly.
+void
+form_disulfide(
+	Conformation & conformation,
+	Size lower_res,
+	Size upper_res,
+	bool const preserve_d_residues,
+	bool const force_d_residues
+) {
+	// Verify we're dealing with a FA conformation
+	runtime_assert( conformation.is_fullatom() );
+
+	chemical::ResidueTypeSetCOP restype_set( conformation.residue_type_set_for_conf( chemical::FULL_ATOM_t ) );
+
+	// Break existing disulfide bonds to lower
+	if ( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) ) { // full atom residue
+
+		// In rare cases this connection-matching logic breaks.
+		// A disulfide bond can be reciprocal even if the other residue's disulfide connection number
+		// is different (for example: if you have no LOWER or UPPER or something)
+
+		std::string lcatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
+		Size const connect_atom( conformation.residue( lower_res ).atom_index( lcatom ) );
+		Size other_res( 0 );
+		Size conn(0);
+		for ( conn = conformation.residue( lower_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+			if ( Size( conformation.residue(lower_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
+				other_res = conformation.residue( lower_res ).connect_map( conn ).resid();
+				break;
 			}
+		}
+		if ( other_res == 0 ) {
+			if ( TR.Error.visible() ) TR.Error << "Residue " << lower_res << " was disulfide bonded but had no partner" << std::endl;
+			utility_exit();
+		}
 
-		/// @brief Gets a disulfide-forming residue's partner in the disulfide bond.
-		/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
-		core::Size get_disulf_partner (
-				core::conformation::Conformation const &conformation,
-				core::Size const res_index
-				) {
-			runtime_assert( res_index <= conformation.size() );
-			runtime_assert( conformation.residue( res_index ).type( ).is_disulfide_bonded() ) ;
-			std::string lcatom = conformation.residue(res_index).type( ).get_disulfide_atom_name();
-			Size const connect_atom( conformation.residue( res_index ).atom_index( lcatom ) );
+		if ( other_res == upper_res ) {
+			// Already a disulfide bond:
+			// A better "reciprocal" test: is its lower_res connect_atom() its disulfide atom?
+			// This way the ATOM contains the constant upper_res information.
+			TR.Trace << "Connect atom on " << upper_res << " was " << conformation.residue_type( upper_res ).atom_name( conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) << std::endl;
+			runtime_assert_msg( ObjexxFCL::stripped(
+				conformation.residue_type( upper_res ).atom_name(
+				conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) )
+				== conformation.residue_type( upper_res ).get_disulfide_atom_name(),
+				"Error: Disulfide bond wasn't reciprocal");
+			//runtime_assert_msg(conformation.residue( upper_res ).connect_map( conn ).resid() == lower_res,
+			// "Error: Disulfide bond wasn't reciprocal");
+			//return;
+		}
+
+		// Break the disulfide bond to upper_res
+		bool result = change_cys_state( other_res, "", conformation );
+		runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
+	} else {
+		form_disulfide_helper(conformation, lower_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the lower_res residue to a disulfide-forming variant, preserving other variant types in the process.
+	}
+	// Break existing disulfide bonds to upper
+	if ( !upper_is_symm_equivalent_of_lower( conformation, lower_res, upper_res ) ) { //If the upper residue is the symmetric equivalent of the lower residue, then we've already altered its disulfide type, and can skip the next few steps.
+		if ( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) ) {
+			std::string ucatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
+			Size const connect_atom( conformation.residue( upper_res ).atom_index( ucatom ) );
 			Size other_res( 0 );
-			for ( core::Size conn = conformation.residue( res_index ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-				if ( static_cast<core::Size>( conformation.residue( res_index ).type().residue_connection(conn).atomno() ) == connect_atom ) {
-					other_res = conformation.residue( res_index ).connect_map( conn ).resid();
+			Size conn(0);
+			for ( conn = conformation.residue( upper_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+				if ( Size ( conformation.residue(upper_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
+					other_res = conformation.residue( upper_res ).connect_map( conn ).resid();
 					break;
 				}
 			}
 			if ( other_res == 0 ) {
-				if ( TR.Error.visible() ) TR.Error << "Residue " << res_index << " was disulfide bonded but had no partner" << std::endl;
+				if ( TR.Error.visible() ) TR.Error << "Residue " << upper_res << " was disulfide bonded but had no partner" << std::endl;
 				utility_exit();
 			}
-			return other_res;
+
+			// Break the disulfide bond to lower_res
+			bool result = change_cys_state( other_res, "", conformation );
+			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
+		} else {
+			form_disulfide_helper(conformation, upper_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the upper_res residue to a disulfide-forming variant, preserving other variant types in the process.
 		}
+	} //If !upper_is_symm_equivalent_of_lower()
 
-		void break_all_disulfides(
-				core::conformation::Conformation &conformation
-				) {
-			utility::vector1< std::pair<core::Size,core::Size> > disulfides;
-			disulfide_bonds( conformation, disulfides);
-			for ( auto const & pair: disulfides ) {
-				break_disulfide( conformation, pair.first, pair.second );
-			}
+	// Both residues are now CYD
+	runtime_assert( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) );
+	runtime_assert( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) );
+
+	//form the bond between the two residues
+	// NOW we still need to get the lc and uc atoms, because we couldn't get them before
+	// since this function doesn't necessarily start with a cys type
+	// (damn this function!)
+	std::string const & lcatom = conformation.residue_type( lower_res ).get_disulfide_atom_name();
+	std::string const & ucatom = conformation.residue_type( upper_res ).get_disulfide_atom_name();
+	conformation.declare_chemical_bond( lower_res, lcatom, upper_res, ucatom );
+}
+
+/// @brief Helper function for the form_disulfide function.
+/// @details This function ensures that as a residue is mutated to a disulfide-bonding residue type,
+/// all other variant types are preserved; it is used to avoid code duplication.
+/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
+void form_disulfide_helper(
+	core::conformation::Conformation &conformation,
+	core::Size const res_index,
+	core::chemical::ResidueTypeSetCOP restype_set,
+	bool const preserve_d_residues,
+	bool const force_d_residues
+) {
+	using namespace core::chemical;
+	AA query_type( aa_cys );
+
+	// AMW: This was not explicit enough to me and I briefly altered this function's semantics!
+	// If the residues aren't already a disulfide-forming type, we must make them one. Functions like
+	// disulfide insertion mover assume we do this.
+	// VKM: This was failing to act properly on residues that were thiol-containing.  I'm taking out the
+	// unncessary check for !thiol-containing and !disulfide-bonded.
+	if ( force_d_residues ) {
+		if ( conformation.residue_type(res_index).is_alpha_aa() ) {
+			query_type = aa_dcs;
+		} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
+			query_type = aa_b3c;
 		}
-
-		/// @brief Breaks a disulfide bond.
-		/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
-		void break_disulfide(
-				core::conformation::Conformation &conformation,
-				core::Size const res1,
-				core::Size const res2
-				) {
-			runtime_assert( res1 <= conformation.size() && res2 <= conformation.size() );
-			runtime_assert( conformation.residue(res1).type().is_disulfide_bonded() && conformation.residue(res2).type().is_disulfide_bonded() );
-			runtime_assert_string_msg( get_disulf_partner( conformation, res1 ) == res2, "Error: cannot break a disulfide bond, because the residues in question are not bonded." );
-			bool result = change_cys_state( res1, "", conformation );
-			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res1).name3());
-			result = change_cys_state( res2, "", conformation );
-			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res2).name3());
-			return;
-		}
-
-		/// @brief Introduce cysteines at the specified location and define a
-		///  disulfide bond between them.
-		/// @details Does not do the repacking & minimization required to place the
-		///  disulfide correctly.
-		void
-			form_disulfide(
-					Conformation & conformation,
-					Size lower_res,
-					Size upper_res,
-					bool const preserve_d_residues,
-					bool const force_d_residues
-					) {
-				// Verify we're dealing with a FA conformation
-				runtime_assert( conformation.is_fullatom() );
-
-				chemical::ResidueTypeSetCOP restype_set( conformation.residue_type_set_for_conf( chemical::FULL_ATOM_t ) );
-
-				// Break existing disulfide bonds to lower
-				if ( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) ) { // full atom residue
-
-					// In rare cases this connection-matching logic breaks.
-					// A disulfide bond can be reciprocal even if the other residue's disulfide connection number
-					// is different (for example: if you have no LOWER or UPPER or something)
-
-					std::string lcatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
-					Size const connect_atom( conformation.residue( lower_res ).atom_index( lcatom ) );
-					Size other_res( 0 );
-					Size conn(0);
-					for ( conn = conformation.residue( lower_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-						if ( Size( conformation.residue(lower_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
-							other_res = conformation.residue( lower_res ).connect_map( conn ).resid();
-							break;
-						}
-					}
-					if ( other_res == 0 ) {
-						if ( TR.Error.visible() ) TR.Error << "Residue " << lower_res << " was disulfide bonded but had no partner" << std::endl;
-						utility_exit();
-					}
-
-					if ( other_res == upper_res ) {
-						// Already a disulfide bond:
-						// A better "reciprocal" test: is its lower_res connect_atom() its disulfide atom?
-						// This way the ATOM contains the constant upper_res information.
-						TR.Trace << "Connect atom on " << upper_res << " was " << conformation.residue_type( upper_res ).atom_name( conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) << std::endl;
-						runtime_assert_msg( ObjexxFCL::stripped(
-									conformation.residue_type( upper_res ).atom_name(
-										conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) )
-								== conformation.residue_type( upper_res ).get_disulfide_atom_name(),
-								"Error: Disulfide bond wasn't reciprocal");
-						//runtime_assert_msg(conformation.residue( upper_res ).connect_map( conn ).resid() == lower_res,
-						// "Error: Disulfide bond wasn't reciprocal");
-						//return;
-					}
-
-					// Break the disulfide bond to upper_res
-					bool result = change_cys_state( other_res, "", conformation );
-					runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
-				} else {
-					form_disulfide_helper(conformation, lower_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the lower_res residue to a disulfide-forming variant, preserving other variant types in the process.
-				}
-				// Break existing disulfide bonds to upper
-				if ( !upper_is_symm_equivalent_of_lower( conformation, lower_res, upper_res ) ) { //If the upper residue is the symmetric equivalent of the lower residue, then we've already altered its disulfide type, and can skip the next few steps.
-					if ( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) ) {
-						std::string ucatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
-						Size const connect_atom( conformation.residue( upper_res ).atom_index( ucatom ) );
-						Size other_res( 0 );
-						Size conn(0);
-						for ( conn = conformation.residue( upper_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-							if ( Size ( conformation.residue(upper_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
-								other_res = conformation.residue( upper_res ).connect_map( conn ).resid();
-								break;
-							}
-						}
-						if ( other_res == 0 ) {
-							if ( TR.Error.visible() ) TR.Error << "Residue " << upper_res << " was disulfide bonded but had no partner" << std::endl;
-							utility_exit();
-						}
-
-						// Break the disulfide bond to lower_res
-						bool result = change_cys_state( other_res, "", conformation );
-						runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
-					} else {
-						form_disulfide_helper(conformation, upper_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the upper_res residue to a disulfide-forming variant, preserving other variant types in the process.
-					}
-				} //If !upper_is_symm_equivalent_of_lower()
-
-				// Both residues are now CYD
-				runtime_assert( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) );
-				runtime_assert( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) );
-
-				//form the bond between the two residues
-				// NOW we still need to get the lc and uc atoms, because we couldn't get them before
-				// since this function doesn't necessarily start with a cys type
-				// (damn this function!)
-				std::string const & lcatom = conformation.residue_type( lower_res ).get_disulfide_atom_name();
-				std::string const & ucatom = conformation.residue_type( upper_res ).get_disulfide_atom_name();
-				conformation.declare_chemical_bond( lower_res, lcatom, upper_res, ucatom );
-			}
-
-		/// @brief Helper function for the form_disulfide function.
-		/// @details This function ensures that as a residue is mutated to a disulfide-bonding residue type,
-		/// all other variant types are preserved; it is used to avoid code duplication.
-		/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
-		void form_disulfide_helper(
-				core::conformation::Conformation &conformation,
-				core::Size const res_index,
-				core::chemical::ResidueTypeSetCOP restype_set,
-				bool const preserve_d_residues,
-				bool const force_d_residues
-				) {
-			using namespace core::chemical;
-			AA query_type( aa_cys );
-
-			// AMW: This was not explicit enough to me and I briefly altered this function's semantics!
-			// If the residues aren't already a disulfide-forming type, we must make them one. Functions like
-			// disulfide insertion mover assume we do this.
-			// VKM: This was failing to act properly on residues that were thiol-containing.  I'm taking out the
-			// unncessary check for !thiol-containing and !disulfide-bonded.
-			if ( force_d_residues ) {
-				if ( conformation.residue_type(res_index).is_alpha_aa() ) {
-					query_type = aa_dcs;
-				} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
-					query_type = aa_b3c;
-				}
+	} else {
+		if ( conformation.residue_type(res_index).is_alpha_aa() ) {
+			if ( !conformation.residue_type(res_index).is_d_aa() || !preserve_d_residues ) {
+				query_type = aa_cys;
 			} else {
-				if ( conformation.residue_type(res_index).is_alpha_aa() ) {
-					if ( !conformation.residue_type(res_index).is_d_aa() || !preserve_d_residues ) {
-						query_type = aa_cys;
-					} else {
-						query_type = aa_dcs;
-					}
-				} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
-					query_type = aa_b3c;
-				}
+				query_type = aa_dcs;
 			}
+		} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
+			query_type = aa_b3c;
+		}
+	}
 
-			//Get the list of variant types for this residue, so that the replacement has the same variant types.
-			utility::vector1< std::string > variant_types = conformation.residue(res_index).type().properties().get_list_of_variants();
+	//Get the list of variant types for this residue, so that the replacement has the same variant types.
+	utility::vector1< std::string > variant_types = conformation.residue(res_index).type().properties().get_list_of_variants();
 
-			//Add a disulfide variant type to the list, since we're turning CYS into CYD and so forth.
-			bool has_disulfide(false);
-			for ( core::Size i = 1, imax = variant_types.size(); i <= imax; ++i ) {
-				if ( variant_types[ i ] == "DISULFIDE" ) {
-					has_disulfide = true;
-					break;
-				}
-			}
-			if ( !has_disulfide ) variant_types.push_back( "DISULFIDE" );
+	//Add a disulfide variant type to the list, since we're turning CYS into CYD and so forth.
+	bool has_disulfide(false);
+	for ( core::Size i = 1, imax = variant_types.size(); i <= imax; ++i ) {
+		if ( variant_types[ i ] == "DISULFIDE" ) {
+			has_disulfide = true;
+			break;
+		}
+	}
+	if ( !has_disulfide ) variant_types.push_back( "DISULFIDE" );
 
-			if ( conformation.residue_type(res_index).is_beta_aa() && ( conformation.residue_type(res_index).is_d_aa() || force_d_residues ) ) {
-				variant_types.push_back( "D" );
-			}
+	if ( conformation.residue_type(res_index).is_beta_aa() && ( conformation.residue_type(res_index).is_d_aa() || force_d_residues ) ) {
+		variant_types.push_back( "D" );
+	}
 
-			//Get the suitable variant type, and create a residue with it:
-			ResidueOP lower_cyd( ResidueFactory::create_residue( *(restype_set->get_representative_type_aa( query_type, variant_types )), conformation.residue( res_index ), conformation ) );
+	//Get the suitable variant type, and create a residue with it:
+	ResidueOP lower_cyd( ResidueFactory::create_residue( *(restype_set->get_representative_type_aa( query_type, variant_types )), conformation.residue( res_index ), conformation ) );
 
-			copy_residue_coordinates_and_rebuild_missing_atoms( conformation.residue(res_index), *lower_cyd, conformation, true );
-			conformation.replace_residue(res_index, *lower_cyd, false /*backbone already oriented*/); // doug
+	copy_residue_coordinates_and_rebuild_missing_atoms( conformation.residue(res_index), *lower_cyd, conformation, true );
+	conformation.replace_residue(res_index, *lower_cyd, false /*backbone already oriented*/); // doug
 
-			return;
+	return;
+}
+
+/// @brief Another helper function for the form_disulfide function.
+/// @details Returns true if and only if the conformation is symmetric and upper_res is a symmetric copy of lower_res.
+/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
+bool
+upper_is_symm_equivalent_of_lower(
+	core::conformation::Conformation const &conformation,
+	core::Size const lower_res,
+	core::Size const upper_res
+) {
+	core::conformation::symmetry::SymmetricConformationCOP sym_conf( utility::pointer::dynamic_pointer_cast< core::conformation::symmetry::SymmetricConformation const >(conformation.get_self_ptr()) );
+	if ( !sym_conf ) return false;
+	//From now on, can assume conformation IS symmetric.
+
+	if ( sym_conf->Symmetry_Info()->bb_is_independent( lower_res ) ) {
+		if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) return false; //If both residues are independent, they're not equivalent.
+		if ( sym_conf->Symmetry_Info()->bb_follows( upper_res ) == lower_res ) return true;  //If the upper res follows the lower, then these ARE equivalent residues.
+		return false; //Otherwise they're not, if the lower res is independent.
+	}
+	//From now on, assume lower_res depends on something
+	if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) {
+		if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == upper_res ) return true; //If the lower res follows the upper, then these ARE equivalent residues.
+		return false; //Otherwise they're not, if the upper is independent.
+	}
+
+	//From now on, lower_res and upper_res can be assumed to depend on something.  If they depend on the same thing, they're equivalent.
+	if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == sym_conf->Symmetry_Info()->bb_follows(upper_res) ) return true;
+
+	return false;
+}
+
+/// @brief Find whether there is a disulfide defined between two residues
+///
+/// @details We define a disulfide to exist between a pair of residues iff
+///  -# They are both cysteines
+///  -# They are bonded by their sidechains
+bool
+is_disulfide_bond( conformation::Conformation const& conformation, Size residueA_pos, Size residueB_pos)
+{
+	Residue const& A = conformation.residue(residueA_pos);
+	Residue const& B = conformation.residue(residueB_pos);
+
+	if ( !A.is_protein() || !B.is_protein() ) {
+		return false;
+	}
+
+	//both Cys or CysD
+	//if( A.type().name1() != 'C' || B.type().name1() != 'C' )
+	if ( ( ! A.type().is_sidechain_thiol() && ! A.type().is_disulfide_bonded() )
+			|| ( ! B.type().is_sidechain_thiol() && ! B.type().is_disulfide_bonded() ) ) {
+		return false;
+	}
+
+	//std::string n1 = A.type().name3(); std::string n2 = B.type().name3();
+
+	//bonded
+	runtime_assert( A.type().has( A.type().get_disulfide_atom_name() ) ); //should be fa or centroid
+	Size a_connect_atom = A.atom_index( A.type().get_disulfide_atom_name() );
+
+	for ( Size connection = A.type().n_possible_residue_connections(); connection >= 1; --connection ) {
+		//check if A bonded to B
+		if ( (Size) A.type().residue_connection( connection ).atomno() == a_connect_atom && //bond to sg, not the backbone
+				A.connect_map( connection ).resid() == residueB_pos ) { //bonded to B
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/// @brief Generate a list of all disulfide bonds in the conformation
+void
+disulfide_bonds( conformation::Conformation const& conformation, utility::vector1< std::pair<Size,Size> > & disulfides )
+{
+	for ( Size i = 1; i<= conformation.size(); ++i ) {
+		Residue const& res(conformation.residue(i));
+
+		// Skip things besides CYD
+		//if( !(res.aa() == chemical::aa_cys && res.has_variant_type(chemical::DISULFIDE) ))
+		if ( !(res.type().is_disulfide_bonded() && res.has_variant_type(chemical::DISULFIDE) ) ) {
+			continue;
+		}
+		Size connect_atom( 0);
+		if ( res.type().get_disulfide_atom_name() == "NONE" ) {
+			if ( TR.Warning.visible() ) TR.Warning << "unable to establish which atom to use for the disulfide to residue " << i << std::endl;
+			continue;
+		} else {
+			connect_atom = res.atom_index( res.type().get_disulfide_atom_name() ) ;
 		}
 
-		/// @brief Another helper function for the form_disulfide function.
-		/// @details Returns true if and only if the conformation is symmetric and upper_res is a symmetric copy of lower_res.
-		/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
-		bool
-			upper_is_symm_equivalent_of_lower(
-					core::conformation::Conformation const &conformation,
-					core::Size const lower_res,
-					core::Size const upper_res
-					) {
-				core::conformation::symmetry::SymmetricConformationCOP sym_conf( utility::pointer::dynamic_pointer_cast< core::conformation::symmetry::SymmetricConformation const >(conformation.get_self_ptr()) );
-				if ( !sym_conf ) return false;
-				//From now on, can assume conformation IS symmetric.
-
-				if ( sym_conf->Symmetry_Info()->bb_is_independent( lower_res ) ) {
-					if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) return false; //If both residues are independent, they're not equivalent.
-					if ( sym_conf->Symmetry_Info()->bb_follows( upper_res ) == lower_res ) return true;  //If the upper res follows the lower, then these ARE equivalent residues.
-					return false; //Otherwise they're not, if the lower res is independent.
-				}
-				//From now on, assume lower_res depends on something
-				if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) {
-					if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == upper_res ) return true; //If the lower res follows the upper, then these ARE equivalent residues.
-					return false; //Otherwise they're not, if the upper is independent.
-				}
-
-				//From now on, lower_res and upper_res can be assumed to depend on something.  If they depend on the same thing, they're equivalent.
-				if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == sym_conf->Symmetry_Info()->bb_follows(upper_res) ) return true;
-
-				return false;
+		Size other_res(0);
+		Size conn;
+		for ( conn = conformation.residue( i ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+			if ( Size( conformation.residue( i ).type().residue_connection(conn).atomno() ) == connect_atom ) {
+				other_res = conformation.residue( i ).connect_map( conn ).resid();
+				break;
 			}
+		}
+		if ( other_res == 0 ) {
+			TR.Error << "Residue " << i << " was disulfide bonded but had no partner" << std::endl;
+			utility_exit();
+		}
 
-		/// @brief Find whether there is a disulfide defined between two residues
-		///
-		/// @details We define a disulfide to exist between a pair of residues iff
-		///  -# They are both cysteines
-		///  -# They are bonded by their sidechains
-		bool
-			is_disulfide_bond( conformation::Conformation const& conformation, Size residueA_pos, Size residueB_pos)
-			{
-				Residue const& A = conformation.residue(residueA_pos);
-				Residue const& B = conformation.residue(residueB_pos);
+		// Output the pair once
+		if ( i < other_res ) {
+			disulfides.push_back( std::make_pair(i, other_res) );
+		}
+	}
+}
 
-				if ( !A.is_protein() || !B.is_protein() ) {
-					return false;
-				}
 
-				//both Cys or CysD
-				//if( A.type().name1() != 'C' || B.type().name1() != 'C' )
-				if ( ( ! A.type().is_sidechain_thiol() && ! A.type().is_disulfide_bonded() )
-						|| ( ! B.type().is_sidechain_thiol() && ! B.type().is_disulfide_bonded() ) ) {
-					return false;
-				}
+/// @brief    Return a nearby TorsionID with approximately the same 3D orientation, selected from the give TorsionIDs.
+/// @details  The downstream effects of a torsion move can be minimized by twisting a nearby torsion in the opposite
+///           direction with the same magnitude, resulting in a net "shearing" motion, if and only if the orientation
+///           of the two bonds are similar, that is, if the two bonds are approximately parallel.  This function is
+///           useful for finding such a torsion from a supplied list of torsions.
+/// @param    <conf>            the Conformation
+/// @param    <torsions>        a list of torsions to search
+/// @param    <query_torsion>   the TorsionID to compare
+/// @author   Labonte <JWLabonte@jhu.edu>
+core::id::TorsionID
+find_bond_torsion_with_nearest_orientation(
+	core::conformation::Conformation const & conf,
+	utility::vector1< core::id::TorsionID > const & torsions,
+	core::id::TorsionID const & query_torsion )
+{
+	using namespace core;
 
-				//std::string n1 = A.type().name3(); std::string n2 = B.type().name3();
+	Vector const ref_bond_vector( conf.bond_orientation( query_torsion ) );
 
-				//bonded
-				runtime_assert( A.type().has( A.type().get_disulfide_atom_name() ) ); //should be fa or centroid
-				Size a_connect_atom = A.atom_index( A.type().get_disulfide_atom_name() );
+	Real max_dot_product( 0.0 );
+	id::TorsionID best_torsion;
+	for ( auto torsion : torsions ) {
+		if ( torsion == query_torsion ) { continue; }  // Do not compare to self.
+		Vector const query_bond_vector( conf.bond_orientation( torsion ) );
+		Real const dot_product( fabs( numeric::dot( query_bond_vector, ref_bond_vector ) ) );
+		if ( dot_product > max_dot_product ) {
+			max_dot_product = dot_product;
+			best_torsion = torsion;
+		}
+	}
 
-				for ( Size connection = A.type().n_possible_residue_connections(); connection >= 1; --connection ) {
-					//check if A bonded to B
-					if ( (Size) A.type().residue_connection( connection ).atomno() == a_connect_atom && //bond to sg, not the backbone
-							A.connect_map( connection ).resid() == residueB_pos ) { //bonded to B
-						return true;
-					}
-				}
+	return best_torsion;
+}
 
-				return false;
+
+// Ring-related Functions /////////////////////////////////////////////////////
+
+// What is the attachment position of the query atom on the given ring?
+core::uint
+position_of_atom_on_ring(
+	Residue const & residue,
+	core::uint query_atom,
+	utility::vector1< core::uint > const & ring_atoms )
+{
+	if ( ring_atoms.contains( query_atom ) ) {
+		return 0;
+	}
+	utility::vector1< uint > const bonded_heavy_atoms( residue.get_adjacent_heavy_atoms( query_atom ) );
+	Size const n_ring_atoms( ring_atoms.size() );
+	for ( uint position( 1 ); position <= n_ring_atoms; ++position ) {
+		for ( uint bonded_heavy_atom : bonded_heavy_atoms ) {
+			if ( ring_atoms[ position ] == bonded_heavy_atom ) {
+				return position;
 			}
+		}
+	}
+	return 0;
+}
 
-		/// @brief Generate a list of all disulfide bonds in the conformation
-		void
-			disulfide_bonds( conformation::Conformation const& conformation, utility::vector1< std::pair<Size,Size> > & disulfides )
-			{
-				for ( Size i = 1; i<= conformation.size(); ++i ) {
-					Residue const& res(conformation.residue(i));
+// Is the query atom in this residue axial or equatorial to the given ring or neither?
+/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
+/// axial or equatorial to it (or neither).  The attachment atom is auto-detected.
+/// @param   <residue>:    The Residue containing the atoms in question.
+/// @param   <query_atom>: The index of the atom in question.
+/// @param   <ring_atoms>: A list of indices for the atoms of a monocyclic ring system in sequence.
+/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
+/// @author  Labonte <JWLabonte@jhu.edu>
+chemical::rings::AxEqDesignation
+is_atom_axial_or_equatorial_to_ring(
+	Residue const & residue,
+	core::uint query_atom,
+	utility::vector1< core::uint > const & ring_atoms )
+{
+	using namespace utility;
+	using namespace numeric;
 
-					// Skip things besides CYD
-					//if( !(res.aa() == chemical::aa_cys && res.has_variant_type(chemical::DISULFIDE) ))
-					if ( !(res.type().is_disulfide_bonded() && res.has_variant_type(chemical::DISULFIDE) ) ) {
-						continue;
-					}
-					Size connect_atom( 0);
-					if ( res.type().get_disulfide_atom_name() == "NONE" ) {
-						if ( TR.Warning.visible() ) TR.Warning << "unable to establish which atom to use for the disulfide to residue " << i << std::endl;
-						continue;
-					} else {
-						connect_atom = res.atom_index( res.type().get_disulfide_atom_name() ) ;
-					}
+	uint const attachment_point( position_of_atom_on_ring( residue, query_atom, ring_atoms) );
+	if ( attachment_point ) {
+		// We found an attachment point.
+		// Now we need to get the coordinates of all the important atoms and call the function that does the actual
+		// math.
+		xyzVector< Distance > const query_atom_coords( residue.xyz( query_atom ) );
+		xyzVector< Distance > const attachment_atom_coords( residue.xyz( ring_atoms[ attachment_point ] ) );
 
-					Size other_res(0);
-					Size conn;
-					for ( conn = conformation.residue( i ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-						if ( Size( conformation.residue( i ).type().residue_connection(conn).atomno() ) == connect_atom ) {
-							other_res = conformation.residue( i ).connect_map( conn ).resid();
-							break;
-						}
-					}
-					if ( other_res == 0 ) {
-						TR.Error << "Residue " << i << " was disulfide bonded but had no partner" << std::endl;
-						utility_exit();
-					}
+		Size const n_ring_atoms( ring_atoms.size() );
+		vector1< xyzVector< Distance > > ring_atom_coords( n_ring_atoms );
+		for ( uint j( 1 ); j <= n_ring_atoms; ++j ) {
+			ring_atom_coords[ j ] = residue.xyz( ring_atoms[ j ] );
+		}
+		return chemical::rings::is_atom_axial_or_equatorial_to_ring(
+			query_atom_coords, attachment_atom_coords, ring_atom_coords );
+	}
+	TR.Debug << "The attachment point for the query atom is not found in the ring; ";
+	TR.Debug << "an axial/equatorial designation is meaningless." << std::endl;
+	return chemical::rings::NEITHER;
+}
 
-					// Output the pair once
-					if ( i < other_res ) {
-						disulfides.push_back( std::make_pair(i, other_res) );
-					}
-				}
-			}
+// Is the query atom in this residue axial or equatorial or neither?
+/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
+/// axial or equatorial to it (or neither).  The ring is requested from the Residue.
+/// @param   <residue>:    The Residue containing the atoms in question, which must have exactly one ring.
+/// @param   <query_atom>: The index of the atom in question.
+/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
+/// @author  Labonte <JWLabonte@jhu.edu>
+chemical::rings::AxEqDesignation
+is_atom_axial_or_equatorial( Residue const & residue, uint query_atom )
+{
+	chemical::ResidueType const & rsd_type( residue.type() );
+	if ( rsd_type.n_rings() != 1 ) {
+		TR.Warning << "Queried atom must be on a cyclic residue with exactly one ring." << std::endl;
+		return chemical::rings::NEITHER;
+	}
 
+	return is_atom_axial_or_equatorial_to_ring( residue, query_atom, rsd_type.ring_atoms( 1 ) );
+}
 
-		/// @brief    Return a nearby TorsionID with approximately the same 3D orientation, selected from the give TorsionIDs.
-		/// @details  The downstream effects of a torsion move can be minimized by twisting a nearby torsion in the opposite
-		///           direction with the same magnitude, resulting in a net "shearing" motion, if and only if the orientation
-		///           of the two bonds are similar, that is, if the two bonds are approximately parallel.  This function is
-		///           useful for finding such a torsion from a supplied list of torsions.
-		/// @param    <conf>            the Conformation
-		/// @param    <torsions>        a list of torsions to search
-		/// @param    <query_torsion>   the TorsionID to compare
-		/// @author   Labonte <JWLabonte@jhu.edu>
-		core::id::TorsionID
-			find_bond_torsion_with_nearest_orientation(
-					core::conformation::Conformation const & conf,
-					utility::vector1< core::id::TorsionID > const & torsions,
-					core::id::TorsionID const & query_torsion )
-			{
-				using namespace core;
+chemical::ResidueTypeCOP
+virtual_type_for_conf( core::conformation::Conformation const & conformation ) {
+	core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
+	core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("VRT") );
+	if ( ! rsd_type ) {
+		// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
+		core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
+		if ( mode == core::chemical::MIXED_t ) {
+			mode = core::chemical::FULL_ATOM_t;
+		}
+		residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
+		rsd_type = residue_set->name_mapOP("VRT");
+		if ( ! rsd_type ) {
+			TR.Error << "Can't find residue type VRT in type set of mode " << mode << std::endl;
+			utility_exit_with_message("Cannot find residue type VRT" );
+		}
+	}
+	return rsd_type;
+}
 
-				Vector const ref_bond_vector( conf.bond_orientation( query_torsion ) );
+chemical::ResidueTypeCOP
+inv_virtual_type_for_conf( core::conformation::Conformation const &conformation ) {
+	core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
+	core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("INV_VRT") );
+	if ( ! rsd_type ) {
+		// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
+		core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
+		if ( mode == core::chemical::MIXED_t ) {
+			mode = core::chemical::FULL_ATOM_t;
+		}
+		residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
+		rsd_type = residue_set->name_mapOP("INV_VRT");
+		if ( ! rsd_type ) {
+			TR.Error << "Can't find residue type INV_VRT in type set of mode " << mode << std::endl;
+			utility_exit_with_message("Cannot find residue type INV_VRT" );
+		}
+	}
+	return rsd_type;
+}
 
-				Real max_dot_product( 0.0 );
-				id::TorsionID best_torsion;
-				for ( auto torsion : torsions ) {
-					if ( torsion == query_torsion ) { continue; }  // Do not compare to self.
-					Vector const query_bond_vector( conf.bond_orientation( torsion ) );
-					Real const dot_product( fabs( numeric::dot( query_bond_vector, ref_bond_vector ) ) );
-					if ( dot_product > max_dot_product ) {
-						max_dot_product = dot_product;
-						best_torsion = torsion;
-					}
-				}
+core::Vector
+all_atom_center(
+	core::conformation::Residue const & rsd
+) {
 
-				return best_torsion;
-			}
+	utility::vector1< core::Vector > coords;
 
+	for ( Size jj(1); jj <= rsd.natoms(); ++ jj ) {
+		coords.push_back( rsd.xyz( jj ) );
+	}
 
-		// Ring-related Functions /////////////////////////////////////////////////////
+	if ( ! coords.size() ) { utility_exit_with_message( "Cannot compute center of mass for no atoms!" ); }
 
-		// What is the attachment position of the query atom on the given ring?
-		core::uint
-			position_of_atom_on_ring(
-					Residue const & residue,
-					core::uint query_atom,
-					utility::vector1< core::uint > const & ring_atoms )
-			{
-				if ( ring_atoms.contains( query_atom ) ) {
-					return 0;
-				}
-				utility::vector1< uint > const bonded_heavy_atoms( residue.get_adjacent_heavy_atoms( query_atom ) );
-				Size const n_ring_atoms( ring_atoms.size() );
-				for ( uint position( 1 ); position <= n_ring_atoms; ++position ) {
-					for ( uint bonded_heavy_atom : bonded_heavy_atoms ) {
-						if ( ring_atoms[ position ] == bonded_heavy_atom ) {
-							return position;
-						}
-					}
-				}
-				return 0;
-			}
+	return numeric::center_of_mass( coords );
+}
 
-		// Is the query atom in this residue axial or equatorial to the given ring or neither?
-		/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
-		/// axial or equatorial to it (or neither).  The attachment atom is auto-detected.
-		/// @param   <residue>:    The Residue containing the atoms in question.
-		/// @param   <query_atom>: The index of the atom in question.
-		/// @param   <ring_atoms>: A list of indices for the atoms of a monocyclic ring system in sequence.
-		/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
-		/// @author  Labonte <JWLabonte@jhu.edu>
-		chemical::rings::AxEqDesignation
-			is_atom_axial_or_equatorial_to_ring(
-					Residue const & residue,
-					core::uint query_atom,
-					utility::vector1< core::uint > const & ring_atoms )
-			{
-				using namespace utility;
-				using namespace numeric;
+/// @brief Given a residue and a connection id, get the heavyatom adjacent to the atom that makes that connection.
+/// @details Chooses mainchain over non-mainchain, and heavyatoms over non-heavyatoms.  Returns true for FAILURE.
+/// @author Vikram K. Mulligan (vmullig@uw.edu).
+bool
+get_second_atom_from_connection(
+	core::Size & resno,
+	core::Size & atomno,
+	Residue const &rsd,
+	Conformation const &conformation,
+	core::Size const &conn_id
+) {
+	core::Size conn_atom( rsd.type().residue_connect_atom_index( conn_id ) );
+	for ( core::Size i(1), imax(rsd.natoms()); i<=imax; ++i ) {
+		if ( i == conn_atom ) continue;
+		if ( rsd.type().atoms_are_bonded( i, conn_atom ) ) {
+			resno = rsd.seqpos();
+			atomno = i;
+			return false; //SUCCESS
+		}
+	}
 
-				uint const attachment_point( position_of_atom_on_ring( residue, query_atom, ring_atoms) );
-				if ( attachment_point ) {
-					// We found an attachment point.
-					// Now we need to get the coordinates of all the important atoms and call the function that does the actual
-					// math.
-					xyzVector< Distance > const query_atom_coords( residue.xyz( query_atom ) );
-					xyzVector< Distance > const attachment_atom_coords( residue.xyz( ring_atoms[ attachment_point ] ) );
+	//If we reach here, then we can't find an atom adjacent to the connection in the residue.  Could be a one-atom residue.
+	for ( core::Size i(1), imax(rsd.type().n_possible_residue_connections()); i<=imax; ++i ) {
+		if ( i == conn_id ) continue;
+		core::Size const connected_res( rsd.connected_residue_at_resconn( i ) );
+		if ( connected_res != 0 ) {
+			resno = connected_res;
+			atomno = conformation.residue( connected_res ).residue_connect_atom_index( rsd.residue_connection_conn_id( conn_id ) );
+			if ( atomno == 0 ) return true; //FAIL
+			return false; //SUCCESS
+		}
+	}
 
-					Size const n_ring_atoms( ring_atoms.size() );
-					vector1< xyzVector< Distance > > ring_atom_coords( n_ring_atoms );
-					for ( uint j( 1 ); j <= n_ring_atoms; ++j ) {
-						ring_atom_coords[ j ] = residue.xyz( ring_atoms[ j ] );
-					}
-					return chemical::rings::is_atom_axial_or_equatorial_to_ring(
-							query_atom_coords, attachment_atom_coords, ring_atom_coords );
-				}
-				TR.Debug << "The attachment point for the query atom is not found in the ring; ";
-				TR.Debug << "an axial/equatorial designation is meaningless." << std::endl;
-				return chemical::rings::NEITHER;
-			}
+	return true; //FAILURE
+}
 
-		// Is the query atom in this residue axial or equatorial or neither?
-		/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
-		/// axial or equatorial to it (or neither).  The ring is requested from the Residue.
-		/// @param   <residue>:    The Residue containing the atoms in question, which must have exactly one ring.
-		/// @param   <query_atom>: The index of the atom in question.
-		/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
-		/// @author  Labonte <JWLabonte@jhu.edu>
-		chemical::rings::AxEqDesignation
-			is_atom_axial_or_equatorial( Residue const & residue, uint query_atom )
-			{
-				chemical::ResidueType const & rsd_type( residue.type() );
-				if ( rsd_type.n_rings() != 1 ) {
-					TR.Warning << "Queried atom must be on a cyclic residue with exactly one ring." << std::endl;
-					return chemical::rings::NEITHER;
-				}
+conformation::ResidueOP
+get_residue_from_name(
+	std::string const & name,
+	std::string const & residue_type_set /* = "fa_standard" */ ) {
 
-				return is_atom_axial_or_equatorial_to_ring( residue, query_atom, rsd_type.ring_atoms( 1 ) );
-			}
+	core::chemical::ResidueTypeSetCOP residue_set( core::chemical::ChemicalManager::get_instance()
+		->residue_type_set( residue_type_set ) );
+	core::chemical::ResidueTypeCOP rsd_type = residue_set->name_map( name ).get_self_ptr();
 
-		chemical::ResidueTypeCOP
-			virtual_type_for_conf( core::conformation::Conformation const & conformation ) {
-				core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
-				core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("VRT") );
-				if ( ! rsd_type ) {
-					// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
-					core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
-					if ( mode == core::chemical::MIXED_t ) {
-						mode = core::chemical::FULL_ATOM_t;
-					}
-					residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
-					rsd_type = residue_set->name_mapOP("VRT");
-					if ( ! rsd_type ) {
-						TR.Error << "Can't find residue type VRT in type set of mode " << mode << std::endl;
-						utility_exit_with_message("Cannot find residue type VRT" );
-					}
-				}
-				return rsd_type;
-			}
+	return  conformation::ResidueFactory::create_residue( *rsd_type );
+}
 
-		chemical::ResidueTypeCOP
-			inv_virtual_type_for_conf( core::conformation::Conformation const &conformation ) {
-				core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
-				core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("INV_VRT") );
-				if ( ! rsd_type ) {
-					// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
-					core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
-					if ( mode == core::chemical::MIXED_t ) {
-						mode = core::chemical::FULL_ATOM_t;
-					}
-					residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
-					rsd_type = residue_set->name_mapOP("INV_VRT");
-					if ( ! rsd_type ) {
-						TR.Error << "Can't find residue type INV_VRT in type set of mode " << mode << std::endl;
-						utility_exit_with_message("Cannot find residue type INV_VRT" );
-					}
-				}
-				return rsd_type;
-			}
+conformation::ResidueOP
+get_residue_from_name1(
+	char name1,
+	bool is_lower_terminus /*= false*/,
+	bool is_upper_terminus /*= false */,
+	bool d_aa /*= false */,
+	std::string const & residue_type_set /* = "fa_standard" */ ) {
 
-		core::Vector
-			all_atom_center(
-					core::conformation::Residue const & rsd
-					) {
+	chemical::ResidueTypeSetCOP residue_set( chemical::ChemicalManager::get_instance()
+		->residue_type_set( residue_type_set ) );
 
-				utility::vector1< core::Vector > coords;
+	chemical::AA my_aa = chemical::aa_from_oneletter_code( name1 );
+	if ( d_aa ) {
+		my_aa = chemical::get_D_equivalent( my_aa );
+	}
 
-				for ( Size jj(1); jj <= rsd.natoms(); ++ jj ) {
-					coords.push_back( rsd.xyz( jj ) );
-				}
+	// this part stolen from core/pose/annotated_sequence.cc to comply with library levels
+	chemical::ResidueTypeCOP rsd_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).get_representative_type();
+	utility::vector1< chemical::VariantType > variants;
+	if ( rsd_type->is_polymer() ) {
+		if ( is_lower_terminus ) variants.push_back( chemical::LOWER_TERMINUS_VARIANT );
+		if ( is_upper_terminus ) variants.push_back( chemical::UPPER_TERMINUS_VARIANT );
+	}
+	chemical::ResidueTypeCOP res_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).variants( variants ).get_representative_type();
 
-				if ( ! coords.size() ) { utility_exit_with_message( "Cannot compute center of mass for no atoms!" ); }
+	return  conformation::ResidueFactory::create_residue( *res_type );
+}
 
-				return numeric::center_of_mass( coords );
-			}
+core::kinematics::Stub
+get_stub_from_residue( core::conformation::Residue const & res ) {
+	Size center = 0;
+	Size nbr1 = 0;
+	Size nbr2 = 0;
+	res.select_orient_atoms( center, nbr1, nbr2 );
+	return core::kinematics::Stub(
+		res.xyz( center ),
+		res.xyz( nbr1 ),
+		res.xyz( nbr2 )
+	);
+}
 
-		/// @brief Given a residue and a connection id, get the heavyatom adjacent to the atom that makes that connection.
-		/// @details Chooses mainchain over non-mainchain, and heavyatoms over non-heavyatoms.  Returns true for FAILURE.
-		/// @author Vikram K. Mulligan (vmullig@uw.edu).
-		bool
-			get_second_atom_from_connection(
-					core::Size & resno,
-					core::Size & atomno,
-					Residue const &rsd,
-					Conformation const &conformation,
-					core::Size const &conn_id
-					) {
-				core::Size conn_atom( rsd.type().residue_connect_atom_index( conn_id ) );
-				for ( core::Size i(1), imax(rsd.natoms()); i<=imax; ++i ) {
-					if ( i == conn_atom ) continue;
-					if ( rsd.type().atoms_are_bonded( i, conn_atom ) ) {
-						resno = rsd.seqpos();
-						atomno = i;
-						return false; //SUCCESS
-					}
-				}
+core::kinematics::RT
+get_rt_from_residue_pair(
+	core::conformation::Residue const & res1,
+	core::conformation::Residue const & res2
+) {
 
-				//If we reach here, then we can't find an atom adjacent to the connection in the residue.  Could be a one-atom residue.
-				for ( core::Size i(1), imax(rsd.type().n_possible_residue_connections()); i<=imax; ++i ) {
-					if ( i == conn_id ) continue;
-					core::Size const connected_res( rsd.connected_residue_at_resconn( i ) );
-					if ( connected_res != 0 ) {
-						resno = connected_res;
-						atomno = conformation.residue( connected_res ).residue_connect_atom_index( rsd.residue_connection_conn_id( conn_id ) );
-						if ( atomno == 0 ) return true; //FAIL
-						return false; //SUCCESS
-					}
-				}
+	core::kinematics::Stub stub1 = get_stub_from_residue( res1 );
+	core::kinematics::Stub stub2 = get_stub_from_residue( res2 );
 
-				return true; //FAILURE
-			}
+	return core::kinematics::RT( stub1, stub2 );
+}
 
-		conformation::ResidueOP
-			get_residue_from_name(
-					std::string const & name,
-					std::string const & residue_type_set /* = "fa_standard" */ ) {
-
-				core::chemical::ResidueTypeSetCOP residue_set( core::chemical::ChemicalManager::get_instance()
-						->residue_type_set( residue_type_set ) );
-				core::chemical::ResidueTypeCOP rsd_type = residue_set->name_map( name ).get_self_ptr();
-
-				return  conformation::ResidueFactory::create_residue( *rsd_type );
-			}
-
-		conformation::ResidueOP
-			get_residue_from_name1(
-					char name1,
-					bool is_lower_terminus /*= false*/,
-					bool is_upper_terminus /*= false */,
-					bool d_aa /*= false */,
-					std::string const & residue_type_set /* = "fa_standard" */ ) {
-
-				chemical::ResidueTypeSetCOP residue_set( chemical::ChemicalManager::get_instance()
-						->residue_type_set( residue_type_set ) );
-
-				chemical::AA my_aa = chemical::aa_from_oneletter_code( name1 );
-				if ( d_aa ) {
-					my_aa = chemical::get_D_equivalent( my_aa );
-				}
-
-				// this part stolen from core/pose/annotated_sequence.cc to comply with library levels
-				chemical::ResidueTypeCOP rsd_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).get_representative_type();
-				utility::vector1< chemical::VariantType > variants;
-				if ( rsd_type->is_polymer() ) {
-					if ( is_lower_terminus ) variants.push_back( chemical::LOWER_TERMINUS_VARIANT );
-					if ( is_upper_terminus ) variants.push_back( chemical::UPPER_TERMINUS_VARIANT );
-				}
-				chemical::ResidueTypeCOP res_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).variants( variants ).get_representative_type();
-
-				return  conformation::ResidueFactory::create_residue( *res_type );
-			}
-
-		core::kinematics::Stub
-			get_stub_from_residue( core::conformation::Residue const & res ) {
-				Size center = 0;
-				Size nbr1 = 0;
-				Size nbr2 = 0;
-				res.select_orient_atoms( center, nbr1, nbr2 );
-				return core::kinematics::Stub(
-						res.xyz( center ),
-						res.xyz( nbr1 ),
-						res.xyz( nbr2 )
-						);
-			}
-
-		core::kinematics::RT
-			get_rt_from_residue_pair(
-					core::conformation::Residue const & res1,
-					core::conformation::Residue const & res2
-					) {
-
-				core::kinematics::Stub stub1 = get_stub_from_residue( res1 );
-				core::kinematics::Stub stub2 = get_stub_from_residue( res2 );
-
-				return core::kinematics::RT( stub1, stub2 );
-			}
-
-	} // namespace conformation
+} // namespace conformation
 } // namespace core

--- a/source/src/core/conformation/util.cc
+++ b/source/src/core/conformation/util.cc
@@ -13,6 +13,7 @@
 
 // Unit headers
 #include <core/conformation/util.hh>
+#include <core/conformation/carbohydrates/util.hh>
 
 // Package headers
 #include <core/conformation/Conformation.hh>
@@ -70,2627 +71,2643 @@ static basic::Tracer TR( "core.conformation.util" );
 
 
 namespace core {
-namespace conformation {
+	namespace conformation {
 
-void
-orient_residue_for_ideal_bond(
-	Residue & moving_rsd,
-	chemical::ResidueConnection const & moving_connection,
-	Residue const & fixed_rsd,
-	chemical::ResidueConnection const & fixed_connection,
-	Conformation const & conformation,
-	bool lookup_bond_length
-)
-{
+		void
+			orient_residue_for_ideal_bond(
+					Residue & moving_rsd,
+					chemical::ResidueConnection const & moving_connection,
+					Residue const & fixed_rsd,
+					chemical::ResidueConnection const & fixed_connection,
+					Conformation const & conformation,
+					bool lookup_bond_length
+					)
+			{
 
-	// confirm that both connections are defined entirely by atoms internal to their residues,
-	// so we don't need the conformation info (which might not be correct for the moving_rsd if we
-	// are in the process of adding it to the conformation)
-	//
-	runtime_assert( moving_connection.icoor().is_internal() && fixed_connection.icoor().is_internal() );
+				// confirm that both connections are defined entirely by atoms internal to their residues,
+				// so we don't need the conformation info (which might not be correct for the moving_rsd if we
+				// are in the process of adding it to the conformation)
+				//
+				runtime_assert( moving_connection.icoor().is_internal() && fixed_connection.icoor().is_internal() );
 
-	// a1 ---  a2  --- (a3)
-	//
-	//  (b2) ---  b3  --- b4
-	//
-	// a3 and b2 are the pseudo-atoms built from their respective residues using the ideal geometry in the
-	// corresponding ResidueConnection objects
-	//
-	Vector
-		a1(  fixed_connection.icoor().stub_atom2().xyz(  fixed_rsd, conformation ) ),
-		b4( moving_connection.icoor().stub_atom2().xyz( moving_rsd, conformation ) ),
+				// a1 ---  a2  --- (a3)
+				//
+				//  (b2) ---  b3  --- b4
+				//
+				// a3 and b2 are the pseudo-atoms built from their respective residues using the ideal geometry in the
+				// corresponding ResidueConnection objects
+				//
+				Vector
+					a1(  fixed_connection.icoor().stub_atom2().xyz(  fixed_rsd, conformation ) ),
+					b4( moving_connection.icoor().stub_atom2().xyz( moving_rsd, conformation ) ),
 
-		a2(  fixed_rsd.xyz(  fixed_connection.atomno() ) ),
-		b3( moving_rsd.xyz( moving_connection.atomno() ) ),
+					a2(  fixed_rsd.xyz(  fixed_connection.atomno() ) ),
+					b3( moving_rsd.xyz( moving_connection.atomno() ) ),
 
-		a3(  fixed_connection.icoor().build(  fixed_rsd, conformation ) ),
-		b2( moving_connection.icoor().build( moving_rsd, conformation ) );
+					a3(  fixed_connection.icoor().build(  fixed_rsd, conformation ) ),
+					b2( moving_connection.icoor().build( moving_rsd, conformation ) );
 
-	// we want to move b2 to align with a2 and b3 to align with a3. Torsion about the a2->a3 bond
-	// (ie the inter-residue bond) determined by atoms a1 and b4 (torsion set to 0 by default).
+				// we want to move b2 to align with a2 and b3 to align with a3. Torsion about the a2->a3 bond
+				// (ie the inter-residue bond) determined by atoms a1 and b4 (torsion set to 0 by default).
 
-	core::Size fixed_rsd_atom_type_index = fixed_rsd.atom_type_index(fixed_connection.atomno());
-	core::Size moving_rsd_atom_type_index = moving_rsd.atom_type_index(moving_connection.atomno());
-	if ( lookup_bond_length ) {
-		if ( TR.visible() ) {
-			TR << "moving atom_type_index " << moving_rsd_atom_type_index<< std::endl;
-			TR << "fixed atom_type_index " << fixed_rsd_atom_type_index<< std::endl;
-		}
+				core::Size fixed_rsd_atom_type_index = fixed_rsd.atom_type_index(fixed_connection.atomno());
+				core::Size moving_rsd_atom_type_index = moving_rsd.atom_type_index(moving_connection.atomno());
+				if ( lookup_bond_length ) {
+					if ( TR.visible() ) {
+						TR << "moving atom_type_index " << moving_rsd_atom_type_index<< std::endl;
+						TR << "fixed atom_type_index " << fixed_rsd_atom_type_index<< std::endl;
+					}
 
-		// Real bond_length= lookup_bond_length(fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
-		core::chemical::ChemicalManager *cm= core::chemical::ChemicalManager::get_instance();
-		core::chemical::IdealBondLengthSetCOP ideal_bond_lengths( cm->ideal_bond_length_set( core::chemical::FA_STANDARD ) );
+					// Real bond_length= lookup_bond_length(fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
+					core::chemical::ChemicalManager *cm= core::chemical::ChemicalManager::get_instance();
+					core::chemical::IdealBondLengthSetCOP ideal_bond_lengths( cm->ideal_bond_length_set( core::chemical::FA_STANDARD ) );
 
-		Real bond_length= ideal_bond_lengths->get_bond_length( fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
-		Vector old_bond= a3-a2;
-		Vector new_bond= old_bond;
-		// new_bond.normalize(2);
-		new_bond.normalize(bond_length);
-		Vector offset = new_bond - old_bond;
-
-
-		a3 += offset;
-		//b2 -= offset;
-	}
+					Real bond_length= ideal_bond_lengths->get_bond_length( fixed_rsd_atom_type_index, moving_rsd_atom_type_index);
+					Vector old_bond= a3-a2;
+					Vector new_bond= old_bond;
+					// new_bond.normalize(2);
+					new_bond.normalize(bond_length);
+					Vector offset = new_bond - old_bond;
 
 
-	kinematics::Stub A( a3, a2, a1 ), B( b3, b2, b4 );
-
-	for ( Size i=1; i<= moving_rsd.natoms(); ++i ) {
-		Vector global = A.local2global( B.global2local( moving_rsd.xyz(i)));
-		//global.z(global.z() -1.1);
-		moving_rsd.set_xyz(i, global );
-	}
-
-	Vector global_action_coord= A.local2global( B.global2local( moving_rsd.actcoord() ));
-	//global_action_coord.z(global_action_coord.z() -1.1);
-	//global_action_coord-=.47;
-	moving_rsd.actcoord() = global_action_coord;
-
-}
+					a3 += offset;
+					//b2 -= offset;
+				}
 
 
-///////////////////////////////////////////////////////////////////////////////////////
-void
-insert_ideal_mainchain_bonds(
-	Size const seqpos,
-	Conformation & conformation
-)
-{
-	using namespace id;
+				kinematics::Stub A( a3, a2, a1 ), B( b3, b2, b4 );
 
-	Residue const & rsd( conformation.residue( seqpos ) );
+				for ( Size i=1; i<= moving_rsd.natoms(); ++i ) {
+					Vector global = A.local2global( B.global2local( moving_rsd.xyz(i)));
+					//global.z(global.z() -1.1);
+					moving_rsd.set_xyz(i, global );
+				}
 
-	// create a mini-conformation with
-	ConformationOP idl_op( new Conformation() );
-	Conformation & idl = *idl_op;
-	{
-		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-		idl.append_residue_by_bond( *idl_rsd );
-	}
+				Vector global_action_coord= A.local2global( B.global2local( moving_rsd.actcoord() ));
+				//global_action_coord.z(global_action_coord.z() -1.1);
+				//global_action_coord-=.47;
+				moving_rsd.actcoord() = global_action_coord;
 
-	int idl_pos(1);
-
-	// intra-residue mainchain bonds and angles
-	Size const nbb( rsd.n_mainchain_atoms() );
-	runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
-	for ( Size i=2; i<= nbb; ++i ) {
-		AtomID
-			bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
-			bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
-			bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
-			bb2 ( rsd.mainchain_atom(  i),  seqpos );
-
-		// bond length
-		conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
-
-		if ( i<nbb ) {
-			AtomID
-				bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
-				bb3 ( rsd.mainchain_atom(i+1),  seqpos );
-
-			// bond angle
-			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-		}
-	}
-
-	if ( seqpos>1 && rsd.is_polymer() && !rsd.is_lower_terminus() ) {
-		ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
-		idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
-		idl_pos = 2;
-
-		Size const nbb_prev( prev_rsd->n_mainchain_atoms() );
-		AtomID
-			bb1_idl( prev_rsd->mainchain_atom( nbb_prev ), idl_pos-1 ),
-			bb1 ( prev_rsd->mainchain_atom( nbb_prev ),  seqpos-1 ),
-			bb2_idl( rsd.mainchain_atom( 1 ), idl_pos ),
-			bb2 ( rsd.mainchain_atom( 1 ),  seqpos ),
-			bb3_idl( rsd.mainchain_atom( 2 ), idl_pos ),
-			bb3 ( rsd.mainchain_atom( 2 ),  seqpos );
-		conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-	}
-
-	if ( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() ) {
-		ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-		idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
-
-		AtomID
-			bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
-			bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
-			bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
-			bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
-			bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
-			bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 );
-
-		// bond angle
-		conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-
-		// bond length
-		conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
-	}
+			}
 
 
-}
+		///////////////////////////////////////////////////////////////////////////////////////
+		void
+			insert_ideal_mainchain_bonds(
+					Size const seqpos,
+					Conformation & conformation
+					)
+			{
+				using namespace id;
 
-/// @details  Just sets the two bond angles and the bond length between seqpos and seqpos+1
+				Residue const & rsd( conformation.residue( seqpos ) );
 
-void
-insert_ideal_bonds_at_polymer_junction(
-	Size const seqpos,
-	Conformation & conformation
-)
-{
-	using namespace id;
+				// create a mini-conformation with
+				ConformationOP idl_op( new Conformation() );
+				Conformation & idl = *idl_op;
+				{
+					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+					idl.append_residue_by_bond( *idl_rsd );
+				}
 
-	Residue const & rsd( conformation.residue( seqpos ) );
-	runtime_assert( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() );
+				int idl_pos(1);
 
-	if ( TR.Warning.visible() && conformation.fold_tree().is_cutpoint( seqpos ) ) {
-		TR.Warning << "insert_ideal_bonds_at_polymer_junction: seqpos (" << seqpos << ") is a foldtree cutpoint, " <<
-			"returning!" << std::endl;
-	}
+				// intra-residue mainchain bonds and angles
+				Size const nbb( rsd.n_mainchain_atoms() );
+				runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+				for ( Size i=2; i<= nbb; ++i ) {
+					AtomID
+						bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
+						bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
+						bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
+						bb2 ( rsd.mainchain_atom(  i),  seqpos );
 
-	// create a mini-conformation with ideal bond lengths and angles
-	ConformationOP idl_op( new Conformation() );
-	Conformation & idl = *idl_op;
-	{
-		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-		idl.append_residue_by_bond( *idl_rsd );
-	}
+					// bond length
+					conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
 
-	int idl_pos(1);
+					if ( i<nbb ) {
+						AtomID
+							bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
+							bb3 ( rsd.mainchain_atom(i+1),  seqpos );
 
-	Size const nbb( rsd.n_mainchain_atoms() );
-	runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+						// bond angle
+						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+					}
+				}
 
-	ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-	idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true /* append with ideal geometry */ );
+				if ( seqpos>1 && rsd.is_polymer() && !rsd.is_lower_terminus() ) {
+					ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
+					idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+					idl_pos = 2;
 
-	AtomID
-		bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
-		bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
-		bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
-		bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
-		bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
-		bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 ),
-		bb4_idl( next_rsd->mainchain_atom( 2 ), idl_pos+1 ),
-		bb4 ( next_rsd->mainchain_atom( 2 ),  seqpos+1 );
+					Size const nbb_prev( prev_rsd->n_mainchain_atoms() );
+					AtomID
+						bb1_idl( prev_rsd->mainchain_atom( nbb_prev ), idl_pos-1 ),
+						bb1 ( prev_rsd->mainchain_atom( nbb_prev ),  seqpos-1 ),
+						bb2_idl( rsd.mainchain_atom( 1 ), idl_pos ),
+						bb2 ( rsd.mainchain_atom( 1 ),  seqpos ),
+						bb3_idl( rsd.mainchain_atom( 2 ), idl_pos ),
+						bb3 ( rsd.mainchain_atom( 2 ),  seqpos );
+					conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+				}
 
-	// bond angle
-	conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+				if ( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() ) {
+					ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
+					idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
 
-	// bond length
-	conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+					AtomID
+						bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
+						bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
+						bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
+						bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
+						bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
+						bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 );
 
-	// bond angle
-	conformation.set_bond_angle( bb2, bb3, bb4, idl.bond_angle( bb2_idl, bb3_idl, bb4_idl ) );
+					// bond angle
+					conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
 
-	// fix up atoms that depend on the atoms across the bond for their torsion offsets
-	conformation.rebuild_polymer_bond_dependent_atoms( seqpos );
-
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////
-void
-idealize_position(
-	Size const seqpos,
-	Conformation & conformation
-)
-{
-	using namespace id;
-
-	runtime_assert( seqpos > 0 );
-	runtime_assert( conformation.size() >= seqpos );
-	runtime_assert( conformation.size() > 0 );
-	Residue const & rsd( conformation.residue( seqpos ) );
-
-	//// create a mini-conformation with completely ideal residue ( and nbrs, if appropriate )
-
-	ConformationOP idl_op( new Conformation() );
-	Conformation & idl = *idl_op;
-	{
-		ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
-		idl.append_residue_by_bond( *idl_rsd );
-	}
-
-	int idl_pos(1);
-	bool lower_connect( false ), upper_connect( false );
-
-	if ( rsd.is_polymer() ) {
-		// add polymer nbrs?
-		if ( seqpos > 1 && !rsd.is_lower_terminus() && !conformation.fold_tree().is_cutpoint( seqpos-1 ) ) {
-			lower_connect = true;
-			ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
-			idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
-			idl_pos = 2;
-		}
-
-		if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
-			upper_connect = true;
-			ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
-			idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
-		}
-	}
-
-	//// now set the torsion angles in the ideal conformation... This is to prepare for replacing rsd with
-	//// the idealized version
-
-	// chi angles
-	for ( Size i=1; i<= rsd.nchi(); ++i ) {
-		idl.set_torsion( TorsionID( idl_pos, CHI, i ), rsd.chi( i ) );
-	}
-	// mainchain torsions, if polymer residue
-	if ( rsd.is_polymer() ) {
-		Size const nbb( rsd.n_mainchain_atoms() );
-		for ( Size i=1; i<= nbb; ++i ) {
-			//if ( ( !lower_connect && i == 1 ) || ( !upper_connect && i >= nbb-1 ) ) continue;
-			idl.set_torsion( TorsionID( idl_pos, BB, i ), rsd.mainchain_torsion( i ) );
-		}
-	}
+					// bond length
+					conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+				}
 
 
-	//// now we copy the mainchain bond geometry from ideal conf into the conf to be idealized
-	if ( rsd.is_polymer() ) {
+			}
 
-		// intra-residue mainchain bonds and angles
-		Size const nbb( rsd.n_mainchain_atoms() );
-		runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
-		for ( Size i=2; i<= nbb; ++i ) {
-			AtomID
-				bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
-				bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
-				bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
-				bb2 ( rsd.mainchain_atom(  i),  seqpos );
+		/// @details  Just sets the two bond angles and the bond length between seqpos and seqpos+1
 
-			// bond length
-			conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
+		void
+			insert_ideal_bonds_at_polymer_junction(
+					Size const seqpos,
+					Conformation & conformation
+					)
+			{
+				using namespace id;
 
-			if ( i<nbb ) {
+				Residue const & rsd( conformation.residue( seqpos ) );
+				runtime_assert( seqpos < conformation.size() && rsd.is_polymer() && !rsd.is_upper_terminus() );
+
+				if ( TR.Warning.visible() && conformation.fold_tree().is_cutpoint( seqpos ) ) {
+					TR.Warning << "insert_ideal_bonds_at_polymer_junction: seqpos (" << seqpos << ") is a foldtree cutpoint, " <<
+						"returning!" << std::endl;
+				}
+
+				// create a mini-conformation with ideal bond lengths and angles
+				ConformationOP idl_op( new Conformation() );
+				Conformation & idl = *idl_op;
+				{
+					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+					idl.append_residue_by_bond( *idl_rsd );
+				}
+
+				int idl_pos(1);
+
+				Size const nbb( rsd.n_mainchain_atoms() );
+				runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+
+				ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
+				idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true /* append with ideal geometry */ );
+
 				AtomID
-					bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
-					bb3 ( rsd.mainchain_atom(i+1),  seqpos );
+					bb1_idl( rsd.mainchain_atom( nbb-1 ), idl_pos ),
+					bb1 ( rsd.mainchain_atom( nbb-1 ),  seqpos ),
+					bb2_idl( rsd.mainchain_atom( nbb   ), idl_pos ),
+					bb2 ( rsd.mainchain_atom( nbb   ),  seqpos ),
+					bb3_idl( next_rsd->mainchain_atom( 1 ), idl_pos+1 ),
+					bb3 ( next_rsd->mainchain_atom( 1 ),  seqpos+1 ),
+					bb4_idl( next_rsd->mainchain_atom( 2 ), idl_pos+1 ),
+					bb4 ( next_rsd->mainchain_atom( 2 ),  seqpos+1 );
 
 				// bond angle
 				conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-			}
-		}
 
-		if ( lower_connect ) {
-			Residue const & prev_rsd( idl.residue( idl_pos-1 ) );
+				// bond length
+				conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
 
-			Size const nbb_prev( prev_rsd.n_mainchain_atoms() );
-			AtomID
-				bb1_idl( prev_rsd.mainchain_atom( nbb_prev ), idl_pos-1 ),
-				bb1 ( prev_rsd.mainchain_atom( nbb_prev ),  seqpos-1 ),
-				bb2_idl(   rsd.mainchain_atom(  1 ), idl_pos   ),
-				bb2 (   rsd.mainchain_atom(  1 ),  seqpos   ),
-				bb3_idl(   rsd.mainchain_atom(  2 ), idl_pos   ),
-				bb3 (   rsd.mainchain_atom(  2 ),  seqpos   );
-			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-		}
+				// bond angle
+				conformation.set_bond_angle( bb2, bb3, bb4, idl.bond_angle( bb2_idl, bb3_idl, bb4_idl ) );
 
-		if ( upper_connect ) {
-			Residue const & next_rsd( idl.residue( idl_pos+1 ) );
+				// fix up atoms that depend on the atoms across the bond for their torsion offsets
+				conformation.rebuild_polymer_bond_dependent_atoms( seqpos );
 
-			AtomID
-				bb1_idl(   rsd.mainchain_atom( nbb-1 ), idl_pos   ),
-				bb1 (   rsd.mainchain_atom( nbb-1 ),  seqpos   ),
-				bb2_idl(   rsd.mainchain_atom( nbb   ), idl_pos   ),
-				bb2 (   rsd.mainchain_atom( nbb   ),  seqpos   ),
-				bb3_idl( next_rsd.mainchain_atom(  1 ), idl_pos+1 ),
-				bb3 ( next_rsd.mainchain_atom(  1 ),  seqpos+1 );
-
-			// bond angle
-			conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
-
-			// bond length
-			conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
-		}
-	} // rsd.is_polymer()
-
-
-	//// now we orient the ideal residue onto the existing residue and replace it
-	ResidueOP idl_rsd( idl.residue( idl_pos ).clone() );
-
-	// EXTREMELY SUBTLE DANGEROUS THING ABOUT HAVING Residue const &'s lying around:
-	// if we put "rsd" in place of conformation.residue( seqpos ) below, this will not behave properly.
-	// that's because the xyz's in rsd don't get updated properly to reflect the changes to the conformation
-	// a "refold" is only triggered by another call to conformation.residue
-	// May want to consider making Residue smarter about this kind of thing, ie knowing its from a
-	// Conformation... acting as an observer... could get pretty tricky though...
-	//
-	idl_rsd->orient_onto_residue( conformation.residue( seqpos ) ); // can't use rsd here!
-	conformation.replace_residue( seqpos, *idl_rsd, false );
-
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////
-// NOTE: conformation is needed for polymer neighbours
-// @author Barak 07/2009
-bool
-is_ideal_position(
-	Size const seqpos,
-	Conformation const & conf,
-	Real theta_epsilon,
-	Real D_epsilon
-)
-{
-	using namespace core::kinematics;
-	runtime_assert( conf.size() >= seqpos  &&  seqpos >= 1 );
-
-	Residue const rsd( conf.residue( seqpos ) );
-
-	// I. Create mini-conformations for both idealized and original residue + nbrs, if appropriate )
-	ConformationOP miniconf_op( new Conformation() );
-	Conformation & miniconf = *miniconf_op;
-	ConformationOP miniconf_idl_op( new Conformation() );
-	Conformation & miniconf_idl = *miniconf_idl_op;
-	{
-		miniconf.append_residue_by_bond( rsd );
-		ResidueOP prsd_idl( ResidueFactory::create_residue( rsd.type() ) );
-		miniconf_idl.append_residue_by_bond( *prsd_idl );
-	}
-	// add polymer nbrs if needed
-	int seqpos_miniconf(1);
-	//bool lower_connect( false ), upper_connect( false );
-	if ( rsd.is_polymer() ) {
-		// prepending previous neighbour
-		if ( seqpos > 1 && !rsd.is_lower_terminus() && !conf.fold_tree().is_cutpoint( seqpos-1 ) ) {
-			//lower_connect = true;  // set but never used ~Labonte
-			seqpos_miniconf = 2; // pushed forward by prependedq residue
-			Residue const & prev_rsd = conf.residue( seqpos-1 );
-			miniconf.safely_prepend_polymer_residue_before_seqpos // TODO: safely is probably unneeded here, verify this point
-				( prev_rsd, 1, false /*build_ideal_geom*/);
-			ResidueOP pprev_rsd_idl( ResidueFactory::create_residue( prev_rsd.type() ) );
-			miniconf_idl.safely_prepend_polymer_residue_before_seqpos
-				( *pprev_rsd_idl, 1, true /*build_ideal_geom*/);
-		}
-		// appending next neighbour
-		if ( seqpos < conf.size() && !rsd.is_upper_terminus() && !conf.fold_tree().is_cutpoint( seqpos ) ) {
-			//upper_connect = true;  // set but never used ~Labonte
-			Residue const & next_rsd = conf.residue( seqpos+1 );
-			miniconf.safely_append_polymer_residue_after_seqpos
-				( next_rsd, seqpos_miniconf, false /*build_ideal_geom*/ );
-			ResidueOP pnext_rsd_idl( ResidueFactory::create_residue( next_rsd.type() ) );
-			miniconf_idl.safely_append_polymer_residue_after_seqpos
-				( *pnext_rsd_idl, seqpos_miniconf, true /*build_ideal_geom*/ );
-		}
-	}
-
-
-	// II. Compare angle and length of all residue bonded atoms in the new mini-conformations
-	for ( Size atom = 1, atom_end = miniconf.residue( seqpos_miniconf ).natoms();
-			atom <= atom_end;
-			++atom ) {
-		id::AtomID aid(atom, seqpos_miniconf);
-		if ( miniconf.atom_tree().atom(aid).is_jump() ) { // skip non-bonded atoms
-			continue;
-		}
-		id::DOF_ID dof_theta(aid, id::THETA); // bond angle
-		id::DOF_ID dof_D(aid, id::D); // bond length
-		if ( ! numeric::equal_by_epsilon(
-				miniconf.dof( dof_theta ), miniconf_idl.dof( dof_theta ), theta_epsilon ) ) {
-			if ( TR.visible() ) {
-				TR << "Non-ideal residue detected: "
-					<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
-					<< " Ideal theta=" << miniconf_idl.dof( dof_theta)
-					<< ", Inspected theta=" << miniconf.dof( dof_theta )
-					<< " (in Radians)"
-					<< std::endl;
-			}
-			return false;
-		}
-		if ( ! numeric::equal_by_epsilon(
-				miniconf.dof( dof_D), miniconf_idl.dof (dof_D), D_epsilon ) ) {
-			if ( TR.visible() ) {
-				TR << "Non-ideal residue detected: "
-					<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
-					<< " Ideal D=" << miniconf_idl.dof( dof_D)
-					<< ", Inspected D=" << miniconf.dof( dof_D )
-					<< std::endl;
-			}
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
-/// @brief  Fills coords of target_rsd with coords from source_rsd of same atom_name, rebuilds others.
-/// @details  If preserve_only_sidechain_dihedrals is true, then this function only copies mainchain coordinates,
-/// and rebuilds all sidechain coordinates from scratch, setting side-chain dihedrals based on the source residue.
-/// Otherwise, if false, it copies all the atoms that it can from the source residue, then rebuilds the rest.
-/// @author Vikram K. Mulligan (vmullig@uw.edu)
-void
-copy_residue_coordinates_and_rebuild_missing_atoms(
-	Residue const & source_rsd,
-	Residue & target_rsd,
-	Conformation const & conformation,
-	bool const preserve_only_sidechain_dihedrals
-) {
-	target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-	target_rsd.chain ( source_rsd.chain () );
-
-	if ( preserve_only_sidechain_dihedrals ) { //If we're keeping only the sidechain dihedral information
-		Size const natoms(target_rsd.natoms());
-		bool any_missing(false);
-		utility::vector1< bool > missing( natoms, false );
-		Size const to_preserve = source_rsd.type().first_sidechain_atom() >= source_rsd.type().natoms() ? source_rsd.type().first_sidechain_atom() : source_rsd.n_mainchain_atoms();
-
-		for ( Size ia=1; ia<=natoms; ++ia ) { //Loop through all atoms
-			std::string const & atom_name( target_rsd.atom_name(ia) );
-			if ( ia <= to_preserve && source_rsd.has( atom_name ) ) {
-				target_rsd.atom(ia).xyz( source_rsd.atom(atom_name).xyz() );
-			} else {
-				if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
-				any_missing=true;
-				missing[ia]=true;
-			}
-		}
-		if ( any_missing ) {
-			target_rsd.fill_missing_atoms( missing, conformation );
-		}
-
-		//Set side-chain dihedrals
-		for ( core::Size i=1, imax=std::min( target_rsd.nchi(), source_rsd.nchi() ); i<=imax; ++i ) { //Loop through all shared chi angles
-			target_rsd.set_chi(i, source_rsd.chi(i)); //Set side-chain dihedral.
-		}
-
-	} else { //If we're trying to keep the sidechain atom position information
-		copy_residue_coordinates_and_rebuild_missing_atoms( source_rsd, target_rsd, conformation );
-	}
-	return;
-}
-
-
-/// @details  For building variant residues, eg
-/// @note  Need conformation for context in case we have to rebuild atoms, eg backbone H
-void
-copy_residue_coordinates_and_rebuild_missing_atoms(
-	Residue const & source_rsd,
-	Residue & target_rsd,
-	Conformation const & conformation
-)
-{
-	target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-	target_rsd.chain ( source_rsd.chain () );
-
-	Size const natoms( target_rsd.natoms() );
-
-	utility::vector1< bool > missing( natoms, false );
-	bool any_missing( false );
-
-	for ( Size i=1; i<= natoms; ++i ) {
-		std::string const & atom_name( target_rsd.atom_name(i) );
-		if ( source_rsd.has( atom_name ) ) {
-			target_rsd.atom( i ).xyz( source_rsd.atom( atom_name ).xyz() );
-		} else {
-			if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
-			any_missing = true;
-			missing[i] = true;
-		}
-	}
-
-	if ( any_missing ) {
-		target_rsd.fill_missing_atoms( missing, conformation );
-	}
-
-}
-
-/// @brief  Fills coords of target_rsd with coords from source_rsd using the provided mapping, rebuilds others
-/// The mapping is indexed by target_rsd atom index, giving source_rsd index or zero for not present.
-void
-copy_residue_coordinates_and_rebuild_missing_atoms(
-	Residue const & source_rsd,
-	Residue & target_rsd,
-	utility::vector1< core::Size > const & mapping,
-	Conformation const & conformation
-) {
-	Size const natoms( target_rsd.natoms() );
-
-	utility::vector1< bool > missing( natoms, false );
-	bool any_missing( false );
-
-	for ( Size i=1; i<= natoms; ++i ) {
-		if ( mapping.size() >= i && mapping[i] != 0 ) {
-			target_rsd.atom( i ).xyz( source_rsd.atom( mapping[i] ).xyz() );
-		} else {
-			TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' <<
-				target_rsd.atom_name(i) << std::endl;
-			any_missing = true;
-			missing[i] = true;
-		}
-	}
-
-	if ( any_missing ) {
-		target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
-		target_rsd.chain ( source_rsd.chain () );
-		target_rsd.fill_missing_atoms( missing, conformation );
-	}
-}
-
-/// @details  Helper function for below
-std::ostream &
-print_atom( id::AtomID const & id, Conformation const & conf, std::ostream & os )
-{
-	Residue const & rsd( conf.residue(id.rsd() ) );
-	os << rsd.atom_name( id.atomno() ) << " (" << id.atomno() << ") " << rsd.name() << ' ' << rsd.seqpos();
-	return os;
-}
-
-/// @brief Given two residues, check that they are compatible types to be connected via a cutpoint.
-/// @author Vikram K. Mulligan (vmullig@uw.edu).
-void
-check_good_cutpoint_neighbour(
-	core::conformation::Residue const &thisres,
-	core::conformation::Residue const &other_res
-) {
-	core::chemical::ResidueType const &thistype( thisres.type() );
-	runtime_assert_string_msg(
-		thistype.is_alpha_aa() || thistype.is_beta_aa() || thistype.is_gamma_aa() ||
-		thistype.is_sri() || thistype.has_property(core::chemical::TRIAZOLE_LINKER) ||
-		thistype.is_peptoid() || thistype.is_carbohydrate() || thistype.is_NA() || thistype.is_oligourea() ||
-		thistype.is_aramid()
-		|| thistype.has_property( chemical::TNA ) ,
-		"Error in core::conformation::check_good_cutpoint_neighbour(): The selected residue is neither an alpha-, beta-, or gamma-amino acid, nor a peptoid, nor a sugar, nor a nucleic acid, nor an oligourea.  Nevertheless, it has a cutpoint variant type.  This should not be possible."
-	);
-
-	if ( thistype.is_carbohydrate() ) {
-		//JASON JASON JASON if ever you need cutpoints between sugar and something else, this is
-		//one spot to make a change.  -VKM
-		runtime_assert_string_msg(
-			other_res.type().is_carbohydrate(),
-			"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a carbohydrate via a cutpoint is not itself a carbohydrate."
-		);
-	} else if ( thistype.is_NA() ) {
-		//AMW TODO: Andy, if ever you need RNA to connect to something other than RNA (or DNA) via a cutpoint, this is
-		//one place to make a change.  -VKM
-		runtime_assert_string_msg(
-			other_res.type().is_polymer(),
-			"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a nucleic acid via a cutpoint is not itself a DNA or RNA residue."
-		);
-	} else {
-		runtime_assert_string_msg(
-			other_res.type().is_alpha_aa() || other_res.type().is_beta_aa() || other_res.type().is_gamma_aa() || other_res.type().is_peptoid() || other_res.type().is_oligourea() || other_res.type().is_aramid() || other_res.type().is_RNA() || other_res.type().has_property( chemical::TNA ),
-			"Error in core::conformation::check_good_cutpoint_neighbour(): The connected residue is neither a peptoid, nor an oligourea, nor an alpha-, beta-, or gamma-amino acid."
-		);
-	}
-}
-
-/// @brief Given a conformation and a position that may or may not be CUTPOINT_UPPER or CUTPOINT_LOWER, determine whether this
-/// position has either of these variant types, and if it does, determine whether it's connected to anything.  If it is,
-/// update the C-OVL1-OVL2 bond lengths and bond angle (for CUTPOINT_LOWER) or OVU1-N bond length (for CUTPOINT_UPPER) to
-/// match any potentially non-ideal geometry in the residue to which it's bonded.
-/// @details Requires a little bit of special-casing for gamma-amino acids.  Throws an exception if the residue to which
-/// a CUTPOINT_LOWER is bonded does not have an "N" and a "CA" or "C4".  Safe to call repeatedly, or if cutpoint variant
-/// types are absent; in these cases, the function does nothing.
-/// @note By default, this function calls itself again once on residues to which this residue is connected, to update their
-/// geometry.  Set recurse=false to disable this.
-/// @author Vikram K. Mulligan (vmullig@uw.edu).
-void
-update_cutpoint_virtual_atoms_if_connected(
-	core::conformation::Conformation & conf,
-	core::Size const cutpoint_res,
-	bool recurse /*= true*/
-) {
-	core::conformation::Residue const &thisres( conf.residue(cutpoint_res) );
-	if ( thisres.is_RNA() ) return;
-	if ( !thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) && !thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) return; //Do nothing if no upper or lower cutpoint type.
-
-	if ( thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) ) {
-		core::Size const other_res_index( thisres.connected_residue_at_upper() ); //The residue to which I'm connected at my upper connection.
-		if ( other_res_index != 0 ) {
-			core::conformation::Residue const & other_res( conf.residue(other_res_index) );
-			check_good_cutpoint_neighbour( thisres, other_res );
-			core::Real const dist1( other_res.lower_connect().icoor().d() ); //Distance from LOWER to N.
-			core::Real const angle2( other_res.lower_connect().icoor().theta() ); //Note that this is Pi-bondangle, in radians.
-			core::Real const dist2( other_res.xyz( other_res.lower_connect().icoor().stub_atom1().atomno() ).distance( other_res.xyz( other_res.lower_connect().icoor().stub_atom2().atomno() ) ) ); //Distance from N to CA (or N to C4 in gamma-aas).
-
-			core::chemical::AtomICoor const & ovl1_icoor ( thisres.icoor(thisres.atom_index("OVL1")) );
-			core::chemical::AtomICoor ovl1_new_icoor("OVL1", ovl1_icoor.phi(), ovl1_icoor.theta(),
-				dist1, thisres.atom_name( ovl1_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom3().atomno() ), thisres.type());
-			conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL1"), cutpoint_res), ovl1_new_icoor.build( thisres, conf ) );
-
-			if ( !thisres.type().is_carbohydrate() && !other_res.type().is_carbohydrate() ) { //JASON JASON JASON -- this is the other special-case thing for carbohydrates.  -VKM
-				core::chemical::AtomICoor const & ovl2_icoor ( thisres.icoor(thisres.atom_index("OVL2")) );
-				core::chemical::AtomICoor ovl2_new_icoor("OVL2", ovl2_icoor.phi(), angle2,
-					dist2, thisres.atom_name( ovl2_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom3().atomno() ), thisres.type());
-				conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL2"), cutpoint_res), ovl2_new_icoor.build( thisres, conf ) );
 			}
 
-			if ( recurse ) {
-				update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+
+		///////////////////////////////////////////////////////////////////////////////////////
+		void
+			idealize_position(
+					Size const seqpos,
+					Conformation & conformation
+					)
+			{
+				using namespace id;
+
+				runtime_assert( seqpos > 0 );
+				runtime_assert( conformation.size() >= seqpos );
+				runtime_assert( conformation.size() > 0 );
+				Residue const & rsd( conformation.residue( seqpos ) );
+
+				//// create a mini-conformation with completely ideal residue ( and nbrs, if appropriate )
+
+				ConformationOP idl_op( new Conformation() );
+				Conformation & idl = *idl_op;
+				{
+					ResidueOP idl_rsd( ResidueFactory::create_residue( rsd.type() ) );
+					idl.append_residue_by_bond( *idl_rsd );
+				}
+
+				int idl_pos(1);
+				bool lower_connect( false ), upper_connect( false );
+
+				if ( rsd.is_polymer() ) {
+					// add polymer nbrs?
+					if (rsd.is_carbohydrate()){
+						if ( seqpos > 1 && !rsd.is_lower_terminus()) {
+							lower_connect = true;
+							core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( rsd ) );
+							ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( parent_res_seqpos ).type() ) );
+							idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+							idl_pos = 2;
+						}
+
+						if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
+							upper_connect = true;
+							core::Size child_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_mainchain_child( rsd ) );
+							ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( child_res_seqpos ).type() ) );
+							idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
+						}
+					}else{
+						if ( seqpos > 1 && !rsd.is_lower_terminus() && !conformation.fold_tree().is_cutpoint( seqpos-1 ) ) {
+							lower_connect = true;
+							ResidueOP prev_rsd( ResidueFactory::create_residue( conformation.residue( seqpos-1 ).type() ) );
+							idl.prepend_polymer_residue_before_seqpos( *prev_rsd, 1, true );
+							idl_pos = 2;
+						}
+
+						if ( seqpos < conformation.size() && !rsd.is_upper_terminus() && !conformation.fold_tree().is_cutpoint( seqpos ) ) {
+							upper_connect = true;
+							ResidueOP next_rsd( ResidueFactory::create_residue( conformation.residue( seqpos+1 ).type() ) );
+							idl.append_polymer_residue_after_seqpos( *next_rsd, idl_pos, true );
+						}
+					}
+				}
+				//// now set the torsion angles in the ideal conformation... This is to prepare for replacing rsd with
+				//// the idealized version
+
+				// chi angles
+				for ( Size i=1; i<= rsd.nchi(); ++i ) {
+					idl.set_torsion( TorsionID( idl_pos, CHI, i ), rsd.chi( i ) );
+				}
+				// mainchain torsions, if polymer residue
+				if ( rsd.is_polymer() ) {
+					Size const nbb( rsd.n_mainchain_atoms() );
+					for ( Size i=1; i<= nbb; ++i ) {
+						//if ( ( !lower_connect && i == 1 ) || ( !upper_connect && i >= nbb-1 ) ) continue;
+						idl.set_torsion( TorsionID( idl_pos, BB, i ), rsd.mainchain_torsion( i ) );
+					}
+				}
+
+
+				//// now we copy the mainchain bond geometry from ideal conf into the conf to be idealized
+				if ( rsd.is_polymer() ) {
+
+					// intra-residue mainchain bonds and angles
+					Size const nbb( rsd.n_mainchain_atoms() );
+					runtime_assert( nbb >= 2 ); // or logic gets a bit trickier
+					for ( Size i=2; i<= nbb; ++i ) {
+						AtomID
+							bb1_idl( rsd.mainchain_atom(i-1), idl_pos ),
+							bb1 ( rsd.mainchain_atom(i-1),  seqpos ),
+							bb2_idl( rsd.mainchain_atom(  i), idl_pos ),
+							bb2 ( rsd.mainchain_atom(  i),  seqpos );
+
+						// bond length
+						conformation.set_bond_length( bb1, bb2, idl.bond_length( bb1_idl, bb2_idl ) );
+
+						if ( i<nbb ) {
+							AtomID
+								bb3_idl( rsd.mainchain_atom(i+1), idl_pos ),
+								bb3 ( rsd.mainchain_atom(i+1),  seqpos );
+
+							// bond angle
+							conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+						}
+					}
+
+					if ( lower_connect ) {
+						Residue const & prev_rsd( idl.residue( idl_pos-1 ) );
+
+						Size const nbb_prev( prev_rsd.n_mainchain_atoms() );
+						AtomID
+							bb1_idl( prev_rsd.mainchain_atom( nbb_prev ), idl_pos-1 ),
+							bb1 ( prev_rsd.mainchain_atom( nbb_prev ),  seqpos-1 ),
+							bb2_idl(   rsd.mainchain_atom(  1 ), idl_pos   ),
+							bb2 (   rsd.mainchain_atom(  1 ),  seqpos   ),
+							bb3_idl(   rsd.mainchain_atom(  2 ), idl_pos   ),
+							bb3 (   rsd.mainchain_atom(  2 ),  seqpos   );
+						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+					}
+
+					if ( upper_connect ) {
+						Residue const & next_rsd( idl.residue( idl_pos+1 ) );
+
+						AtomID
+							bb1_idl(   rsd.mainchain_atom( nbb-1 ), idl_pos   ),
+							bb1 (   rsd.mainchain_atom( nbb-1 ),  seqpos   ),
+							bb2_idl(   rsd.mainchain_atom( nbb   ), idl_pos   ),
+							bb2 (   rsd.mainchain_atom( nbb   ),  seqpos   ),
+							bb3_idl( next_rsd.mainchain_atom(  1 ), idl_pos+1 ),
+							bb3 ( next_rsd.mainchain_atom(  1 ),  seqpos+1 );
+
+						// bond angle
+						conformation.set_bond_angle( bb1, bb2, bb3, idl.bond_angle( bb1_idl, bb2_idl, bb3_idl ) );
+
+						// bond length
+						conformation.set_bond_length( bb2, bb3, idl.bond_length( bb2_idl, bb3_idl ) );
+					}
+				} // rsd.is_polymer()
+
+
+				//// now we orient the ideal residue onto the existing residue and replace it
+				ResidueOP idl_rsd( idl.residue( idl_pos ).clone() );
+
+				// EXTREMELY SUBTLE DANGEROUS THING ABOUT HAVING Residue const &'s lying around:
+				// if we put "rsd" in place of conformation.residue( seqpos ) below, this will not behave properly.
+				// that's because the xyz's in rsd don't get updated properly to reflect the changes to the conformation
+				// a "refold" is only triggered by another call to conformation.residue
+				// May want to consider making Residue smarter about this kind of thing, ie knowing its from a
+				// Conformation... acting as an observer... could get pretty tricky though...
+				//
+				idl_rsd->orient_onto_residue( conformation.residue( seqpos ) ); // can't use rsd here!
+				conformation.replace_residue( seqpos, *idl_rsd, false );
+
 			}
-		}
-	}
-	if ( thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) {
-		core::Size const other_res_index( thisres.connected_residue_at_lower() ); //The residue to which I'm connected at my lower connection.
-		if ( other_res_index != 0 ) {
-			core::conformation::Residue const & other_res( conf.residue(other_res_index) );
-			check_good_cutpoint_neighbour( thisres, other_res );
-			core::Real const dist1( other_res.upper_connect().icoor().d() ); //Distance from UPPER to C.
 
-			core::chemical::AtomICoor const & ovu1_icoor ( thisres.icoor(thisres.atom_index("OVU1")) );
-			core::chemical::AtomICoor ovu1_new_icoor("OVU1", ovu1_icoor.phi(), ovu1_icoor.theta(), dist1,
-				thisres.atom_name( ovu1_icoor.stub_atom1().atomno() ),
-				thisres.atom_name( ovu1_icoor.stub_atom2().atomno() ),
-				ovu1_icoor.stub_atom3().atomno() == 0 ? "LOWER" : thisres.atom_name( ovu1_icoor.stub_atom3().atomno() ), //In some cases, the third stub atom is the lower connection.
-				thisres.type()
-			);
-			conf.set_xyz( core::id::AtomID(thisres.atom_index("OVU1"), cutpoint_res), ovu1_new_icoor.build(thisres, conf ) );
 
-			if ( recurse ) {
-				update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+		///////////////////////////////////////////////////////////////////////////////////////
+		// NOTE: conformation is needed for polymer neighbours
+		// @author Barak 07/2009
+		bool
+			is_ideal_position(
+					Size const seqpos,
+					Conformation const & conf,
+					Real theta_epsilon,
+					Real D_epsilon
+					)
+			{
+				using namespace core::kinematics;
+				runtime_assert( conf.size() >= seqpos  &&  seqpos >= 1 );
+
+				Residue const rsd( conf.residue( seqpos ) );
+
+				// I. Create mini-conformations for both idealized and original residue + nbrs, if appropriate )
+				ConformationOP miniconf_op( new Conformation() );
+				Conformation & miniconf = *miniconf_op;
+				ConformationOP miniconf_idl_op( new Conformation() );
+				Conformation & miniconf_idl = *miniconf_idl_op;
+				{
+					miniconf.append_residue_by_bond( rsd );
+					ResidueOP prsd_idl( ResidueFactory::create_residue( rsd.type() ) );
+					miniconf_idl.append_residue_by_bond( *prsd_idl );
+				}
+				// add polymer nbrs if needed
+				int seqpos_miniconf(1);
+				//bool lower_connect( false ), upper_connect( false );
+				if ( rsd.is_polymer() ) {
+					// prepending previous neighbour
+					if ( seqpos > 1 && !rsd.is_lower_terminus() && !conf.fold_tree().is_cutpoint( seqpos-1 ) ) {
+						//lower_connect = true;  // set but never used ~Labonte
+						seqpos_miniconf = 2; // pushed forward by prependedq residue
+						Residue const & prev_rsd = conf.residue( seqpos-1 );
+						miniconf.safely_prepend_polymer_residue_before_seqpos // TODO: safely is probably unneeded here, verify this point
+							( prev_rsd, 1, false /*build_ideal_geom*/);
+						ResidueOP pprev_rsd_idl( ResidueFactory::create_residue( prev_rsd.type() ) );
+						miniconf_idl.safely_prepend_polymer_residue_before_seqpos
+							( *pprev_rsd_idl, 1, true /*build_ideal_geom*/);
+					}
+					// appending next neighbour
+					if ( seqpos < conf.size() && !rsd.is_upper_terminus() && !conf.fold_tree().is_cutpoint( seqpos ) ) {
+						//upper_connect = true;  // set but never used ~Labonte
+						Residue const & next_rsd = conf.residue( seqpos+1 );
+						miniconf.safely_append_polymer_residue_after_seqpos
+							( next_rsd, seqpos_miniconf, false /*build_ideal_geom*/ );
+						ResidueOP pnext_rsd_idl( ResidueFactory::create_residue( next_rsd.type() ) );
+						miniconf_idl.safely_append_polymer_residue_after_seqpos
+							( *pnext_rsd_idl, seqpos_miniconf, true /*build_ideal_geom*/ );
+					}
+				}
+
+
+				// II. Compare angle and length of all residue bonded atoms in the new mini-conformations
+				for ( Size atom = 1, atom_end = miniconf.residue( seqpos_miniconf ).natoms();
+						atom <= atom_end;
+						++atom ) {
+					id::AtomID aid(atom, seqpos_miniconf);
+					if ( miniconf.atom_tree().atom(aid).is_jump() ) { // skip non-bonded atoms
+						continue;
+					}
+					id::DOF_ID dof_theta(aid, id::THETA); // bond angle
+					id::DOF_ID dof_D(aid, id::D); // bond length
+					if ( ! numeric::equal_by_epsilon(
+								miniconf.dof( dof_theta ), miniconf_idl.dof( dof_theta ), theta_epsilon ) ) {
+						if ( TR.visible() ) {
+							TR << "Non-ideal residue detected: "
+								<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
+								<< " Ideal theta=" << miniconf_idl.dof( dof_theta)
+								<< ", Inspected theta=" << miniconf.dof( dof_theta )
+								<< " (in Radians)"
+								<< std::endl;
+						}
+						return false;
+					}
+					if ( ! numeric::equal_by_epsilon(
+								miniconf.dof( dof_D), miniconf_idl.dof (dof_D), D_epsilon ) ) {
+						if ( TR.visible() ) {
+							TR << "Non-ideal residue detected: "
+								<< " Residue #" << seqpos << " atom #" << atom << "( " << rsd.atom_name( atom ) << " ) " << ": "
+								<< " Ideal D=" << miniconf_idl.dof( dof_D)
+								<< ", Inspected D=" << miniconf.dof( dof_D )
+								<< std::endl;
+						}
+						return false;
+					}
+				}
+
+				return true;
 			}
-		}
-	}
-	conf.update_actcoord( cutpoint_res );
-}
-
-void
-show_atom_tree(
-	kinematics::tree::Atom const & atom,
-	Conformation const & conf, std::ostream & os
-) {
-	os << "ATOM "; print_atom( atom.id(), conf, os ) << std::endl;
-	os << "CHILDREN: ";
-	for ( Size i=0; i< atom.n_children(); ++i ) {
-		print_atom( atom.child(i)->id(), conf, os ) << ' ';
-	}
-	os << std::endl;
-	for ( Size i=0; i< atom.n_children(); ++i ) {
-		show_atom_tree( *atom.child(i), conf, os );
-	}
-}
-
-/// helper function for residue replacement/residuetype switching
-/// @note  Will call new_rsd->fill_missing_atoms if the new residue has atoms
-/// that the old one doesn't
-
-void
-replace_conformation_residue_copying_existing_coordinates(
-	conformation::Conformation & conformation,
-	Size const seqpos,
-	chemical::ResidueType const & new_rsd_type
-)
-{
-
-	Residue const & old_rsd( conformation.residue( seqpos ) );
-	ResidueOP new_rsd( ResidueFactory::create_residue( new_rsd_type ) );
-	conformation::copy_residue_coordinates_and_rebuild_missing_atoms( old_rsd, *new_rsd, conformation );
-	conformation.replace_residue( seqpos, *new_rsd, false );
-
-}
 
 
-/// @details E.g., make a terminus variant, and replace the original in pose.
-/// @note This copies any atoms in common between old and new residues, rebuilding the others.
-void
-add_variant_type_to_conformation_residue(
-	conformation::Conformation & conformation,
-	chemical::VariantType const variant_type,
-	Size const seqpos )
-{
-	Residue const & old_rsd( conformation.residue( seqpos ) );
+		/// @brief  Fills coords of target_rsd with coords from source_rsd of same atom_name, rebuilds others.
+		/// @details  If preserve_only_sidechain_dihedrals is true, then this function only copies mainchain coordinates,
+		/// and rebuilds all sidechain coordinates from scratch, setting side-chain dihedrals based on the source residue.
+		/// Otherwise, if false, it copies all the atoms that it can from the source residue, then rebuilds the rest.
+		/// @author Vikram K. Mulligan (vmullig@uw.edu)
+		void
+			copy_residue_coordinates_and_rebuild_missing_atoms(
+					Residue const & source_rsd,
+					Residue & target_rsd,
+					Conformation const & conformation,
+					bool const preserve_only_sidechain_dihedrals
+					) {
+				target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+				target_rsd.chain ( source_rsd.chain () );
 
-	// the type of the desired variant residue
-	chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
-	chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_added( old_rsd.type(), variant_type ) );
+				if ( preserve_only_sidechain_dihedrals ) { //If we're keeping only the sidechain dihedral information
+					Size const natoms(target_rsd.natoms());
+					bool any_missing(false);
+					utility::vector1< bool > missing( natoms, false );
+					Size const to_preserve = source_rsd.type().first_sidechain_atom() >= source_rsd.type().natoms() ? source_rsd.type().first_sidechain_atom() : source_rsd.n_mainchain_atoms();
 
-	core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
-}
+					for ( Size ia=1; ia<=natoms; ++ia ) { //Loop through all atoms
+						std::string const & atom_name( target_rsd.atom_name(ia) );
+						if ( ia <= to_preserve && source_rsd.has( atom_name ) ) {
+							target_rsd.atom(ia).xyz( source_rsd.atom(atom_name).xyz() );
+						} else {
+							if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
+							any_missing=true;
+							missing[ia]=true;
+						}
+					}
+					if ( any_missing ) {
+						target_rsd.fill_missing_atoms( missing, conformation );
+					}
 
+					//Set side-chain dihedrals
+					for ( core::Size i=1, imax=std::min( target_rsd.nchi(), source_rsd.nchi() ); i<=imax; ++i ) { //Loop through all shared chi angles
+						target_rsd.set_chi(i, source_rsd.chi(i)); //Set side-chain dihedral.
+					}
 
-/// @details E.g., remove a terminus variant, and replace the original in pose.
-/// @note This copies any atoms in common between old and new residues, rebuilding the others.
-void
-remove_variant_type_from_conformation_residue(
-	conformation::Conformation & conformation,
-	chemical::VariantType const variant_type,
-	Size const seqpos )
-{
-	Residue const & old_rsd( conformation.residue( seqpos ) );
-
-	// the type of the desired variant residue
-	chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
-	chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_removed( old_rsd.type(), variant_type ) );
-
-	core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-void
-add_lower_terminus_type_to_conformation_residue(
-	conformation::Conformation & conformation,
-	Size const seqpos
-)
-{
-	core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
-}
-
-///////////////////////////////////////////////////////////////////////////////
-void
-remove_lower_terminus_type_from_conformation_residue(
-	conformation::Conformation & conformation,
-	Size const seqpos
-)
-{
-	remove_variant_type_from_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
-	remove_variant_type_from_conformation_residue( conformation, chemical::LOWERTERM_TRUNC_VARIANT, seqpos );
-}
-
-///////////////////////////////////////////////////////////////////////////////
-void
-add_upper_terminus_type_to_conformation_residue(
-	conformation::Conformation & conformation,
-	Size const seqpos
-)
-{
-	core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
-}
-
-///////////////////////////////////////////////////////////////////////////////
-void
-remove_upper_terminus_type_from_conformation_residue(
-	conformation::Conformation & conformation,
-	Size const seqpos
-)
-{
-	remove_variant_type_from_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
-	remove_variant_type_from_conformation_residue( conformation, chemical::UPPERTERM_TRUNC_VARIANT, seqpos );
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-/// @details  Build an atom-tree from a fold-tree and a set of residues
-/// atoms in the tree are allocated with new (on the heap) and held in owning pointers in atom_pointer
-/// @note  atom_pointer is cleared at the beginning and then filled with AtomOPs to all the atoms
-
-
-void
-build_tree(
-	kinematics::FoldTree const & fold_tree,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomPointer2D & atom_pointer
-)
-{
-	using conformation::Residue;
-
-	// note -- we clear atom_pointer
-	atom_pointer.clear();
-	atom_pointer.resize( residues.size() );
-
-	// build first atom. make it a "JumpAtom"
-	{
-		int const start_pos( fold_tree.root() );
-		Residue const & rsd( *(residues[start_pos]) );
-
-		build_residue_tree( residues, rsd, fold_tree, atom_pointer[ start_pos ] );
-
-	}
-
-	// traverse tree, build edges
-	for ( auto const & it : fold_tree ) {
-
-		if ( it.is_jump() ) {
-			build_jump_edge( it, residues, atom_pointer );
-
-		} else if ( it.label() == kinematics::Edge::PEPTIDE ) {
-			// build a peptide edge
-			build_polymer_edge( it, residues, atom_pointer );
-
-		} else if ( it.label() == kinematics::Edge::CHEMICAL ) {
-			build_chemical_edge( it, residues, atom_pointer );
-
-		} else {
-			if ( TR.Error.visible() ) {
-				TR.Error << "Failed to identify kinematics::Edge label in core/kinematics/util.cc::build_tree()" << std::endl;
-				TR.Error << "Label = " << it.label() << std::endl;
+				} else { //If we're trying to keep the sidechain atom position information
+					copy_residue_coordinates_and_rebuild_missing_atoms( source_rsd, target_rsd, conformation );
+				}
+				return;
 			}
-			utility_exit();
-		}
-	}
-
-	// now guarantee that jump stubs are residue-internal if desired
-	for ( auto const & it : fold_tree ) {
-		if ( it.is_jump() && it.keep_stub_in_residue() ) {
-			promote_sameresidue_child_of_jump_atom( it, residues, atom_pointer );
-		}
-	}
-}
 
 
-///////////////////////////////////////////////////////////////////////////////
-/// @details root_atomno is the root for the sub atom-tree of this edge.
-/// anchor_atomno is the entry point of this sub atom-tree into the main atom-tree.
+		/// @details  For building variant residues, eg
+		/// @note  Need conformation for context in case we have to rebuild atoms, eg backbone H
+		void
+			copy_residue_coordinates_and_rebuild_missing_atoms(
+					Residue const & source_rsd,
+					Residue & target_rsd,
+					Conformation const & conformation
+					)
+			{
+				target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+				target_rsd.chain ( source_rsd.chain () );
 
-void
-build_jump_edge(
-	kinematics::Edge const & edge,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomPointer2D & atom_pointer
-)
-{
-	debug_assert( edge.is_jump() );
+				Size const natoms( target_rsd.natoms() );
 
-	int const estart  ( edge.start() );
-	int const estop   ( edge.stop () );
+				utility::vector1< bool > missing( natoms, false );
+				bool any_missing( false );
 
-	// these may have been set in the edge
-	Size anchor_atomno, root_atomno;
-	get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
+				for ( Size i=1; i<= natoms; ++i ) {
+					std::string const & atom_name( target_rsd.atom_name(i) );
+					if ( source_rsd.has( atom_name ) ) {
+						target_rsd.atom( i ).xyz( source_rsd.atom( atom_name ).xyz() );
+					} else {
+						if ( TR.Debug.visible() ) TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' << atom_name << std::endl;
+						any_missing = true;
+						missing[i] = true;
+					}
+				}
 
-	// get the anchor atom
-	kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
-	debug_assert( anchor_atom );
+				if ( any_missing ) {
+					target_rsd.fill_missing_atoms( missing, conformation );
+				}
 
-	// build the new residue
-	build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], true /*Jump*/ );
-
-	// now wire in the new residue connection
-	anchor_atom->insert_atom( atom_pointer[ id::AtomID( root_atomno, estop ) ] );
-
-
-	//  std::cout << "build_jump_edge: " << edge << ' ' <<  estop << ' ' << root_atomno << ' ' <<
-	//   estart << ' ' << anchor_atomno << std::endl;
-
-	//  std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
-	//  anchor_atom->show();
-	// debug_assert( anchor_atom->id() == AtomID( anchor_atomno, estart ) );
-	//  std::cout << "TREE AFTER END: " << edge << std::endl;
-
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-/// @details assumes that the start residue of edge has already been built. Traverse
-///the polymer edge residue by residue and after building sub atom-tree for this residue,
-///attaches the edge's subtree to the anchor_atom in the previous residue.
-///
-void
-build_polymer_edge(
-	kinematics::Edge const & edge,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomPointer2D & atom_pointer
-)
-{
-	int const start( edge.start() );
-	int const stop ( edge.stop() );
-	int const dir  ( edge.polymer_direction() );
-
-	debug_assert( dir == 1 || dir == -1 );
-
-	//id::AtomID first_anchor;
-	for ( int pos=start+dir; pos != stop + dir; pos += dir ) {
-		runtime_assert( pos > 0 );
-		conformation::Residue const & rsd( *residues[pos] );
-		int const anchor_pos( pos-dir );
-		Size anchor_atomno, root_atomno;
-		get_anchor_and_root_atoms( *residues[ anchor_pos ], rsd, edge, anchor_atomno, root_atomno );
-
-		// build the new residue tree, fill in the atom_pointer array
-		build_residue_tree( root_atomno, rsd, atom_pointer[pos], false /*Jump*/ );
-
-		kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, anchor_pos ) ) );
-		kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno,  pos ) ) );
-		debug_assert( anchor_atom && root_atom );
-		anchor_atom->insert_atom( root_atom );
-		//std::cout << "build_polymer_edge: " << edge << ' ' <<  pos << ' ' << root_atomno << ' ' <<
-		//   anchor_pos << ' ' << anchor_atomno << std::endl;
-		//  if ( pos == start+dir ) first_anchor = AtomID( anchor_atomno, anchor_pos );
-	}
-	//  if ( start != stop ) {
-	//   std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
-	//   atom_pointer[ first_anchor ]->show();
-	//   std::cout << "TREE AFTER END: " << edge << std::endl;
-	//  }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @details assumes that the start residue of edge has already been built. Traverse
-///the chemical edge residue by residue and after building sub atom-tree for this residue,
-///attaches the edge's subtree to the anchor_atom in the previous residue.
-///
-void
-build_chemical_edge(
-	kinematics::Edge const & edge,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomPointer2D & atom_pointer
-)
-{
-
-	int const estart  ( edge.start() );
-	int const estop   ( edge.stop () );
-
-	// these may have been set in the edge
-	Size anchor_atomno, root_atomno;
-	get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
-
-	build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], false /*Jump*/ );
-
-	// get the anchor atom
-	kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
-	kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno, estop  ) ) );
-	debug_assert( anchor_atom && root_atom );
-
-	anchor_atom->insert_atom( root_atom );
-}
-
-/////////////////////////////////////////////////////////////////////////////
-///\brief get the root atom for building residue atom-tree given the folding direction "dir"
-int
-get_root_atomno(
-	conformation::Residue const & rsd,
-	int const dir // +1, -1, or "dir_jump"
-)
-{
-	// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
-	// in the fold_tree ( ==> residue should be a polymer type? )
-	int const forward( 1 );
-	int const backward( -1 );
-
-	if ( dir == forward ) {
-		// N for proteins, P for DNA
-		if ( rsd.is_polymer() ) {
-			if ( rsd.is_lower_terminus() && rsd.mainchain_atoms().size() > 0 ) {
-				// this is a little strange to be folding through a terminal residue but kinematics doesn't
-				// have to correlate perfectly with chemical
-				return rsd.mainchain_atom(1);
-			} else {
-				return rsd.lower_connect_atom(); //mainchain_atoms()[1];
 			}
-		} else {
-			return get_root_atomno( rsd, kinematics::dir_jump );
-		}
-	} else if ( dir == backward ) {
-		if ( rsd.is_polymer() ) {
-			if ( rsd.is_upper_terminus() && rsd.mainchain_atoms().size() > 0 ) {
-				// this is a little strange to be folding through a terminal residue but kinematics doesn't
-				// have to correlate perfectly with chemical
-				return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
-			} else {
-				// C for proteins, O3' for DNA
-				return rsd.upper_connect_atom(); //mainchain_atoms()[ rsd.mainchain_atoms().size() ];
-			}
-		} else {
-			return get_root_atomno( rsd, kinematics::dir_jump );
-		}
-	} else {
-		debug_assert( dir == kinematics::dir_jump );
-		// default for jumps, use the N-terminal attachment?
-		if ( rsd.mainchain_atoms().empty() ) {
-			// For non-polymeric ligands, match the ICOOR root.
-			// (This should minimize issues with matching trees.)
-			return rsd.type().root_atom();
-		} else if ( rsd.type().has_variant_type( chemical::N_ACETYLATION ) ) {
-			return 1; // awful hack! want N-CA-C triad to stay put when one of these residues is at root.
-		} else {
-			// PB 10/29/07 - changing to use an interior mainchain atom
-			//
-			// old choice of mainchain_atoms()[1] meant that changing omega of jump_pos-1 would propagate
-			// C-terminal to jump_pos, which is bad for loop modeling where the usual assumption was that
-			// we can use loop_begin-1 and loop_end+1 as jump points
-			//
-			Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
-			Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
-			return rsd.mainchain_atoms()[ mainchain_index ];
-		}
-	}
-}
 
-/// @details  Determine which atom to use as the root of the root residue in the atomtree.
-/// It is sometimes useful to be able to control the atom chosen as the root of the atomtree, eg in graphics.
-/// The logic below uses atom_info stored in the foldtree for jump edges emanating from the root residue
-/// to override the default atom (if the root residue is a jump_point and said atom_info exists)
-
-
-Size
-get_root_residue_root_atomno(
-	conformation::Residue const & rsd,
-	kinematics::FoldTree const & fold_tree
-)
-{
-	if ( !rsd.type().is_polymer() ) return 1;
-
-
-	Size const seqpos( rsd.seqpos() );
-	debug_assert( seqpos == Size( fold_tree.root() ) ); // need to refactor foldtree to use Size instead of int
-
-	Size root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
-
-	if ( fold_tree.is_jump_point( seqpos ) ) {
-		for ( Size i=1; i<= fold_tree.num_jump(); ++i ) {
-			kinematics::Edge const & edge( fold_tree.jump_edge( i ) );
-			if ( seqpos == Size(edge.start()) && edge.has_atom_info() ) {
-				root_atomno = rsd.atom_index( edge.upstream_atom() );
-				break;
-			}
-		}
-	}
-	return root_atomno;
-}
-
-/// @details  A wrapper function to build an atom-tree for a residue. Uses information from the foldtree to
-/// find the proper root atom if it is not defined, and determine the direction in which to build the residue.
-/// The goal of this function is to allow the Conformation to rebuild parts of the AtomTree in a way that is
-/// compatible with what would be built if we erased the entire atomtree and rebuilt it using the foldtree.
-/// Also used to build the atomtree for the root residue when we are building the atomtree from scratch.
-
-void
-build_residue_tree(
-	conformation::ResidueCOPs const & residues,
-	conformation::Residue const & rsd,
-	kinematics::FoldTree const & fold_tree,
-	kinematics::AtomPointer1D & atom_ptr
-)
-{
-	// determine root_atomno and whether root_atom is a jump_atom
-
-	bool root_atom_is_jump_atom( false );
-	Size root_atomno(0);
-
-	Size const seqpos( rsd.seqpos() );
-
-	if ( seqpos == fold_tree.root() ) {
-		root_atom_is_jump_atom = true;
-
-		root_atomno = get_root_residue_root_atomno( rsd, fold_tree );
-
-	} else {
-		// seqpos is not the root of the fold_tree
-		kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) ); // the edge that builds seqpos
-
-		if ( edge.is_peptide() ) {
-			// peptide edge
-			root_atomno = get_root_atomno( rsd, edge.polymer_direction() ); // the default setting
-		} else if ( edge.is_jump() ) {
-			// jump edge
-			root_atom_is_jump_atom = true;
-			if ( edge.has_atom_info() ) {
-				root_atomno = rsd.atom_index( edge.downstream_atom() );
-			} else {
-				root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
-			}
-		} else {
-			//// chemical edge -- atomnumbers of connections should be programmed in
-			//debug_assert( edge.has_atom_info() );
-			//root_atomno = rsd.atom_index( edge.downstream_atom() );
-			// Connection atoms are not always present in the edge, but might be;  else use defaults.
-			int const estart  ( edge.start() );
-			int const estop   ( edge.stop () );
-			Size anchor_atno, root_atno;
-			get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atno, root_atno );
-			root_atomno = (int) root_atno; // stupid Size/int confusion...
-		}
-	}
-	debug_assert( root_atomno );
-
-	// now call the main build_residue_tree function
-	build_residue_tree( root_atomno, rsd, atom_ptr, root_atom_is_jump_atom );
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Check if this atom neighbor has been black-listed ("CUT_BOND" in params file).
-bool
-check_good_neighbor( Size const & atom_index, utility::vector1< Size > const & cut_nbrs ) {
-	for ( Size kk=1; kk<=cut_nbrs.size(); ++kk )  {
-		if ( cut_nbrs[kk] == atom_index ) return false;
-	}
-	return true;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief is atom2 the last atom of our chi angle ?
-inline
-bool
-chi_continuation(
-	Size const atom1, // current atom
-	Size const atom2, // potential nbr
-	utility::vector1< utility::vector1< Size > > const & chi_atoms
-)
-{
-	int const nchi( chi_atoms.size() );
-
-	for ( int i=1; i<= nchi; ++i ) {
-		utility::vector1< Size > const & atoms( chi_atoms[i] );
-		if ( atom1 == atoms[2] &&
-				atom2 == atoms[1] ) return true;
-
-		if ( atom1 == atoms[3] &&
-				atom2 == atoms[4] ) return true;
-	}
-	return false;
-
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief would we be breaking into a chi angle by adding atom2 to the tree now?
-inline
-bool
-chi_interruption(
-	Size const atom1, // current atom
-	Size const atom2, // potential nbr
-	utility::vector1< utility::vector1< Size > > const & chi_atoms,
-	utility::vector1< bool > const & is_done
-)
-{
-	int const nchi( chi_atoms.size() );
-
-	//not an interruption if atom1 and atom2 delineate a chi angle.
-	for ( int i=1; i<= nchi; ++i ) {
-		utility::vector1< Size > const & atoms( chi_atoms[i] );
-
-		if ( atom2 == atoms[2] &&
-				( atom1 == atoms[1] || atom1 == atoms[3] ) ) return false;
-
-		if ( atom2 == atoms[3] &&
-				( atom1 == atoms[2] || atom1 == atoms[4] ) ) return false;
-	}
-
-
-	for ( int i=1; i<= nchi; ++i ) {
-		utility::vector1< Size > const & atoms( chi_atoms[i] );
-
-		if ( atom2 == atoms[2] &&
-				atom1 != atoms[1] &&
-				atom1 != atoms[3] ) return true;
-
-		if ( atom2 == atoms[3] &&
-				atom1 != atoms[2] &&
-				atom1 != atoms[4] ) return true;
-
-		if ( (atom2 == atoms[1] && is_done[ atoms[4] ]) ||
-				(atom2 == atoms[4] && is_done[ atoms[1] ]) ) return true;
-
-	}
-	return false;
-
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief simply fill the "links" by adding, for each atom, its bonded neighbors
-void
-setup_links_simple(
-	conformation::Residue const & rsd,
-	kinematics::Links & links
-)
-{
-	int const natoms( rsd.natoms() );
-
-	links.clear();
-	links.resize( natoms );
-
-	for ( int atomno1=1; atomno1<= natoms; ++atomno1 ) {
-		utility::vector1< Size > const & nbrs( rsd.nbrs( atomno1 ) );
-		utility::vector1< Size > const & cut_nbrs( rsd.cut_bond_neighbor( atomno1 ) );
-		for ( Size jj=1; jj<= nbrs.size(); ++jj ) {
-			if ( !check_good_neighbor( nbrs[jj], cut_nbrs ) ) continue;
-			links[ atomno1 ].push_back( nbrs[jj] );
-		}
-	}
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// called recursively
-
-// Rule I -- dont enter a chi angle in the middle (atoms 2 or 3 ),
-//     and don't enter a chi angle from one side if the other side's atoms have already been added to the tree
-//
-//
-// Rule II -- if you're atom 2 and atom 1 hasn't been done, put that first
-//   likewise for atoms 3 and 4
-//
-// Rule III -- mainchain atoms 1st, tiebreaking by rule II
-//
-// Rule IV -- heavyatoms before hydrogens, subject to other three rules
-//
-/// @brief set correct order for how atoms are linked to each other.
-///
-/// this function is called recursively.
-/// @li atom1 is the root of links at the current level.
-/// @li full_links store information about UNORDERED bonded neighbors for each atom in this residue.
-/// @li is_done indicates which atoms have already been linked.
-/// @li is_mainchain, is_chi, is_hydrogen and chi atoms are self explanatory
-/// @li new_links store information about ORDERED bonded neighbors (links) for each atom in this residue.
-void
-setup_atom_links(
-	int const atom1,
-	kinematics::Links const & full_links,
-	utility::vector1< bool > & is_done,
-	utility::vector1< bool > const & is_mainchain,
-	utility::vector1< bool > const & is_chi,
-	utility::vector1< bool > const & is_hydrogen,
-	utility::vector1< utility::vector1< Size > > const & chi_atoms,
-	kinematics::Links & new_links
-)
-{
-	is_done[atom1] = true;
-
-	utility::vector1< Size > const & full_l( full_links[atom1] );
-	utility::vector1< Size >    &  new_l(  new_links[atom1] );
-
-	debug_assert( new_l.empty() );
-
-	Size const n_nbrs( full_l.size() );
-
-	if ( n_nbrs == 1 ) {
-		Size const nbr( full_l[1] );
-		if ( !is_done[nbr] ) {
-			// special case -- we have no choice but to add this guy otherwise setup will fail
-			new_l.push_back( nbr );
-			setup_atom_links( nbr, full_links, is_done, is_mainchain, is_chi, is_hydrogen, chi_atoms, new_links );
-		}
-		return;
-	}
-
-	// top priority -- within a chi angle, and mainchain
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-
-		if ( is_mainchain[ atom2 ] && is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-	// next priority -- mainchain
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-
-		if ( is_mainchain[ atom2 ] ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-	// next priority -- within a chi angle and heavy.
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-
-		if ( is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) && !is_hydrogen[ atom2 ] ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-	// next priority -- any heavy atom chi?
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-
-		if ( is_chi[ atom2 ] && !is_hydrogen[ atom2 ] ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-
-	// next priority -- any chi -- could be hydrogen
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-
-		if ( is_chi[ atom2 ] ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-	// next priority -- heavyatoms
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-		if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
-		if ( !is_hydrogen[ atom2 ] ) {
-			new_l.push_back( atom2 );
-			setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-				is_hydrogen, chi_atoms, new_links );
-		}
-	}
-
-
-	// lowest priority -- hydrogens
-	for ( Size i=1; i<= n_nbrs; ++i ) {
-		int const atom2( full_l[i] );
-		if ( is_done[ atom2 ] ) continue;
-		if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
-		new_l.push_back( atom2 );
-		setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
-			is_hydrogen, chi_atoms, new_links );
-	}
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief given the root_atomno, set up rules for how other atoms are linked for this residue
-///a wrapper function calling setup_atom_links recursively .
-void
-setup_links(
-	conformation::Residue const & rsd,
-	int const root_atomno,
-	kinematics::Links & links
-)
-{
-	using BVec = utility::vector1<bool>;
-
-	//////////////////////////////////
-	// get the full list of atom nbrs:
-	kinematics::Links full_links;
-
-	setup_links_simple( rsd, full_links );
-
-	// natoms
-	Size const natoms( rsd.natoms() );
-
-	////////////////
-	// chi atoms
-	BVec is_chi( natoms, false ); // vector bool
-	utility::vector1< utility::vector1< Size > > const & chi_atoms
-		( rsd.chi_atoms() );
-	for ( Size i=1; i<= chi_atoms.size(); ++i ) {
-		for ( int j=1; j<= 4; ++j ) {
-			is_chi[ chi_atoms[i][j] ] = true;
-		}
-	}
-
-
-	//////////////////
-	// mainchain atoms
-	BVec is_mainchain( natoms, false ); // vector bool
-	utility::vector1< Size > const & mainchain( rsd.mainchain_atoms() );
-	for ( Size i=1; i<= mainchain.size(); ++i ) {
-		is_mainchain[ mainchain[i] ] = true;
-	}
-	if ( rsd.has_variant_type( chemical::CUTPOINT_LOWER ) ) {
-		is_mainchain[ rsd.atom_index( "OVL1" ) ] = true;
-		if ( rsd.has( "OVL2" ) ) {
-			is_mainchain[ rsd.atom_index( "OVL2" ) ] = true;
-		}
-	}
-	if ( rsd.has_variant_type( chemical::CUTPOINT_UPPER ) ) {
-		is_mainchain[ rsd.atom_index( "OVU1" ) ] = true;
-	}
-
-	////////////
-	// hydrogens
-	BVec is_hydrogen( natoms, false );
-	for ( Size i=1; i<= natoms; ++i ) {
-		is_hydrogen[i] = rsd.atom_type(i).is_hydrogen();
-	}
-
-
-	links.clear();
-	links.resize( natoms );
-
-	BVec is_done( natoms, false ); // keep track of what's done
-	setup_atom_links( root_atomno, full_links, is_done, is_mainchain,  is_chi,
-		is_hydrogen, chi_atoms, links );
-
-
-	// check for an atom that wasn't added
-	for ( Size i=1; i<= natoms; ++i ) {
-		if ( !is_done[ i ] ) {
-			if ( TR.Error.visible() ) {
-				TR.Error << "Unable to setup links for residue " << std::endl;
-				for ( Size j=1; j<= natoms; ++j ) {
-					TR.Error << rsd.atom_name(j) << ' ' << is_done[j] << ' ' << is_mainchain[j] << ' ' << is_chi[j] << ' ' <<
-						is_hydrogen[j] << std::endl;
+		/// @brief  Fills coords of target_rsd with coords from source_rsd using the provided mapping, rebuilds others
+		/// The mapping is indexed by target_rsd atom index, giving source_rsd index or zero for not present.
+		void
+			copy_residue_coordinates_and_rebuild_missing_atoms(
+					Residue const & source_rsd,
+					Residue & target_rsd,
+					utility::vector1< core::Size > const & mapping,
+					Conformation const & conformation
+					) {
+				Size const natoms( target_rsd.natoms() );
+
+				utility::vector1< bool > missing( natoms, false );
+				bool any_missing( false );
+
+				for ( Size i=1; i<= natoms; ++i ) {
+					if ( mapping.size() >= i && mapping[i] != 0 ) {
+						target_rsd.atom( i ).xyz( source_rsd.atom( mapping[i] ).xyz() );
+					} else {
+						TR.Debug << "copy_residue_coordinates_and_rebuild_missing_atoms: missing atom " << target_rsd.name() << ' ' <<
+							target_rsd.atom_name(i) << std::endl;
+						any_missing = true;
+						missing[i] = true;
+					}
+				}
+
+				if ( any_missing ) {
+					target_rsd.seqpos( source_rsd.seqpos() ); // in case fill_missing_atoms needs context info
+					target_rsd.chain ( source_rsd.chain () );
+					target_rsd.fill_missing_atoms( missing, conformation );
 				}
 			}
-			utility_exit();
-		}
-	}
-}
 
-
-///////////////////////////////////////////////////////////////////////////////
-///\brief set up a local atom-tree for a residue from the defined root atom.
-void
-build_residue_tree(
-	int const root_atomno,
-	conformation::Residue const & rsd,
-	kinematics::AtomPointer1D & atom_ptr,
-	bool const root_is_jump_atom
-)
-{
-	Size const natoms( rsd.natoms() );
-
-	atom_ptr.clear();
-	atom_ptr.resize( natoms ); // default C-TOR for AtomOP is 0 initialized
-
-	// setup the atom nbrs so that the tree will match the desired torsion
-	// angles
-	kinematics::Links links;
-	setup_links( rsd, root_atomno, links );
-
-	// now build the residue atom-tree using the recursive function add_atom
-	kinematics::add_atom( root_atomno, rsd.seqpos(), links, atom_ptr, root_is_jump_atom );
-
-	// fill in the coordinates from the residue into the atomtree
-	for ( Size i=1; i<= natoms; ++i ) {
-		atom_ptr[i]->xyz( rsd.atom(i).xyz() );
-	}
-}
-
-/// @details  Get the incoming connection and all outgoing connections from a residue
-
-void
-get_residue_connections(
-	conformation::Residue const & new_rsd,
-	kinematics::FoldTree const & fold_tree,
-	conformation::ResidueCOPs const & residues,
-	id::BondID & new_rsd_in,
-	utility::vector1< id::BondID > & new_rsd_out
-)
-{
-
-	Size const seqpos( new_rsd.seqpos() );
-
-	// setup incoming connection
-	if ( fold_tree.is_root( seqpos ) ) {
-		new_rsd_in.atom1 = id::AtomID::BOGUS_ATOM_ID();
-		new_rsd_in.atom2 = id::AtomID( get_root_residue_root_atomno( new_rsd, fold_tree ), seqpos );
-	} else {
-		Size anchor_atomno, root_atomno, anchor_pos;
-		kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
-		if ( edge.is_polymer() ) anchor_pos = seqpos - edge.polymer_direction();
-		else anchor_pos = edge.start();
-		get_anchor_and_root_atoms( *residues[ anchor_pos ], new_rsd, edge, anchor_atomno, root_atomno );
-		new_rsd_in.atom1 = id::AtomID( anchor_atomno, anchor_pos );
-		new_rsd_in.atom2 = id::AtomID( root_atomno, seqpos );
-	}
-
-
-	// setup the outgoing connections
-	new_rsd_out.clear();
-	utility::vector1< kinematics::Edge > const outgoing_edges( fold_tree.get_outgoing_edges( seqpos ) );
-	for ( auto const & outgoing_edge : outgoing_edges ) {
-		Size anchor_atomno, root_atomno;
-		Size const root_pos( ( outgoing_edge.is_polymer() ) ? seqpos + outgoing_edge.polymer_direction() : outgoing_edge.stop() );
-		get_anchor_and_root_atoms( new_rsd, *residues[ root_pos ], outgoing_edge, anchor_atomno, root_atomno );
-		new_rsd_out.push_back( id::BondID( id::AtomID( anchor_atomno, seqpos ), id::AtomID( root_atomno, root_pos ) ) );
-	}
-}
-
-
-/// @details  Helper function for conformation routines.
-/// Uses fold_tree to deduce the incoming/outgoing connections for the new residue and the old residue
-/// We want it to be the case that the tree we get after this call is the same one that we would have gotten
-/// by calling build_tree
-void
-replace_residue_in_atom_tree(
-	conformation::Residue const & new_rsd,
-	//conformation::Residue const & old_rsd,
-	kinematics::FoldTree const & fold_tree,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomTree & atom_tree
-)
-{
-	id::BondID new_rsd_in;
-	utility::vector1< id::BondID > new_rsd_out;
-
-	get_residue_connections( new_rsd, fold_tree, residues, new_rsd_in, new_rsd_out );
-
-	// build the new atoms
-	kinematics::AtomPointer1D new_atoms;
-	build_residue_tree( residues, new_rsd, fold_tree, new_atoms );
-
-	// now replace the atoms
-	atom_tree.replace_residue_subtree( new_rsd_in, new_rsd_out, new_atoms );
-
-	// preserve same-residue jump status if necessary
-	if ( fold_tree.is_jump_point( new_rsd.seqpos() ) && !fold_tree.is_root( new_rsd.seqpos() ) ) {
-		kinematics::Edge const & edge( fold_tree.get_residue_edge( new_rsd.seqpos() ) );
-		if ( edge.is_jump() && edge.keep_stub_in_residue() ) {
-			promote_sameresidue_child_of_jump_atom( edge, residues, atom_tree );
-		}
-	}
-}
-
-/// @brief  Inserts/ appends new residue subtree into an existing atomtree
-/// @note  The foldtree must already have been changed to reflect the new residue
-/// @note  The residues array should already have been inserted into
-/// @note  The sequence position of the new residue is deduced from new_rsd.seqpos()
-/// @note  This function handles renumbering of the atomtree if necessary
-void
-insert_residue_into_atom_tree(
-	conformation::Residue const & new_rsd,
-	kinematics::FoldTree const & fold_tree,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomTree & atom_tree
-)
-{
-
-	Size const seqpos( new_rsd.seqpos() );
-	Size const nres( fold_tree.nres() );
-	Size const old_nres( atom_tree.size() );
-	debug_assert( nres == residues.size() && seqpos <= nres && old_nres == nres-1 );
-
-	/////////////////////////////////
-	// setup for renumbering atomtree
-	utility::vector1< int > old2new( old_nres, 0 );
-	for ( Size i=1; i<= old_nres; ++i ) {
-		if ( i< seqpos ) old2new[i] = i;
-		else old2new[i] = i+1;
-	}
-
-	// renumber the atomtree, fold_tree
-	atom_tree.update_sequence_numbering( nres, old2new );
-	debug_assert( atom_tree.size() == nres );
-
-	replace_residue_in_atom_tree( new_rsd, fold_tree, residues, atom_tree );
-
-}
-
-
-/// @details  Get the atom-index of the atom to which the residue at position seqpos should be anchored in
-/// constructing the atomtree.
-
-int
-get_anchor_atomno( conformation::Residue const & anchor_rsd, Size const seqpos, kinematics::FoldTree const & fold_tree )
-{
-	int anchor_atomno(0);
-	debug_assert( seqpos != (Size)fold_tree.root() );
-
-	kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
-
-	if ( edge.is_jump() ) {
-		// jump edge
-		debug_assert( (seqpos == (Size)edge.stop()) && ((Size)anchor_rsd.seqpos() == (Size)edge.start()) );
-		if ( edge.has_atom_info() ) {
-			anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-		} else {
-			anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
-		}
-	} else if ( edge.is_peptide() ) {
-		// peptide edge
-		int const dir( edge.polymer_direction() );
-		debug_assert( anchor_rsd.seqpos() == seqpos-dir );
-		anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
-	} else {
-		// chemical edge
-		debug_assert( seqpos == static_cast< Size >( edge.stop() ) && anchor_rsd.seqpos() == static_cast< Size >( edge.start() ) && edge.has_atom_info() );
-		anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-	}
-	debug_assert( anchor_atomno );
-	return anchor_atomno;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-int
-get_anchor_atomno(
-	conformation::Residue const & rsd,
-	int const dir // forward(1), backward(-1), or "dir_jump"
-)
-{
-	// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
-	// in the fold_tree ( ==> residue should be a polymer type? )
-	int const forward( 1 ), backward( -1 );
-
-	if ( dir == forward ) {
-		// C for proteins, O3' for DNA
-		if ( rsd.is_polymer() ) {
-			if ( rsd.is_upper_terminus() ) {
-				// this is a little strange to be folding through a terminal residue but kinematics doesn't
-				// have to correlate perfectly with chemical
-				return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
-			} else {
-				return rsd.upper_connect_atom();
+		/// @details  Helper function for below
+		std::ostream &
+			print_atom( id::AtomID const & id, Conformation const & conf, std::ostream & os )
+			{
+				Residue const & rsd( conf.residue(id.rsd() ) );
+				os << rsd.atom_name( id.atomno() ) << " (" << id.atomno() << ") " << rsd.name() << ' ' << rsd.seqpos();
+				return os;
 			}
-		} else {
-			return get_anchor_atomno( rsd, kinematics::dir_jump );
-		}
-	} else if ( dir == backward ) {
-		// N for proteins, P for DNA
-		if ( rsd.is_polymer() ) {
-			if ( rsd.is_lower_terminus() ) {
-				// this is a little strange to be folding through a terminal residue but kinematics doesn't
-				// have to correlate perfectly with chemical
-				return rsd.mainchain_atom(1);
-			} else {
-				return rsd.lower_connect_atom();
-			}
-		} else {
-			return get_anchor_atomno( rsd, kinematics::dir_jump );
-		}
 
-	} else {
-		debug_assert( dir == kinematics::dir_jump );
-		// default for jumps, use the N-terminal attachment?
-		if ( rsd.mainchain_atoms().empty() ) {
-			// SHORT TERM HACK -- need to add some logic for root atomno
-			return 1;
-		} else {
-			// PB 10/29/07 - changing to use an interior mainchain atom
-			Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
-			Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
-			return rsd.mainchain_atoms()[ mainchain_index ];
-			//return rsd.mainchain_atoms()[1];
-		}
-	}
-}
+		/// @brief Given two residues, check that they are compatible types to be connected via a cutpoint.
+		/// @author Vikram K. Mulligan (vmullig@uw.edu).
+		void
+			check_good_cutpoint_neighbour(
+					core::conformation::Residue const &thisres,
+					core::conformation::Residue const &other_res
+					) {
+				core::chemical::ResidueType const &thistype( thisres.type() );
+				runtime_assert_string_msg(
+						thistype.is_alpha_aa() || thistype.is_beta_aa() || thistype.is_gamma_aa() ||
+						thistype.is_sri() || thistype.has_property(core::chemical::TRIAZOLE_LINKER) ||
+						thistype.is_peptoid() || thistype.is_carbohydrate() || thistype.is_NA() || thistype.is_oligourea() ||
+						thistype.is_aramid()
+						|| thistype.has_property( chemical::TNA ) ,
+						"Error in core::conformation::check_good_cutpoint_neighbour(): The selected residue is neither an alpha-, beta-, or gamma-amino acid, nor a peptoid, nor a sugar, nor a nucleic acid, nor an oligourea.  Nevertheless, it has a cutpoint variant type.  This should not be possible."
+						);
 
-/// @details  Determines the anchor and root atom indices based on residue types and the foldtree edge.
-
-void
-get_anchor_and_root_atoms(
-	conformation::Residue const & anchor_rsd,
-	conformation::Residue const & root_rsd,
-	kinematics::Edge const & edge,
-	Size & anchor_atomno,
-	Size & root_atomno
-)
-{
-	// AMW: There are some ugly special cases for pdb_GAI here. That's
-	// because the edges weren't getting good atom indices on them, I think?
-	// In any case, this function isn't called in tight loops, so we are ok.
-
-	ASSERT_ONLY(Size const anchor_pos( anchor_rsd.seqpos() ););
-	ASSERT_ONLY(Size const root_pos( root_rsd.seqpos() ););
-
-	if ( edge.is_polymer() ) {
-		// POLYMER EDGE
-		int const dir( edge.polymer_direction() );
-		debug_assert( dir == 1 || dir == -1 );
-		debug_assert( root_pos == anchor_pos + dir );
-		anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
-		root_atomno   = get_root_atomno  (   root_rsd, dir );
-	} else {
-		debug_assert( anchor_pos == Size(edge.start()) && root_pos == Size(edge.stop()) );
-		if ( edge.has_atom_info() ) {
-			// JUMP OR CHEMICAL W/ ATOM INFO
-			if ( anchor_rsd.type().name() == "pdb_GAI" ||
-					anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
-			else anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
-			if ( root_rsd.type().name() == "pdb_GAI" ||
-					anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
-			else root_atomno   =   root_rsd.atom_index( edge.downstream_atom() );
-		} else {
-			if ( edge.is_jump() ) {
-				// JUMP EDGE
-				if ( anchor_rsd.type().name() == "pdb_GAI" ||
-						anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
-				else anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
-				if ( root_rsd.type().name() == "pdb_GAI" ||
-						anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
-				else root_atomno   =   get_root_atomno(   root_rsd, kinematics::dir_jump );
-			} else if ( edge.is_chemical_bond() ) {
-				// CHEMICAL EDGE
-				get_chemical_root_and_anchor_atomnos( anchor_rsd, root_rsd, anchor_atomno, root_atomno );
-			} else {
-				utility_exit_with_message( "Unrecognized edge type!" );
-			}
-		}
-	}
-	return;
-}
-
-
-// this code assumed we were also being passed old_rsd:
-// optionally debug some things before making atom_tree call
-/**if ( debug ) {
-BondID old_rsd_in;
-vector1< BondID > old_rsd_out;
-get_residue_connections( old_rsd, fold_tree, residues, old_rsd_in, old_rsd_out );
-debug_assert( new_rsd_in.atom1 == old_rsd_in.atom1 && new_rsd_out.size() == old_rsd_out.size() );
-for ( Size i=1; i<= new_rsd_out.size(); ++i ) {
-debug_assert( new_rsd_out[i].atom2 == old_rsd_out[i].atom2 );
-}
-}**/
-
-
-///////////////////////////////////////////////////////////////////////////////
-
-void
-promote_sameresidue_child_of_jump_atom(
-	kinematics::Edge const & edge,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomTree & atom_tree
-)
-{
-	debug_assert( edge.is_jump() );
-	Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
-	get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
-	atom_tree.promote_sameresidue_nonjump_child( id::AtomID( root_atomno, root_pos ) );
-}
-
-
-void
-promote_sameresidue_child_of_jump_atom(
-	kinematics::Edge const & edge,
-	conformation::ResidueCOPs const & residues,
-	kinematics::AtomPointer2D const & atom_pointer
-)
-{
-	debug_assert( edge.is_jump() );
-	Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
-	get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
-	kinematics::tree::AtomOP root_atom( atom_pointer[ id::AtomID( root_atomno, root_pos ) ] );
-	debug_assert( root_atom->is_jump() );
-	kinematics::tree::AtomOP same_residue_child( nullptr );
-	for ( Size i=0; i< root_atom->n_nonjump_children(); ++i ) {
-		kinematics::tree::AtomOP child( atom_pointer[ root_atom->get_nonjump_atom( i )->id() ] ); // want nonconst, use atom_pointer
-		if ( Size(child->id().rsd()) == root_pos ) {
-			same_residue_child = child;
-			break;
-		}
-	}
-	if ( same_residue_child ) {
-		debug_assert( !same_residue_child->is_jump() );
-		root_atom->delete_atom( same_residue_child );
-		root_atom->insert_atom( same_residue_child );
-	} else {
-		if ( TR.Warning.visible() ) TR.Warning << "Unable to keep stub in residue: jump_atom has no non-jump, same-residue children!" << std::endl;
-	}
-}
-
-void
-get_chemical_root_and_anchor_atomnos(
-	conformation::Residue const & rsd_anchor,
-	conformation::Residue const & rsd_root,
-	Size & anchor_atom_no,
-	Size & root_atom_no
-)
-{
-	debug_assert( rsd_anchor.is_bonded( rsd_root ) );
-
-	Size first_connection_id = rsd_anchor.connections_to_residue( rsd_root )[ 1 ];
-	chemical::ResConnID first_connection = rsd_anchor.connect_map( first_connection_id );
-	anchor_atom_no = rsd_anchor.residue_connection( first_connection_id ).atomno();
-	root_atom_no = rsd_root.residue_connection( first_connection.connid() ).atomno();
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-// right now, this is used by the pose to setup a mapping which is
-// passed in to the atomtree when replacing one residue with another
-//
-//
-// maybe the behavior should really be to identify atoms with the same
-// name in the two residues and map them...
-//
-// oh well, this will work for rewiring backbone connections properly;
-// basically the atomtree will use this mapping when it is replacing
-// the atoms of rsd1 with the subtree formed by the atoms of rsd2
-// for this to work, all outgoing connections from the rsd1 atoms have
-// to have their rsd1-atom represented in this map, so the atomtree
-// knows where to attach the child when rsd2 is put in.
-
-
-/// @details only map by atom number, not by identity currently.
-void
-setup_corresponding_atoms(
-	id::AtomID_Map< id::AtomID > & atom_map,
-	conformation::Residue const & rsd1,
-	conformation::Residue const & rsd2
-)
-{
-
-	// PB -- this whole function is going to go away soon, so I'm not really worried about all the hacks
-
-	int const seqpos1( rsd1.seqpos() );
-	int const seqpos2( rsd2.seqpos() );
-
-	utility::vector1< Size > const &
-		mainchain1( rsd1.mainchain_atoms() ),
-		mainchain2( rsd2.mainchain_atoms() );
-
-	debug_assert( mainchain1.size() == mainchain2.size() );
-
-	// special case for virtual residues -- fpd
-	if ( mainchain1.size() == 0 &&
-			rsd1.type().name3() == "XXX" && rsd2.type().name3() == "XXX" ) {
-		debug_assert( rsd1.atoms().size() == rsd2.atoms().size() );
-
-		for ( Size i=1, i_end = rsd1.atoms().size(); i<= i_end; ++i ) {
-			atom_map.set( id::AtomID( i, seqpos1 ), id::AtomID( i, seqpos2 ) );
-		}
-	} else {
-		for ( Size i=1, i_end = mainchain1.size(); i<= i_end; ++i ) {
-			atom_map.set( id::AtomID( mainchain1[i], seqpos1 ),
-				id::AtomID( mainchain2[i], seqpos2 ) );
-		}
-		if ( rsd1.is_DNA() && rsd2.is_DNA() ) {
-			// special case for dna-dna jumps anchored at sidechain atoms
-			for ( Size i=1; i<= 4; ++i ) {
-				atom_map.set( id::AtomID( rsd1.chi_atoms(1)[i], seqpos1 ),
-					id::AtomID( rsd2.chi_atoms(1)[i], seqpos2 ) );
-			}
-		}
-
-		if ( rsd1.is_RNA() && rsd2.is_RNA() ) {
-			// By the way, this is a total hack AND SHOULD NOT BE CHECKED IN
-			// BEFORE CONSULTING WITH PHIL! -- rhiju
-			// special case for rna-rna jumps anchored at sidechain atoms
-			if ( rsd1.name1() == rsd2.name1() ) {
-				for ( Size i=1; i<= rsd1.natoms(); ++i ) {
-					atom_map.set( id::AtomID( i, seqpos1 ),
-						id::AtomID( i, seqpos2 ) );
+				if ( thistype.is_carbohydrate() ) {
+					//JASON JASON JASON if ever you need cutpoints between sugar and something else, this is
+					//one spot to make a change.  -VKM
+					runtime_assert_string_msg(
+							other_res.type().is_carbohydrate(),
+							"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a carbohydrate via a cutpoint is not itself a carbohydrate."
+							);
+				} else if ( thistype.is_NA() ) {
+					//AMW TODO: Andy, if ever you need RNA to connect to something other than RNA (or DNA) via a cutpoint, this is
+					//one place to make a change.  -VKM
+					runtime_assert_string_msg(
+							other_res.type().is_polymer(),
+							"Error in core::conformation::check_good_cutpoint_neighbour(): The residue connected to a nucleic acid via a cutpoint is not itself a DNA or RNA residue."
+							);
+				} else {
+					runtime_assert_string_msg(
+							other_res.type().is_alpha_aa() || other_res.type().is_beta_aa() || other_res.type().is_gamma_aa() || other_res.type().is_peptoid() || other_res.type().is_oligourea() || other_res.type().is_aramid() || other_res.type().is_RNA() || other_res.type().has_property( chemical::TNA ),
+							"Error in core::conformation::check_good_cutpoint_neighbour(): The connected residue is neither a peptoid, nor an oligourea, nor an alpha-, beta-, or gamma-amino acid."
+							);
 				}
 			}
-		}
 
-	}
+		/// @brief Given a conformation and a position that may or may not be CUTPOINT_UPPER or CUTPOINT_LOWER, determine whether this
+		/// position has either of these variant types, and if it does, determine whether it's connected to anything.  If it is,
+		/// update the C-OVL1-OVL2 bond lengths and bond angle (for CUTPOINT_LOWER) or OVU1-N bond length (for CUTPOINT_UPPER) to
+		/// match any potentially non-ideal geometry in the residue to which it's bonded.
+		/// @details Requires a little bit of special-casing for gamma-amino acids.  Throws an exception if the residue to which
+		/// a CUTPOINT_LOWER is bonded does not have an "N" and a "CA" or "C4".  Safe to call repeatedly, or if cutpoint variant
+		/// types are absent; in these cases, the function does nothing.
+		/// @note By default, this function calls itself again once on residues to which this residue is connected, to update their
+		/// geometry.  Set recurse=false to disable this.
+		/// @author Vikram K. Mulligan (vmullig@uw.edu).
+		void
+			update_cutpoint_virtual_atoms_if_connected(
+					core::conformation::Conformation & conf,
+					core::Size const cutpoint_res,
+					bool recurse /*= true*/
+					) {
+				core::conformation::Residue const &thisres( conf.residue(cutpoint_res) );
+				if ( thisres.is_RNA() ) return;
+				if ( !thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) && !thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) return; //Do nothing if no upper or lower cutpoint type.
 
-	/// Now include atoms involved in residue connections, since these might be anchor points for the atomtree
-	for ( Size connid=1; connid<= rsd1.n_possible_residue_connections() && connid <= rsd2.n_possible_residue_connections(); ++connid ) {
-		Size const atom1( rsd1.type().residue_connection( connid ).atomno() );
-		Size const atom2( rsd2.type().residue_connection( connid ).atomno() );
-		if ( rsd1.atom_name( atom1 ) == rsd2.atom_name( atom2 ) ) {
-			atom_map.set( id::AtomID( atom1, seqpos1 ), id::AtomID( atom2, seqpos2 ) );
-		}
-	}
-}
+				if ( thisres.has_variant_type(core::chemical::CUTPOINT_LOWER) ) {
+					core::Size const other_res_index( thisres.connected_residue_at_upper() ); //The residue to which I'm connected at my upper connection.
+					if ( other_res_index != 0 ) {
+						core::conformation::Residue const & other_res( conf.residue(other_res_index) );
+						check_good_cutpoint_neighbour( thisres, other_res );
+						core::Real const dist1( other_res.lower_connect().icoor().d() ); //Distance from LOWER to N.
+						core::Real const angle2( other_res.lower_connect().icoor().theta() ); //Note that this is Pi-bondangle, in radians.
+						core::Real const dist2( other_res.xyz( other_res.lower_connect().icoor().stub_atom1().atomno() ).distance( other_res.xyz( other_res.lower_connect().icoor().stub_atom2().atomno() ) ) ); //Distance from N to CA (or N to C4 in gamma-aas).
 
-/// @brief Switch the disulfide state of a disulfide-forming residue (e.g. CYS->CYD or CYD->CYS or
-/// DCYD->DCYS or DCYS->DCYD or whatnot).
-/// @param[in] index Position of the residue to replace.
-/// @param[in] cys_type_name3 The 3-letter name of the cys type to use: e.g. CYS
-///  or CYD.  DEPRECATED and kept only for backward-compatibility.
-/// @param[inout] conf The conformation to modify
-/// @details Substitutes a residue with the given cys type, keeping as many of
-///  the existing atom positions as possible.  If the original residue has a
-///  disulfide variant it will be removed, otherwise a disulfide variant will
-///  be added.  Should work with any ResidueTypeSet that has the proper
-///  disulfide variants.  If the replacement fails for any reason a warning
-///  will be printed.
-/// @return true if the replacement was successful, false otherwise.
-bool change_cys_state(
-	Size const index,
-	std::string const & cys_type_name3, //Deprecated.
-	Conformation & conf
-) {
+						core::chemical::AtomICoor const & ovl1_icoor ( thisres.icoor(thisres.atom_index("OVL1")) );
+						core::chemical::AtomICoor ovl1_new_icoor("OVL1", ovl1_icoor.phi(), ovl1_icoor.theta(),
+								dist1, thisres.atom_name( ovl1_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl1_icoor.stub_atom3().atomno() ), thisres.type());
+						conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL1"), cutpoint_res), ovl1_new_icoor.build( thisres, conf ) );
 
-	bool removing(false);
+						if ( !thisres.type().is_carbohydrate() && !other_res.type().is_carbohydrate() ) { //JASON JASON JASON -- this is the other special-case thing for carbohydrates.  -VKM
+							core::chemical::AtomICoor const & ovl2_icoor ( thisres.icoor(thisres.atom_index("OVL2")) );
+							core::chemical::AtomICoor ovl2_new_icoor("OVL2", ovl2_icoor.phi(), angle2,
+									dist2, thisres.atom_name( ovl2_icoor.stub_atom1().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom2().atomno() ), thisres.atom_name( ovl2_icoor.stub_atom3().atomno() ), thisres.type());
+							conf.set_xyz( core::id::AtomID(thisres.atom_index("OVL2"), cutpoint_res), ovl2_new_icoor.build( thisres, conf ) );
+						}
 
-	// Cache information on old residue.
-	core::chemical::ResidueType const & old_type( conf.residue_type( index ) );
-	chemical::ResidueTypeSetCOP residue_type_set = conf.residue_type_set_for_conf( old_type.mode() );
+						if ( recurse ) {
+							update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+						}
+					}
+				}
+				if ( thisres.has_variant_type(core::chemical::CUTPOINT_UPPER) ) {
+					core::Size const other_res_index( thisres.connected_residue_at_lower() ); //The residue to which I'm connected at my lower connection.
+					if ( other_res_index != 0 ) {
+						core::conformation::Residue const & other_res( conf.residue(other_res_index) );
+						check_good_cutpoint_neighbour( thisres, other_res );
+						core::Real const dist1( other_res.upper_connect().icoor().d() ); //Distance from UPPER to C.
 
-	// make sure we're working on a disulfide-forming type.
-	if ( ( ! old_type.is_sidechain_thiol() ) && ( ! old_type.is_disulfide_bonded() ) ) {
-		if ( TR.Warning.visible() ) TR.Warning << "change_cys_state() was called on non-cys-like residue " << index << ", skipping!" << std::endl;
-		return false;
-	}
+						core::chemical::AtomICoor const & ovu1_icoor ( thisres.icoor(thisres.atom_index("OVU1")) );
+						core::chemical::AtomICoor ovu1_new_icoor("OVU1", ovu1_icoor.phi(), ovu1_icoor.theta(), dist1,
+								thisres.atom_name( ovu1_icoor.stub_atom1().atomno() ),
+								thisres.atom_name( ovu1_icoor.stub_atom2().atomno() ),
+								ovu1_icoor.stub_atom3().atomno() == 0 ? "LOWER" : thisres.atom_name( ovu1_icoor.stub_atom3().atomno() ), //In some cases, the third stub atom is the lower connection.
+								thisres.type()
+								);
+						conf.set_xyz( core::id::AtomID(thisres.atom_index("OVU1"), cutpoint_res), ovu1_new_icoor.build(thisres, conf ) );
 
-	// Track the variant types of the old residue type.  We want the
-	// new residue to have the same variant type as the old.
-	utility::vector1< std::string > variant_types = old_type.properties().get_list_of_variants();
-
-	// check and handle disulfide state
-	if ( old_type.has_variant_type( chemical::DISULFIDE ) ) {
-		// if the old residue has DISULFIDE variant type then we are removing a
-		// disulfide, so remove the variant type from the list
-		variant_types.erase( std::find( variant_types.begin(), variant_types.end(), "DISULFIDE" ) );
-		removing = true;
-		//TR << "We just erased the DISULFIDE variant type as desired, since we are going from rn " << rn << " to thiol type " << std::endl;
-
-	} else /*If it does not have the DISULFIDE variant type*/ {
-		//TR << "We just added the DISULFIDE variant type as desired, since we are going from rn " << rn << " to disulfide type " << std::endl;
-		variant_types.push_back( "DISULFIDE" ); //chemical::DISULFIDE ); // creating a disulfide
-		removing = false;
-	}
-
-	// The following is for backward-compatibility only, for functions that would request CYD when the residue was already CYD or whatnot.
-	if ( cys_type_name3=="CYS" && !removing /*not removing if disulfide variant not found*/ ) return true; //If we're asked for a cys and we already have a cys, do nothing.
-	else if ( cys_type_name3=="CYD" && removing /*removing if the disulfide variant was found*/ ) return true; //Similarly, if we're asked for a cyd and we already have a cyd, do nothing.
-
-	// Get the residue type of the desired new residue type.
-	chemical::ResidueTypeCOP replacement_type( residue_type_set->get_representative_type_name3( old_type.name3(), variant_types ) );
-	if ( replacement_type ) {
-		Residue const & res = conf.residue(index);
-		ResidueOP new_res = ResidueFactory::create_residue( *replacement_type, res, conf );
-		copy_residue_coordinates_and_rebuild_missing_atoms( res, *new_res, conf );
-		conf.replace_residue( index, *new_res, false );
-		return true;
-	}
-
-
-	// If we are here then a residue type match wasn't found; issue error message.
-	if ( TR.Error.visible() ) TR.Error << "Couldn't find a " << (removing ? "disulfide-free" : "disulfide-bonded")  << " equivalent for residue " << old_type.name3() << index << "." <<std::endl;
-
-	return false;
-}
-
-id::NamedAtomID
-atom_id_to_named_atom_id(
-	id::AtomID const & atom_id,
-	conformation::Residue const & rsd
-){
-	std::string atom_name;
-	Size rsd_id;
-	if ( atom_id.atomno() <= rsd.atoms().size() ) {
-		atom_name = rsd.atom_name( atom_id.atomno() );
-		rsd_id = atom_id.rsd();
-	} else {
-		if ( TR.Error.visible() ) TR.Error << "Can't resolve atom_id " << atom_id << std::endl;
-		rsd_id = 0;
-		atom_name ="";
-	}
-
-	return id::NamedAtomID( atom_name, rsd_id );
-}
-
-id::AtomID
-named_atom_id_to_atom_id(
-	id::NamedAtomID const & named_atom_id,
-	conformation::Residue const & rsd
-){
-	return id::AtomID( rsd.atom_index( named_atom_id.atom() ), named_atom_id.rsd() );
-}
-
-id::NamedStubID
-stub_id_to_named_stub_id(
-	id::StubID const & stub_id,
-	conformation::Residue const & rsd
-){
-	using namespace core::id;
-	if ( stub_id.center().valid() ) {
-		return NamedStubID(
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.center() , rsd ) ),
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
-		);
-	} else {
-		return NamedStubID( // TODO does this make sense? if input stub is bad, what should be done?
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
-			NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
-		);
-	}
-}
-
-id::StubID
-named_stub_id_to_stub_id(
-	id::NamedStubID const & named_stub_id,
-	conformation::Residue const & rsd
-){
-	using namespace core::id;
-	if ( named_stub_id.center().valid() ) {
-		return StubID(
-			AtomID( named_atom_id_to_atom_id( named_stub_id.center() , rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
-		);
-	} else {
-		return StubID( // TODO does this make sense? if input stub is bad, what should be done?
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
-			AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
-		);
-	}
-}
-
-/// @brief Gets a disulfide-forming residue's partner in the disulfide bond.
-/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
-core::Size get_disulf_partner (
-	core::conformation::Conformation const &conformation,
-	core::Size const res_index
-) {
-	runtime_assert( res_index <= conformation.size() );
-	runtime_assert( conformation.residue( res_index ).type( ).is_disulfide_bonded() ) ;
-	std::string lcatom = conformation.residue(res_index).type( ).get_disulfide_atom_name();
-	Size const connect_atom( conformation.residue( res_index ).atom_index( lcatom ) );
-	Size other_res( 0 );
-	for ( core::Size conn = conformation.residue( res_index ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-		if ( static_cast<core::Size>( conformation.residue( res_index ).type().residue_connection(conn).atomno() ) == connect_atom ) {
-			other_res = conformation.residue( res_index ).connect_map( conn ).resid();
-			break;
-		}
-	}
-	if ( other_res == 0 ) {
-		if ( TR.Error.visible() ) TR.Error << "Residue " << res_index << " was disulfide bonded but had no partner" << std::endl;
-		utility_exit();
-	}
-	return other_res;
-}
-
-void break_all_disulfides(
-	core::conformation::Conformation &conformation
-) {
-	utility::vector1< std::pair<core::Size,core::Size> > disulfides;
-	disulfide_bonds( conformation, disulfides);
-	for ( auto const & pair: disulfides ) {
-		break_disulfide( conformation, pair.first, pair.second );
-	}
-}
-
-/// @brief Breaks a disulfide bond.
-/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
-void break_disulfide(
-	core::conformation::Conformation &conformation,
-	core::Size const res1,
-	core::Size const res2
-) {
-	runtime_assert( res1 <= conformation.size() && res2 <= conformation.size() );
-	runtime_assert( conformation.residue(res1).type().is_disulfide_bonded() && conformation.residue(res2).type().is_disulfide_bonded() );
-	runtime_assert_string_msg( get_disulf_partner( conformation, res1 ) == res2, "Error: cannot break a disulfide bond, because the residues in question are not bonded." );
-	bool result = change_cys_state( res1, "", conformation );
-	runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res1).name3());
-	result = change_cys_state( res2, "", conformation );
-	runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res2).name3());
-	return;
-}
-
-/// @brief Introduce cysteines at the specified location and define a
-///  disulfide bond between them.
-/// @details Does not do the repacking & minimization required to place the
-///  disulfide correctly.
-void
-form_disulfide(
-	Conformation & conformation,
-	Size lower_res,
-	Size upper_res,
-	bool const preserve_d_residues,
-	bool const force_d_residues
-) {
-	// Verify we're dealing with a FA conformation
-	runtime_assert( conformation.is_fullatom() );
-
-	chemical::ResidueTypeSetCOP restype_set( conformation.residue_type_set_for_conf( chemical::FULL_ATOM_t ) );
-
-	// Break existing disulfide bonds to lower
-	if ( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) ) { // full atom residue
-
-		// In rare cases this connection-matching logic breaks.
-		// A disulfide bond can be reciprocal even if the other residue's disulfide connection number
-		// is different (for example: if you have no LOWER or UPPER or something)
-
-		std::string lcatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
-		Size const connect_atom( conformation.residue( lower_res ).atom_index( lcatom ) );
-		Size other_res( 0 );
-		Size conn(0);
-		for ( conn = conformation.residue( lower_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-			if ( Size( conformation.residue(lower_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
-				other_res = conformation.residue( lower_res ).connect_map( conn ).resid();
-				break;
+						if ( recurse ) {
+							update_cutpoint_virtual_atoms_if_connected(conf, other_res_index, false);
+						}
+					}
+				}
+				conf.update_actcoord( cutpoint_res );
 			}
-		}
-		if ( other_res == 0 ) {
-			if ( TR.Error.visible() ) TR.Error << "Residue " << lower_res << " was disulfide bonded but had no partner" << std::endl;
-			utility_exit();
+
+		void
+			show_atom_tree(
+					kinematics::tree::Atom const & atom,
+					Conformation const & conf, std::ostream & os
+					) {
+				os << "ATOM "; print_atom( atom.id(), conf, os ) << std::endl;
+				os << "CHILDREN: ";
+				for ( Size i=0; i< atom.n_children(); ++i ) {
+					print_atom( atom.child(i)->id(), conf, os ) << ' ';
+				}
+				os << std::endl;
+				for ( Size i=0; i< atom.n_children(); ++i ) {
+					show_atom_tree( *atom.child(i), conf, os );
+				}
+			}
+
+		/// helper function for residue replacement/residuetype switching
+		/// @note  Will call new_rsd->fill_missing_atoms if the new residue has atoms
+		/// that the old one doesn't
+
+		void
+			replace_conformation_residue_copying_existing_coordinates(
+					conformation::Conformation & conformation,
+					Size const seqpos,
+					chemical::ResidueType const & new_rsd_type
+					)
+			{
+
+				Residue const & old_rsd( conformation.residue( seqpos ) );
+				ResidueOP new_rsd( ResidueFactory::create_residue( new_rsd_type ) );
+				conformation::copy_residue_coordinates_and_rebuild_missing_atoms( old_rsd, *new_rsd, conformation );
+				conformation.replace_residue( seqpos, *new_rsd, false );
+
+			}
+
+
+		/// @details E.g., make a terminus variant, and replace the original in pose.
+		/// @note This copies any atoms in common between old and new residues, rebuilding the others.
+		void
+			add_variant_type_to_conformation_residue(
+					conformation::Conformation & conformation,
+					chemical::VariantType const variant_type,
+					Size const seqpos )
+			{
+				Residue const & old_rsd( conformation.residue( seqpos ) );
+
+				// the type of the desired variant residue
+				chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
+				chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_added( old_rsd.type(), variant_type ) );
+
+				core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
+			}
+
+
+		/// @details E.g., remove a terminus variant, and replace the original in pose.
+		/// @note This copies any atoms in common between old and new residues, rebuilding the others.
+		void
+			remove_variant_type_from_conformation_residue(
+					conformation::Conformation & conformation,
+					chemical::VariantType const variant_type,
+					Size const seqpos )
+			{
+				Residue const & old_rsd( conformation.residue( seqpos ) );
+
+				// the type of the desired variant residue
+				chemical::ResidueTypeSetCOP rsd_set( conformation.residue_type_set_for_conf( old_rsd.type().mode() ) );
+				chemical::ResidueType const & new_rsd_type( rsd_set->get_residue_type_with_variant_removed( old_rsd.type(), variant_type ) );
+
+				core::conformation::replace_conformation_residue_copying_existing_coordinates( conformation, seqpos, new_rsd_type );
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		void
+			add_lower_terminus_type_to_conformation_residue(
+					conformation::Conformation & conformation,
+					Size const seqpos
+					)
+			{
+				core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		void
+			remove_lower_terminus_type_from_conformation_residue(
+					conformation::Conformation & conformation,
+					Size const seqpos
+					)
+			{
+				remove_variant_type_from_conformation_residue( conformation, chemical::LOWER_TERMINUS_VARIANT, seqpos );
+				remove_variant_type_from_conformation_residue( conformation, chemical::LOWERTERM_TRUNC_VARIANT, seqpos );
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		void
+			add_upper_terminus_type_to_conformation_residue(
+					conformation::Conformation & conformation,
+					Size const seqpos
+					)
+			{
+				core::conformation::add_variant_type_to_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		void
+			remove_upper_terminus_type_from_conformation_residue(
+					conformation::Conformation & conformation,
+					Size const seqpos
+					)
+			{
+				remove_variant_type_from_conformation_residue( conformation, chemical::UPPER_TERMINUS_VARIANT, seqpos );
+				remove_variant_type_from_conformation_residue( conformation, chemical::UPPERTERM_TRUNC_VARIANT, seqpos );
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @details  Build an atom-tree from a fold-tree and a set of residues
+		/// atoms in the tree are allocated with new (on the heap) and held in owning pointers in atom_pointer
+		/// @note  atom_pointer is cleared at the beginning and then filled with AtomOPs to all the atoms
+
+
+		void
+			build_tree(
+					kinematics::FoldTree const & fold_tree,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomPointer2D & atom_pointer
+					)
+			{
+				using conformation::Residue;
+
+				// note -- we clear atom_pointer
+				atom_pointer.clear();
+				atom_pointer.resize( residues.size() );
+
+				// build first atom. make it a "JumpAtom"
+				{
+					int const start_pos( fold_tree.root() );
+					Residue const & rsd( *(residues[start_pos]) );
+
+					build_residue_tree( residues, rsd, fold_tree, atom_pointer[ start_pos ] );
+
+				}
+
+				// traverse tree, build edges
+				for ( auto const & it : fold_tree ) {
+
+					if ( it.is_jump() ) {
+						build_jump_edge( it, residues, atom_pointer );
+
+					} else if ( it.label() == kinematics::Edge::PEPTIDE ) {
+						// build a peptide edge
+						build_polymer_edge( it, residues, atom_pointer );
+
+					} else if ( it.label() == kinematics::Edge::CHEMICAL ) {
+						build_chemical_edge( it, residues, atom_pointer );
+
+					} else {
+						if ( TR.Error.visible() ) {
+							TR.Error << "Failed to identify kinematics::Edge label in core/kinematics/util.cc::build_tree()" << std::endl;
+							TR.Error << "Label = " << it.label() << std::endl;
+						}
+						utility_exit();
+					}
+				}
+
+				// now guarantee that jump stubs are residue-internal if desired
+				for ( auto const & it : fold_tree ) {
+					if ( it.is_jump() && it.keep_stub_in_residue() ) {
+						promote_sameresidue_child_of_jump_atom( it, residues, atom_pointer );
+					}
+				}
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @details root_atomno is the root for the sub atom-tree of this edge.
+		/// anchor_atomno is the entry point of this sub atom-tree into the main atom-tree.
+
+		void
+			build_jump_edge(
+					kinematics::Edge const & edge,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomPointer2D & atom_pointer
+					)
+			{
+				debug_assert( edge.is_jump() );
+
+				int const estart  ( edge.start() );
+				int const estop   ( edge.stop () );
+
+				// these may have been set in the edge
+				Size anchor_atomno, root_atomno;
+				get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
+
+				// get the anchor atom
+				kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
+				debug_assert( anchor_atom );
+
+				// build the new residue
+				build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], true /*Jump*/ );
+
+				// now wire in the new residue connection
+				anchor_atom->insert_atom( atom_pointer[ id::AtomID( root_atomno, estop ) ] );
+
+
+				//  std::cout << "build_jump_edge: " << edge << ' ' <<  estop << ' ' << root_atomno << ' ' <<
+				//   estart << ' ' << anchor_atomno << std::endl;
+
+				//  std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
+				//  anchor_atom->show();
+				// debug_assert( anchor_atom->id() == AtomID( anchor_atomno, estart ) );
+				//  std::cout << "TREE AFTER END: " << edge << std::endl;
+
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @details assumes that the start residue of edge has already been built. Traverse
+		///the polymer edge residue by residue and after building sub atom-tree for this residue,
+		///attaches the edge's subtree to the anchor_atom in the previous residue.
+		///
+		void
+			build_polymer_edge(
+					kinematics::Edge const & edge,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomPointer2D & atom_pointer
+					)
+			{
+				int const start( edge.start() );
+				int const stop ( edge.stop() );
+				int const dir  ( edge.polymer_direction() );
+
+				debug_assert( dir == 1 || dir == -1 );
+
+				//id::AtomID first_anchor;
+				for ( int pos=start+dir; pos != stop + dir; pos += dir ) {
+					runtime_assert( pos > 0 );
+					conformation::Residue const & rsd( *residues[pos] );
+					int const anchor_pos( pos-dir );
+					Size anchor_atomno, root_atomno;
+					get_anchor_and_root_atoms( *residues[ anchor_pos ], rsd, edge, anchor_atomno, root_atomno );
+
+					// build the new residue tree, fill in the atom_pointer array
+					build_residue_tree( root_atomno, rsd, atom_pointer[pos], false /*Jump*/ );
+
+					kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, anchor_pos ) ) );
+					kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno,  pos ) ) );
+					debug_assert( anchor_atom && root_atom );
+					anchor_atom->insert_atom( root_atom );
+					//std::cout << "build_polymer_edge: " << edge << ' ' <<  pos << ' ' << root_atomno << ' ' <<
+					//   anchor_pos << ' ' << anchor_atomno << std::endl;
+					//  if ( pos == start+dir ) first_anchor = AtomID( anchor_atomno, anchor_pos );
+				}
+				//  if ( start != stop ) {
+				//   std::cout << "TREE AFTER BEGIN: " << edge << std::endl;
+				//   atom_pointer[ first_anchor ]->show();
+				//   std::cout << "TREE AFTER END: " << edge << std::endl;
+				//  }
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @details assumes that the start residue of edge has already been built. Traverse
+		///the chemical edge residue by residue and after building sub atom-tree for this residue,
+		///attaches the edge's subtree to the anchor_atom in the previous residue.
+		///
+		void
+			build_chemical_edge(
+					kinematics::Edge const & edge,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomPointer2D & atom_pointer
+					)
+			{
+
+				int const estart  ( edge.start() );
+				int const estop   ( edge.stop () );
+
+				// these may have been set in the edge
+				Size anchor_atomno, root_atomno;
+				get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atomno, root_atomno );
+
+				build_residue_tree( root_atomno, *residues[ estop ], atom_pointer[ estop ], false /*Jump*/ );
+
+				// get the anchor atom
+				kinematics::tree::AtomOP anchor_atom( atom_pointer( id::AtomID( anchor_atomno, estart ) ) );
+				kinematics::tree::AtomOP   root_atom( atom_pointer( id::AtomID(   root_atomno, estop  ) ) );
+				debug_assert( anchor_atom && root_atom );
+
+				anchor_atom->insert_atom( root_atom );
+			}
+
+		/////////////////////////////////////////////////////////////////////////////
+		///\brief get the root atom for building residue atom-tree given the folding direction "dir"
+		int
+			get_root_atomno(
+					conformation::Residue const & rsd,
+					int const dir // +1, -1, or "dir_jump"
+					)
+			{
+				// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
+				// in the fold_tree ( ==> residue should be a polymer type? )
+				int const forward( 1 );
+				int const backward( -1 );
+
+				if ( dir == forward ) {
+					// N for proteins, P for DNA
+					if ( rsd.is_polymer() ) {
+						if ( rsd.is_lower_terminus() && rsd.mainchain_atoms().size() > 0 ) {
+							// this is a little strange to be folding through a terminal residue but kinematics doesn't
+							// have to correlate perfectly with chemical
+							return rsd.mainchain_atom(1);
+						} else {
+							return rsd.lower_connect_atom(); //mainchain_atoms()[1];
+						}
+					} else {
+						return get_root_atomno( rsd, kinematics::dir_jump );
+					}
+				} else if ( dir == backward ) {
+					if ( rsd.is_polymer() ) {
+						if ( rsd.is_upper_terminus() && rsd.mainchain_atoms().size() > 0 ) {
+							// this is a little strange to be folding through a terminal residue but kinematics doesn't
+							// have to correlate perfectly with chemical
+							return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
+						} else {
+							// C for proteins, O3' for DNA
+							return rsd.upper_connect_atom(); //mainchain_atoms()[ rsd.mainchain_atoms().size() ];
+						}
+					} else {
+						return get_root_atomno( rsd, kinematics::dir_jump );
+					}
+				} else {
+					debug_assert( dir == kinematics::dir_jump );
+					// default for jumps, use the N-terminal attachment?
+					if ( rsd.mainchain_atoms().empty() ) {
+						// For non-polymeric ligands, match the ICOOR root.
+						// (This should minimize issues with matching trees.)
+						return rsd.type().root_atom();
+					} else if ( rsd.type().has_variant_type( chemical::N_ACETYLATION ) ) {
+						return 1; // awful hack! want N-CA-C triad to stay put when one of these residues is at root.
+					} else {
+						// PB 10/29/07 - changing to use an interior mainchain atom
+						//
+						// old choice of mainchain_atoms()[1] meant that changing omega of jump_pos-1 would propagate
+						// C-terminal to jump_pos, which is bad for loop modeling where the usual assumption was that
+						// we can use loop_begin-1 and loop_end+1 as jump points
+						//
+						Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
+						Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
+						return rsd.mainchain_atoms()[ mainchain_index ];
+					}
+				}
+			}
+
+		/// @details  Determine which atom to use as the root of the root residue in the atomtree.
+		/// It is sometimes useful to be able to control the atom chosen as the root of the atomtree, eg in graphics.
+		/// The logic below uses atom_info stored in the foldtree for jump edges emanating from the root residue
+		/// to override the default atom (if the root residue is a jump_point and said atom_info exists)
+
+
+		Size
+			get_root_residue_root_atomno(
+					conformation::Residue const & rsd,
+					kinematics::FoldTree const & fold_tree
+					)
+			{
+				if ( !rsd.type().is_polymer() ) return 1;
+
+
+				Size const seqpos( rsd.seqpos() );
+				debug_assert( seqpos == Size( fold_tree.root() ) ); // need to refactor foldtree to use Size instead of int
+
+				Size root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
+
+				if ( fold_tree.is_jump_point( seqpos ) ) {
+					for ( Size i=1; i<= fold_tree.num_jump(); ++i ) {
+						kinematics::Edge const & edge( fold_tree.jump_edge( i ) );
+						if ( seqpos == Size(edge.start()) && edge.has_atom_info() ) {
+							root_atomno = rsd.atom_index( edge.upstream_atom() );
+							break;
+						}
+					}
+				}
+				return root_atomno;
+			}
+
+		/// @details  A wrapper function to build an atom-tree for a residue. Uses information from the foldtree to
+		/// find the proper root atom if it is not defined, and determine the direction in which to build the residue.
+		/// The goal of this function is to allow the Conformation to rebuild parts of the AtomTree in a way that is
+		/// compatible with what would be built if we erased the entire atomtree and rebuilt it using the foldtree.
+		/// Also used to build the atomtree for the root residue when we are building the atomtree from scratch.
+
+		void
+			build_residue_tree(
+					conformation::ResidueCOPs const & residues,
+					conformation::Residue const & rsd,
+					kinematics::FoldTree const & fold_tree,
+					kinematics::AtomPointer1D & atom_ptr
+					)
+			{
+				// determine root_atomno and whether root_atom is a jump_atom
+
+				bool root_atom_is_jump_atom( false );
+				Size root_atomno(0);
+
+				Size const seqpos( rsd.seqpos() );
+
+				if ( seqpos == fold_tree.root() ) {
+					root_atom_is_jump_atom = true;
+
+					root_atomno = get_root_residue_root_atomno( rsd, fold_tree );
+
+				} else {
+					// seqpos is not the root of the fold_tree
+					kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) ); // the edge that builds seqpos
+
+					if ( edge.is_peptide() ) {
+						// peptide edge
+						root_atomno = get_root_atomno( rsd, edge.polymer_direction() ); // the default setting
+					} else if ( edge.is_jump() ) {
+						// jump edge
+						root_atom_is_jump_atom = true;
+						if ( edge.has_atom_info() ) {
+							root_atomno = rsd.atom_index( edge.downstream_atom() );
+						} else {
+							root_atomno = get_root_atomno( rsd, kinematics::dir_jump ); // the default setting
+						}
+					} else {
+						//// chemical edge -- atomnumbers of connections should be programmed in
+						//debug_assert( edge.has_atom_info() );
+						//root_atomno = rsd.atom_index( edge.downstream_atom() );
+						// Connection atoms are not always present in the edge, but might be;  else use defaults.
+						int const estart  ( edge.start() );
+						int const estop   ( edge.stop () );
+						Size anchor_atno, root_atno;
+						get_anchor_and_root_atoms( *residues[ estart ], *residues[ estop ], edge, anchor_atno, root_atno );
+						root_atomno = (int) root_atno; // stupid Size/int confusion...
+					}
+				}
+				debug_assert( root_atomno );
+
+				// now call the main build_residue_tree function
+				build_residue_tree( root_atomno, rsd, atom_ptr, root_atom_is_jump_atom );
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @brief Check if this atom neighbor has been black-listed ("CUT_BOND" in params file).
+		bool
+			check_good_neighbor( Size const & atom_index, utility::vector1< Size > const & cut_nbrs ) {
+				for ( Size kk=1; kk<=cut_nbrs.size(); ++kk )  {
+					if ( cut_nbrs[kk] == atom_index ) return false;
+				}
+				return true;
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @brief is atom2 the last atom of our chi angle ?
+		inline
+			bool
+			chi_continuation(
+					Size const atom1, // current atom
+					Size const atom2, // potential nbr
+					utility::vector1< utility::vector1< Size > > const & chi_atoms
+					)
+			{
+				int const nchi( chi_atoms.size() );
+
+				for ( int i=1; i<= nchi; ++i ) {
+					utility::vector1< Size > const & atoms( chi_atoms[i] );
+					if ( atom1 == atoms[2] &&
+							atom2 == atoms[1] ) return true;
+
+					if ( atom1 == atoms[3] &&
+							atom2 == atoms[4] ) return true;
+				}
+				return false;
+
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @brief would we be breaking into a chi angle by adding atom2 to the tree now?
+		inline
+			bool
+			chi_interruption(
+					Size const atom1, // current atom
+					Size const atom2, // potential nbr
+					utility::vector1< utility::vector1< Size > > const & chi_atoms,
+					utility::vector1< bool > const & is_done
+					)
+			{
+				int const nchi( chi_atoms.size() );
+
+				//not an interruption if atom1 and atom2 delineate a chi angle.
+				for ( int i=1; i<= nchi; ++i ) {
+					utility::vector1< Size > const & atoms( chi_atoms[i] );
+
+					if ( atom2 == atoms[2] &&
+							( atom1 == atoms[1] || atom1 == atoms[3] ) ) return false;
+
+					if ( atom2 == atoms[3] &&
+							( atom1 == atoms[2] || atom1 == atoms[4] ) ) return false;
+				}
+
+
+				for ( int i=1; i<= nchi; ++i ) {
+					utility::vector1< Size > const & atoms( chi_atoms[i] );
+
+					if ( atom2 == atoms[2] &&
+							atom1 != atoms[1] &&
+							atom1 != atoms[3] ) return true;
+
+					if ( atom2 == atoms[3] &&
+							atom1 != atoms[2] &&
+							atom1 != atoms[4] ) return true;
+
+					if ( (atom2 == atoms[1] && is_done[ atoms[4] ]) ||
+							(atom2 == atoms[4] && is_done[ atoms[1] ]) ) return true;
+
+				}
+				return false;
+
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @brief simply fill the "links" by adding, for each atom, its bonded neighbors
+		void
+			setup_links_simple(
+					conformation::Residue const & rsd,
+					kinematics::Links & links
+					)
+			{
+				int const natoms( rsd.natoms() );
+
+				links.clear();
+				links.resize( natoms );
+
+				for ( int atomno1=1; atomno1<= natoms; ++atomno1 ) {
+					utility::vector1< Size > const & nbrs( rsd.nbrs( atomno1 ) );
+					utility::vector1< Size > const & cut_nbrs( rsd.cut_bond_neighbor( atomno1 ) );
+					for ( Size jj=1; jj<= nbrs.size(); ++jj ) {
+						if ( !check_good_neighbor( nbrs[jj], cut_nbrs ) ) continue;
+						links[ atomno1 ].push_back( nbrs[jj] );
+					}
+				}
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		// called recursively
+
+		// Rule I -- dont enter a chi angle in the middle (atoms 2 or 3 ),
+		//     and don't enter a chi angle from one side if the other side's atoms have already been added to the tree
+		//
+		//
+		// Rule II -- if you're atom 2 and atom 1 hasn't been done, put that first
+		//   likewise for atoms 3 and 4
+		//
+		// Rule III -- mainchain atoms 1st, tiebreaking by rule II
+		//
+		// Rule IV -- heavyatoms before hydrogens, subject to other three rules
+		//
+		/// @brief set correct order for how atoms are linked to each other.
+		///
+		/// this function is called recursively.
+		/// @li atom1 is the root of links at the current level.
+		/// @li full_links store information about UNORDERED bonded neighbors for each atom in this residue.
+		/// @li is_done indicates which atoms have already been linked.
+		/// @li is_mainchain, is_chi, is_hydrogen and chi atoms are self explanatory
+		/// @li new_links store information about ORDERED bonded neighbors (links) for each atom in this residue.
+		void
+			setup_atom_links(
+					int const atom1,
+					kinematics::Links const & full_links,
+					utility::vector1< bool > & is_done,
+					utility::vector1< bool > const & is_mainchain,
+					utility::vector1< bool > const & is_chi,
+					utility::vector1< bool > const & is_hydrogen,
+					utility::vector1< utility::vector1< Size > > const & chi_atoms,
+					kinematics::Links & new_links
+					)
+			{
+				is_done[atom1] = true;
+
+				utility::vector1< Size > const & full_l( full_links[atom1] );
+				utility::vector1< Size >    &  new_l(  new_links[atom1] );
+
+				debug_assert( new_l.empty() );
+
+				Size const n_nbrs( full_l.size() );
+
+				if ( n_nbrs == 1 ) {
+					Size const nbr( full_l[1] );
+					if ( !is_done[nbr] ) {
+						// special case -- we have no choice but to add this guy otherwise setup will fail
+						new_l.push_back( nbr );
+						setup_atom_links( nbr, full_links, is_done, is_mainchain, is_chi, is_hydrogen, chi_atoms, new_links );
+					}
+					return;
+				}
+
+				// top priority -- within a chi angle, and mainchain
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+
+					if ( is_mainchain[ atom2 ] && is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+				// next priority -- mainchain
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+
+					if ( is_mainchain[ atom2 ] ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+				// next priority -- within a chi angle and heavy.
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+
+					if ( is_chi[ atom1 ] && is_chi[ atom2 ] && chi_continuation( atom1, atom2, chi_atoms ) && !is_hydrogen[ atom2 ] ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+				// next priority -- any heavy atom chi?
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+
+					if ( is_chi[ atom2 ] && !is_hydrogen[ atom2 ] ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+
+				// next priority -- any chi -- could be hydrogen
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+
+					if ( is_chi[ atom2 ] ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+				// next priority -- heavyatoms
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+					if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
+					if ( !is_hydrogen[ atom2 ] ) {
+						new_l.push_back( atom2 );
+						setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+								is_hydrogen, chi_atoms, new_links );
+					}
+				}
+
+
+				// lowest priority -- hydrogens
+				for ( Size i=1; i<= n_nbrs; ++i ) {
+					int const atom2( full_l[i] );
+					if ( is_done[ atom2 ] ) continue;
+					if ( is_chi[ atom2 ] && chi_interruption( atom1, atom2, chi_atoms, is_done ) ) continue;
+					new_l.push_back( atom2 );
+					setup_atom_links( atom2, full_links, is_done, is_mainchain, is_chi,
+							is_hydrogen, chi_atoms, new_links );
+				}
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		/// @brief given the root_atomno, set up rules for how other atoms are linked for this residue
+		///a wrapper function calling setup_atom_links recursively .
+		void
+			setup_links(
+					conformation::Residue const & rsd,
+					int const root_atomno,
+					kinematics::Links & links
+					)
+			{
+				using BVec = utility::vector1<bool>;
+
+				//////////////////////////////////
+				// get the full list of atom nbrs:
+				kinematics::Links full_links;
+
+				setup_links_simple( rsd, full_links );
+
+				// natoms
+				Size const natoms( rsd.natoms() );
+
+				////////////////
+				// chi atoms
+				BVec is_chi( natoms, false ); // vector bool
+				utility::vector1< utility::vector1< Size > > const & chi_atoms
+					( rsd.chi_atoms() );
+				for ( Size i=1; i<= chi_atoms.size(); ++i ) {
+					for ( int j=1; j<= 4; ++j ) {
+						is_chi[ chi_atoms[i][j] ] = true;
+					}
+				}
+
+
+				//////////////////
+				// mainchain atoms
+				BVec is_mainchain( natoms, false ); // vector bool
+				utility::vector1< Size > const & mainchain( rsd.mainchain_atoms() );
+				for ( Size i=1; i<= mainchain.size(); ++i ) {
+					is_mainchain[ mainchain[i] ] = true;
+				}
+				if ( rsd.has_variant_type( chemical::CUTPOINT_LOWER ) ) {
+					is_mainchain[ rsd.atom_index( "OVL1" ) ] = true;
+					if ( rsd.has( "OVL2" ) ) {
+						is_mainchain[ rsd.atom_index( "OVL2" ) ] = true;
+					}
+				}
+				if ( rsd.has_variant_type( chemical::CUTPOINT_UPPER ) ) {
+					is_mainchain[ rsd.atom_index( "OVU1" ) ] = true;
+				}
+
+				////////////
+				// hydrogens
+				BVec is_hydrogen( natoms, false );
+				for ( Size i=1; i<= natoms; ++i ) {
+					is_hydrogen[i] = rsd.atom_type(i).is_hydrogen();
+				}
+
+
+				links.clear();
+				links.resize( natoms );
+
+				BVec is_done( natoms, false ); // keep track of what's done
+				setup_atom_links( root_atomno, full_links, is_done, is_mainchain,  is_chi,
+						is_hydrogen, chi_atoms, links );
+
+
+				// check for an atom that wasn't added
+				for ( Size i=1; i<= natoms; ++i ) {
+					if ( !is_done[ i ] ) {
+						if ( TR.Error.visible() ) {
+							TR.Error << "Unable to setup links for residue " << std::endl;
+							for ( Size j=1; j<= natoms; ++j ) {
+								TR.Error << rsd.atom_name(j) << ' ' << is_done[j] << ' ' << is_mainchain[j] << ' ' << is_chi[j] << ' ' <<
+									is_hydrogen[j] << std::endl;
+							}
+						}
+						utility_exit();
+					}
+				}
+			}
+
+
+		///////////////////////////////////////////////////////////////////////////////
+		///\brief set up a local atom-tree for a residue from the defined root atom.
+		void
+			build_residue_tree(
+					int const root_atomno,
+					conformation::Residue const & rsd,
+					kinematics::AtomPointer1D & atom_ptr,
+					bool const root_is_jump_atom
+					)
+			{
+				Size const natoms( rsd.natoms() );
+
+				atom_ptr.clear();
+				atom_ptr.resize( natoms ); // default C-TOR for AtomOP is 0 initialized
+
+				// setup the atom nbrs so that the tree will match the desired torsion
+				// angles
+				kinematics::Links links;
+				setup_links( rsd, root_atomno, links );
+
+				// now build the residue atom-tree using the recursive function add_atom
+				kinematics::add_atom( root_atomno, rsd.seqpos(), links, atom_ptr, root_is_jump_atom );
+
+				// fill in the coordinates from the residue into the atomtree
+				for ( Size i=1; i<= natoms; ++i ) {
+					atom_ptr[i]->xyz( rsd.atom(i).xyz() );
+				}
+			}
+
+		/// @details  Get the incoming connection and all outgoing connections from a residue
+
+		void
+			get_residue_connections(
+					conformation::Residue const & new_rsd,
+					kinematics::FoldTree const & fold_tree,
+					conformation::ResidueCOPs const & residues,
+					id::BondID & new_rsd_in,
+					utility::vector1< id::BondID > & new_rsd_out
+					)
+			{
+
+				Size const seqpos( new_rsd.seqpos() );
+
+				// setup incoming connection
+				if ( fold_tree.is_root( seqpos ) ) {
+					new_rsd_in.atom1 = id::AtomID::BOGUS_ATOM_ID();
+					new_rsd_in.atom2 = id::AtomID( get_root_residue_root_atomno( new_rsd, fold_tree ), seqpos );
+				} else {
+					Size anchor_atomno, root_atomno, anchor_pos;
+					kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
+					if ( edge.is_polymer() ) anchor_pos = seqpos - edge.polymer_direction();
+					else anchor_pos = edge.start();
+					get_anchor_and_root_atoms( *residues[ anchor_pos ], new_rsd, edge, anchor_atomno, root_atomno );
+					new_rsd_in.atom1 = id::AtomID( anchor_atomno, anchor_pos );
+					new_rsd_in.atom2 = id::AtomID( root_atomno, seqpos );
+				}
+
+
+				// setup the outgoing connections
+				new_rsd_out.clear();
+				utility::vector1< kinematics::Edge > const outgoing_edges( fold_tree.get_outgoing_edges( seqpos ) );
+				for ( auto const & outgoing_edge : outgoing_edges ) {
+					Size anchor_atomno, root_atomno;
+					Size const root_pos( ( outgoing_edge.is_polymer() ) ? seqpos + outgoing_edge.polymer_direction() : outgoing_edge.stop() );
+					get_anchor_and_root_atoms( new_rsd, *residues[ root_pos ], outgoing_edge, anchor_atomno, root_atomno );
+					new_rsd_out.push_back( id::BondID( id::AtomID( anchor_atomno, seqpos ), id::AtomID( root_atomno, root_pos ) ) );
+				}
+			}
+
+
+		/// @details  Helper function for conformation routines.
+		/// Uses fold_tree to deduce the incoming/outgoing connections for the new residue and the old residue
+		/// We want it to be the case that the tree we get after this call is the same one that we would have gotten
+		/// by calling build_tree
+		void
+			replace_residue_in_atom_tree(
+					conformation::Residue const & new_rsd,
+					//conformation::Residue const & old_rsd,
+					kinematics::FoldTree const & fold_tree,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomTree & atom_tree
+					)
+			{
+				id::BondID new_rsd_in;
+				utility::vector1< id::BondID > new_rsd_out;
+
+				get_residue_connections( new_rsd, fold_tree, residues, new_rsd_in, new_rsd_out );
+
+				// build the new atoms
+				kinematics::AtomPointer1D new_atoms;
+				build_residue_tree( residues, new_rsd, fold_tree, new_atoms );
+
+				// now replace the atoms
+				atom_tree.replace_residue_subtree( new_rsd_in, new_rsd_out, new_atoms );
+
+				// preserve same-residue jump status if necessary
+				if ( fold_tree.is_jump_point( new_rsd.seqpos() ) && !fold_tree.is_root( new_rsd.seqpos() ) ) {
+					kinematics::Edge const & edge( fold_tree.get_residue_edge( new_rsd.seqpos() ) );
+					if ( edge.is_jump() && edge.keep_stub_in_residue() ) {
+						promote_sameresidue_child_of_jump_atom( edge, residues, atom_tree );
+					}
+				}
+			}
+
+		/// @brief  Inserts/ appends new residue subtree into an existing atomtree
+		/// @note  The foldtree must already have been changed to reflect the new residue
+		/// @note  The residues array should already have been inserted into
+		/// @note  The sequence position of the new residue is deduced from new_rsd.seqpos()
+		/// @note  This function handles renumbering of the atomtree if necessary
+		void
+			insert_residue_into_atom_tree(
+					conformation::Residue const & new_rsd,
+					kinematics::FoldTree const & fold_tree,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomTree & atom_tree
+					)
+			{
+
+				Size const seqpos( new_rsd.seqpos() );
+				Size const nres( fold_tree.nres() );
+				Size const old_nres( atom_tree.size() );
+				debug_assert( nres == residues.size() && seqpos <= nres && old_nres == nres-1 );
+
+				/////////////////////////////////
+				// setup for renumbering atomtree
+				utility::vector1< int > old2new( old_nres, 0 );
+				for ( Size i=1; i<= old_nres; ++i ) {
+					if ( i< seqpos ) old2new[i] = i;
+					else old2new[i] = i+1;
+				}
+
+				// renumber the atomtree, fold_tree
+				atom_tree.update_sequence_numbering( nres, old2new );
+				debug_assert( atom_tree.size() == nres );
+
+				replace_residue_in_atom_tree( new_rsd, fold_tree, residues, atom_tree );
+
+			}
+
+
+		/// @details  Get the atom-index of the atom to which the residue at position seqpos should be anchored in
+		/// constructing the atomtree.
+
+		int
+			get_anchor_atomno( conformation::Residue const & anchor_rsd, Size const seqpos, kinematics::FoldTree const & fold_tree )
+			{
+				int anchor_atomno(0);
+				debug_assert( seqpos != (Size)fold_tree.root() );
+
+				kinematics::Edge const & edge( fold_tree.get_residue_edge( seqpos ) );
+
+				if ( edge.is_jump() ) {
+					// jump edge
+					debug_assert( (seqpos == (Size)edge.stop()) && ((Size)anchor_rsd.seqpos() == (Size)edge.start()) );
+					if ( edge.has_atom_info() ) {
+						anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+					} else {
+						anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
+					}
+				} else if ( edge.is_peptide() ) {
+					// peptide edge
+					int const dir( edge.polymer_direction() );
+					debug_assert( anchor_rsd.seqpos() == seqpos-dir );
+					anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
+				} else {
+					// chemical edge
+					debug_assert( seqpos == static_cast< Size >( edge.stop() ) && anchor_rsd.seqpos() == static_cast< Size >( edge.start() ) && edge.has_atom_info() );
+					anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+				}
+				debug_assert( anchor_atomno );
+				return anchor_atomno;
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		int
+			get_anchor_atomno(
+					conformation::Residue const & rsd,
+					int const dir // forward(1), backward(-1), or "dir_jump"
+					)
+			{
+				// if dir == 1 or -1, we are building a contiguous edge ("peptide edge")
+				// in the fold_tree ( ==> residue should be a polymer type? )
+				int const forward( 1 ), backward( -1 );
+
+				if ( dir == forward ) {
+					// C for proteins, O3' for DNA
+					if ( rsd.is_polymer() ) {
+						if ( rsd.is_upper_terminus() ) {
+							// this is a little strange to be folding through a terminal residue but kinematics doesn't
+							// have to correlate perfectly with chemical
+							return rsd.mainchain_atom( rsd.mainchain_atoms().size() );
+						} else {
+							return rsd.upper_connect_atom();
+						}
+					} else {
+						return get_anchor_atomno( rsd, kinematics::dir_jump );
+					}
+				} else if ( dir == backward ) {
+					// N for proteins, P for DNA
+					if ( rsd.is_polymer() ) {
+						if ( rsd.is_lower_terminus() ) {
+							// this is a little strange to be folding through a terminal residue but kinematics doesn't
+							// have to correlate perfectly with chemical
+							return rsd.mainchain_atom(1);
+						} else {
+							return rsd.lower_connect_atom();
+						}
+					} else {
+						return get_anchor_atomno( rsd, kinematics::dir_jump );
+					}
+
+				} else {
+					debug_assert( dir == kinematics::dir_jump );
+					// default for jumps, use the N-terminal attachment?
+					if ( rsd.mainchain_atoms().empty() ) {
+						// SHORT TERM HACK -- need to add some logic for root atomno
+						return 1;
+					} else {
+						// PB 10/29/07 - changing to use an interior mainchain atom
+						Size const nbb( rsd.n_mainchain_atoms() ); //    1  2  3  4  5  6  -- nbb
+						Size const mainchain_index( ( nbb-1 )/2 + 1 ); //   1  1  2  2  3  3  -- mainchain_index
+						return rsd.mainchain_atoms()[ mainchain_index ];
+						//return rsd.mainchain_atoms()[1];
+					}
+				}
+			}
+
+		/// @details  Determines the anchor and root atom indices based on residue types and the foldtree edge.
+
+		void
+			get_anchor_and_root_atoms(
+					conformation::Residue const & anchor_rsd,
+					conformation::Residue const & root_rsd,
+					kinematics::Edge const & edge,
+					Size & anchor_atomno,
+					Size & root_atomno
+					)
+			{
+				// AMW: There are some ugly special cases for pdb_GAI here. That's
+				// because the edges weren't getting good atom indices on them, I think?
+				// In any case, this function isn't called in tight loops, so we are ok.
+
+				ASSERT_ONLY(Size const anchor_pos( anchor_rsd.seqpos() ););
+				ASSERT_ONLY(Size const root_pos( root_rsd.seqpos() ););
+
+				if ( edge.is_polymer() ) {
+					// POLYMER EDGE
+					int const dir( edge.polymer_direction() );
+					debug_assert( dir == 1 || dir == -1 );
+					debug_assert( root_pos == anchor_pos + dir );
+					anchor_atomno = get_anchor_atomno( anchor_rsd, dir );
+					root_atomno   = get_root_atomno  (   root_rsd, dir );
+				} else {
+					debug_assert( anchor_pos == Size(edge.start()) && root_pos == Size(edge.stop()) );
+					if ( edge.has_atom_info() ) {
+						// JUMP OR CHEMICAL W/ ATOM INFO
+						if ( anchor_rsd.type().name() == "pdb_GAI" ||
+								anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
+						else anchor_atomno = anchor_rsd.atom_index( edge.upstream_atom() );
+						if ( root_rsd.type().name() == "pdb_GAI" ||
+								anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
+						else root_atomno   =   root_rsd.atom_index( edge.downstream_atom() );
+					} else {
+						if ( edge.is_jump() ) {
+							// JUMP EDGE
+							if ( anchor_rsd.type().name() == "pdb_GAI" ||
+									anchor_rsd.type().name() == "pdb_AX2" ) anchor_atomno = 1;
+							else anchor_atomno = get_anchor_atomno( anchor_rsd, kinematics::dir_jump );
+							if ( root_rsd.type().name() == "pdb_GAI" ||
+									anchor_rsd.type().name() == "pdb_AX2" ) root_atomno = 1;
+							else root_atomno   =   get_root_atomno(   root_rsd, kinematics::dir_jump );
+						} else if ( edge.is_chemical_bond() ) {
+							// CHEMICAL EDGE
+							get_chemical_root_and_anchor_atomnos( anchor_rsd, root_rsd, anchor_atomno, root_atomno );
+						} else {
+							utility_exit_with_message( "Unrecognized edge type!" );
+						}
+					}
+				}
+				return;
+			}
+
+
+		// this code assumed we were also being passed old_rsd:
+		// optionally debug some things before making atom_tree call
+		/**if ( debug ) {
+			BondID old_rsd_in;
+			vector1< BondID > old_rsd_out;
+			get_residue_connections( old_rsd, fold_tree, residues, old_rsd_in, old_rsd_out );
+			debug_assert( new_rsd_in.atom1 == old_rsd_in.atom1 && new_rsd_out.size() == old_rsd_out.size() );
+			for ( Size i=1; i<= new_rsd_out.size(); ++i ) {
+			debug_assert( new_rsd_out[i].atom2 == old_rsd_out[i].atom2 );
+			}
+			}**/
+
+
+		///////////////////////////////////////////////////////////////////////////////
+
+		void
+			promote_sameresidue_child_of_jump_atom(
+					kinematics::Edge const & edge,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomTree & atom_tree
+					)
+			{
+				debug_assert( edge.is_jump() );
+				Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
+				get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
+				atom_tree.promote_sameresidue_nonjump_child( id::AtomID( root_atomno, root_pos ) );
+			}
+
+
+		void
+			promote_sameresidue_child_of_jump_atom(
+					kinematics::Edge const & edge,
+					conformation::ResidueCOPs const & residues,
+					kinematics::AtomPointer2D const & atom_pointer
+					)
+			{
+				debug_assert( edge.is_jump() );
+				Size root_pos( edge.stop() ), anchor_atomno, root_atomno;
+				get_anchor_and_root_atoms( *residues[ edge.start() ], *residues[ root_pos ], edge, anchor_atomno, root_atomno );
+				kinematics::tree::AtomOP root_atom( atom_pointer[ id::AtomID( root_atomno, root_pos ) ] );
+				debug_assert( root_atom->is_jump() );
+				kinematics::tree::AtomOP same_residue_child( nullptr );
+				for ( Size i=0; i< root_atom->n_nonjump_children(); ++i ) {
+					kinematics::tree::AtomOP child( atom_pointer[ root_atom->get_nonjump_atom( i )->id() ] ); // want nonconst, use atom_pointer
+					if ( Size(child->id().rsd()) == root_pos ) {
+						same_residue_child = child;
+						break;
+					}
+				}
+				if ( same_residue_child ) {
+					debug_assert( !same_residue_child->is_jump() );
+					root_atom->delete_atom( same_residue_child );
+					root_atom->insert_atom( same_residue_child );
+				} else {
+					if ( TR.Warning.visible() ) TR.Warning << "Unable to keep stub in residue: jump_atom has no non-jump, same-residue children!" << std::endl;
+				}
+			}
+
+		void
+			get_chemical_root_and_anchor_atomnos(
+					conformation::Residue const & rsd_anchor,
+					conformation::Residue const & rsd_root,
+					Size & anchor_atom_no,
+					Size & root_atom_no
+					)
+			{
+				debug_assert( rsd_anchor.is_bonded( rsd_root ) );
+
+				Size first_connection_id = rsd_anchor.connections_to_residue( rsd_root )[ 1 ];
+				chemical::ResConnID first_connection = rsd_anchor.connect_map( first_connection_id );
+				anchor_atom_no = rsd_anchor.residue_connection( first_connection_id ).atomno();
+				root_atom_no = rsd_root.residue_connection( first_connection.connid() ).atomno();
+			}
+
+		///////////////////////////////////////////////////////////////////////////////
+		//
+		// right now, this is used by the pose to setup a mapping which is
+		// passed in to the atomtree when replacing one residue with another
+		//
+		//
+		// maybe the behavior should really be to identify atoms with the same
+		// name in the two residues and map them...
+		//
+		// oh well, this will work for rewiring backbone connections properly;
+		// basically the atomtree will use this mapping when it is replacing
+		// the atoms of rsd1 with the subtree formed by the atoms of rsd2
+		// for this to work, all outgoing connections from the rsd1 atoms have
+		// to have their rsd1-atom represented in this map, so the atomtree
+		// knows where to attach the child when rsd2 is put in.
+
+
+		/// @details only map by atom number, not by identity currently.
+		void
+			setup_corresponding_atoms(
+					id::AtomID_Map< id::AtomID > & atom_map,
+					conformation::Residue const & rsd1,
+					conformation::Residue const & rsd2
+					)
+			{
+
+				// PB -- this whole function is going to go away soon, so I'm not really worried about all the hacks
+
+				int const seqpos1( rsd1.seqpos() );
+				int const seqpos2( rsd2.seqpos() );
+
+				utility::vector1< Size > const &
+					mainchain1( rsd1.mainchain_atoms() ),
+					mainchain2( rsd2.mainchain_atoms() );
+
+				debug_assert( mainchain1.size() == mainchain2.size() );
+
+				// special case for virtual residues -- fpd
+				if ( mainchain1.size() == 0 &&
+						rsd1.type().name3() == "XXX" && rsd2.type().name3() == "XXX" ) {
+					debug_assert( rsd1.atoms().size() == rsd2.atoms().size() );
+
+					for ( Size i=1, i_end = rsd1.atoms().size(); i<= i_end; ++i ) {
+						atom_map.set( id::AtomID( i, seqpos1 ), id::AtomID( i, seqpos2 ) );
+					}
+				} else {
+					for ( Size i=1, i_end = mainchain1.size(); i<= i_end; ++i ) {
+						atom_map.set( id::AtomID( mainchain1[i], seqpos1 ),
+								id::AtomID( mainchain2[i], seqpos2 ) );
+					}
+					if ( rsd1.is_DNA() && rsd2.is_DNA() ) {
+						// special case for dna-dna jumps anchored at sidechain atoms
+						for ( Size i=1; i<= 4; ++i ) {
+							atom_map.set( id::AtomID( rsd1.chi_atoms(1)[i], seqpos1 ),
+									id::AtomID( rsd2.chi_atoms(1)[i], seqpos2 ) );
+						}
+					}
+
+					if ( rsd1.is_RNA() && rsd2.is_RNA() ) {
+						// By the way, this is a total hack AND SHOULD NOT BE CHECKED IN
+						// BEFORE CONSULTING WITH PHIL! -- rhiju
+						// special case for rna-rna jumps anchored at sidechain atoms
+						if ( rsd1.name1() == rsd2.name1() ) {
+							for ( Size i=1; i<= rsd1.natoms(); ++i ) {
+								atom_map.set( id::AtomID( i, seqpos1 ),
+										id::AtomID( i, seqpos2 ) );
+							}
+						}
+					}
+
+				}
+
+				/// Now include atoms involved in residue connections, since these might be anchor points for the atomtree
+				for ( Size connid=1; connid<= rsd1.n_possible_residue_connections() && connid <= rsd2.n_possible_residue_connections(); ++connid ) {
+					Size const atom1( rsd1.type().residue_connection( connid ).atomno() );
+					Size const atom2( rsd2.type().residue_connection( connid ).atomno() );
+					if ( rsd1.atom_name( atom1 ) == rsd2.atom_name( atom2 ) ) {
+						atom_map.set( id::AtomID( atom1, seqpos1 ), id::AtomID( atom2, seqpos2 ) );
+					}
+				}
+			}
+
+		/// @brief Switch the disulfide state of a disulfide-forming residue (e.g. CYS->CYD or CYD->CYS or
+		/// DCYD->DCYS or DCYS->DCYD or whatnot).
+		/// @param[in] index Position of the residue to replace.
+		/// @param[in] cys_type_name3 The 3-letter name of the cys type to use: e.g. CYS
+		///  or CYD.  DEPRECATED and kept only for backward-compatibility.
+		/// @param[inout] conf The conformation to modify
+		/// @details Substitutes a residue with the given cys type, keeping as many of
+		///  the existing atom positions as possible.  If the original residue has a
+		///  disulfide variant it will be removed, otherwise a disulfide variant will
+		///  be added.  Should work with any ResidueTypeSet that has the proper
+		///  disulfide variants.  If the replacement fails for any reason a warning
+		///  will be printed.
+		/// @return true if the replacement was successful, false otherwise.
+		bool change_cys_state(
+				Size const index,
+				std::string const & cys_type_name3, //Deprecated.
+				Conformation & conf
+				) {
+
+			bool removing(false);
+
+			// Cache information on old residue.
+			core::chemical::ResidueType const & old_type( conf.residue_type( index ) );
+			chemical::ResidueTypeSetCOP residue_type_set = conf.residue_type_set_for_conf( old_type.mode() );
+
+			// make sure we're working on a disulfide-forming type.
+			if ( ( ! old_type.is_sidechain_thiol() ) && ( ! old_type.is_disulfide_bonded() ) ) {
+				if ( TR.Warning.visible() ) TR.Warning << "change_cys_state() was called on non-cys-like residue " << index << ", skipping!" << std::endl;
+				return false;
+			}
+
+			// Track the variant types of the old residue type.  We want the
+			// new residue to have the same variant type as the old.
+			utility::vector1< std::string > variant_types = old_type.properties().get_list_of_variants();
+
+			// check and handle disulfide state
+			if ( old_type.has_variant_type( chemical::DISULFIDE ) ) {
+				// if the old residue has DISULFIDE variant type then we are removing a
+				// disulfide, so remove the variant type from the list
+				variant_types.erase( std::find( variant_types.begin(), variant_types.end(), "DISULFIDE" ) );
+				removing = true;
+				//TR << "We just erased the DISULFIDE variant type as desired, since we are going from rn " << rn << " to thiol type " << std::endl;
+
+			} else /*If it does not have the DISULFIDE variant type*/ {
+				//TR << "We just added the DISULFIDE variant type as desired, since we are going from rn " << rn << " to disulfide type " << std::endl;
+				variant_types.push_back( "DISULFIDE" ); //chemical::DISULFIDE ); // creating a disulfide
+				removing = false;
+			}
+
+			// The following is for backward-compatibility only, for functions that would request CYD when the residue was already CYD or whatnot.
+			if ( cys_type_name3=="CYS" && !removing /*not removing if disulfide variant not found*/ ) return true; //If we're asked for a cys and we already have a cys, do nothing.
+			else if ( cys_type_name3=="CYD" && removing /*removing if the disulfide variant was found*/ ) return true; //Similarly, if we're asked for a cyd and we already have a cyd, do nothing.
+
+			// Get the residue type of the desired new residue type.
+			chemical::ResidueTypeCOP replacement_type( residue_type_set->get_representative_type_name3( old_type.name3(), variant_types ) );
+			if ( replacement_type ) {
+				Residue const & res = conf.residue(index);
+				ResidueOP new_res = ResidueFactory::create_residue( *replacement_type, res, conf );
+				copy_residue_coordinates_and_rebuild_missing_atoms( res, *new_res, conf );
+				conf.replace_residue( index, *new_res, false );
+				return true;
+			}
+
+
+			// If we are here then a residue type match wasn't found; issue error message.
+			if ( TR.Error.visible() ) TR.Error << "Couldn't find a " << (removing ? "disulfide-free" : "disulfide-bonded")  << " equivalent for residue " << old_type.name3() << index << "." <<std::endl;
+
+			return false;
 		}
 
-		if ( other_res == upper_res ) {
-			// Already a disulfide bond:
-			// A better "reciprocal" test: is its lower_res connect_atom() its disulfide atom?
-			// This way the ATOM contains the constant upper_res information.
-			TR.Trace << "Connect atom on " << upper_res << " was " << conformation.residue_type( upper_res ).atom_name( conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) << std::endl;
-			runtime_assert_msg( ObjexxFCL::stripped(
-				conformation.residue_type( upper_res ).atom_name(
-				conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) )
-				== conformation.residue_type( upper_res ).get_disulfide_atom_name(),
-				"Error: Disulfide bond wasn't reciprocal");
-			//runtime_assert_msg(conformation.residue( upper_res ).connect_map( conn ).resid() == lower_res,
-			// "Error: Disulfide bond wasn't reciprocal");
-			//return;
-		}
+		id::NamedAtomID
+			atom_id_to_named_atom_id(
+					id::AtomID const & atom_id,
+					conformation::Residue const & rsd
+					){
+				std::string atom_name;
+				Size rsd_id;
+				if ( atom_id.atomno() <= rsd.atoms().size() ) {
+					atom_name = rsd.atom_name( atom_id.atomno() );
+					rsd_id = atom_id.rsd();
+				} else {
+					if ( TR.Error.visible() ) TR.Error << "Can't resolve atom_id " << atom_id << std::endl;
+					rsd_id = 0;
+					atom_name ="";
+				}
 
-		// Break the disulfide bond to upper_res
-		bool result = change_cys_state( other_res, "", conformation );
-		runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
-	} else {
-		form_disulfide_helper(conformation, lower_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the lower_res residue to a disulfide-forming variant, preserving other variant types in the process.
-	}
-	// Break existing disulfide bonds to upper
-	if ( !upper_is_symm_equivalent_of_lower( conformation, lower_res, upper_res ) ) { //If the upper residue is the symmetric equivalent of the lower residue, then we've already altered its disulfide type, and can skip the next few steps.
-		if ( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) ) {
-			std::string ucatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
-			Size const connect_atom( conformation.residue( upper_res ).atom_index( ucatom ) );
+				return id::NamedAtomID( atom_name, rsd_id );
+			}
+
+		id::AtomID
+			named_atom_id_to_atom_id(
+					id::NamedAtomID const & named_atom_id,
+					conformation::Residue const & rsd
+					){
+				return id::AtomID( rsd.atom_index( named_atom_id.atom() ), named_atom_id.rsd() );
+			}
+
+		id::NamedStubID
+			stub_id_to_named_stub_id(
+					id::StubID const & stub_id,
+					conformation::Residue const & rsd
+					){
+				using namespace core::id;
+				if ( stub_id.center().valid() ) {
+					return NamedStubID(
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.center() , rsd ) ),
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
+							);
+				} else {
+					return NamedStubID( // TODO does this make sense? if input stub is bad, what should be done?
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 1 ), rsd ) ),
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 2 ), rsd ) ),
+							NamedAtomID( atom_id_to_named_atom_id( stub_id.atom( 3 ), rsd ) )
+							);
+				}
+			}
+
+		id::StubID
+			named_stub_id_to_stub_id(
+					id::NamedStubID const & named_stub_id,
+					conformation::Residue const & rsd
+					){
+				using namespace core::id;
+				if ( named_stub_id.center().valid() ) {
+					return StubID(
+							AtomID( named_atom_id_to_atom_id( named_stub_id.center() , rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
+							);
+				} else {
+					return StubID( // TODO does this make sense? if input stub is bad, what should be done?
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 1 ), rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 2 ), rsd ) ),
+							AtomID( named_atom_id_to_atom_id( named_stub_id.atom( 3 ), rsd ) )
+							);
+				}
+			}
+
+		/// @brief Gets a disulfide-forming residue's partner in the disulfide bond.
+		/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
+		core::Size get_disulf_partner (
+				core::conformation::Conformation const &conformation,
+				core::Size const res_index
+				) {
+			runtime_assert( res_index <= conformation.size() );
+			runtime_assert( conformation.residue( res_index ).type( ).is_disulfide_bonded() ) ;
+			std::string lcatom = conformation.residue(res_index).type( ).get_disulfide_atom_name();
+			Size const connect_atom( conformation.residue( res_index ).atom_index( lcatom ) );
 			Size other_res( 0 );
-			Size conn(0);
-			for ( conn = conformation.residue( upper_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-				if ( Size ( conformation.residue(upper_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
-					other_res = conformation.residue( upper_res ).connect_map( conn ).resid();
+			for ( core::Size conn = conformation.residue( res_index ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+				if ( static_cast<core::Size>( conformation.residue( res_index ).type().residue_connection(conn).atomno() ) == connect_atom ) {
+					other_res = conformation.residue( res_index ).connect_map( conn ).resid();
 					break;
 				}
 			}
 			if ( other_res == 0 ) {
-				if ( TR.Error.visible() ) TR.Error << "Residue " << upper_res << " was disulfide bonded but had no partner" << std::endl;
+				if ( TR.Error.visible() ) TR.Error << "Residue " << res_index << " was disulfide bonded but had no partner" << std::endl;
 				utility_exit();
 			}
-
-			// Break the disulfide bond to lower_res
-			bool result = change_cys_state( other_res, "", conformation );
-			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
-		} else {
-			form_disulfide_helper(conformation, upper_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the upper_res residue to a disulfide-forming variant, preserving other variant types in the process.
+			return other_res;
 		}
-	} //If !upper_is_symm_equivalent_of_lower()
 
-	// Both residues are now CYD
-	runtime_assert( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) );
-	runtime_assert( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) );
-
-	//form the bond between the two residues
-	// NOW we still need to get the lc and uc atoms, because we couldn't get them before
-	// since this function doesn't necessarily start with a cys type
-	// (damn this function!)
-	std::string const & lcatom = conformation.residue_type( lower_res ).get_disulfide_atom_name();
-	std::string const & ucatom = conformation.residue_type( upper_res ).get_disulfide_atom_name();
-	conformation.declare_chemical_bond( lower_res, lcatom, upper_res, ucatom );
-}
-
-/// @brief Helper function for the form_disulfide function.
-/// @details This function ensures that as a residue is mutated to a disulfide-bonding residue type,
-/// all other variant types are preserved; it is used to avoid code duplication.
-/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
-void form_disulfide_helper(
-	core::conformation::Conformation &conformation,
-	core::Size const res_index,
-	core::chemical::ResidueTypeSetCOP restype_set,
-	bool const preserve_d_residues,
-	bool const force_d_residues
-) {
-	using namespace core::chemical;
-	AA query_type( aa_cys );
-
-	// AMW: This was not explicit enough to me and I briefly altered this function's semantics!
-	// If the residues aren't already a disulfide-forming type, we must make them one. Functions like
-	// disulfide insertion mover assume we do this.
-	// VKM: This was failing to act properly on residues that were thiol-containing.  I'm taking out the
-	// unncessary check for !thiol-containing and !disulfide-bonded.
-	if ( force_d_residues ) {
-		if ( conformation.residue_type(res_index).is_alpha_aa() ) {
-			query_type = aa_dcs;
-		} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
-			query_type = aa_b3c;
+		void break_all_disulfides(
+				core::conformation::Conformation &conformation
+				) {
+			utility::vector1< std::pair<core::Size,core::Size> > disulfides;
+			disulfide_bonds( conformation, disulfides);
+			for ( auto const & pair: disulfides ) {
+				break_disulfide( conformation, pair.first, pair.second );
+			}
 		}
-	} else {
-		if ( conformation.residue_type(res_index).is_alpha_aa() ) {
-			if ( !conformation.residue_type(res_index).is_d_aa() || !preserve_d_residues ) {
-				query_type = aa_cys;
+
+		/// @brief Breaks a disulfide bond.
+		/// @author Vikram K. Mulligan, Baker lab (vmullig@uw.edu).
+		void break_disulfide(
+				core::conformation::Conformation &conformation,
+				core::Size const res1,
+				core::Size const res2
+				) {
+			runtime_assert( res1 <= conformation.size() && res2 <= conformation.size() );
+			runtime_assert( conformation.residue(res1).type().is_disulfide_bonded() && conformation.residue(res2).type().is_disulfide_bonded() );
+			runtime_assert_string_msg( get_disulf_partner( conformation, res1 ) == res2, "Error: cannot break a disulfide bond, because the residues in question are not bonded." );
+			bool result = change_cys_state( res1, "", conformation );
+			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res1).name3());
+			result = change_cys_state( res2, "", conformation );
+			runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(res2).name3());
+			return;
+		}
+
+		/// @brief Introduce cysteines at the specified location and define a
+		///  disulfide bond between them.
+		/// @details Does not do the repacking & minimization required to place the
+		///  disulfide correctly.
+		void
+			form_disulfide(
+					Conformation & conformation,
+					Size lower_res,
+					Size upper_res,
+					bool const preserve_d_residues,
+					bool const force_d_residues
+					) {
+				// Verify we're dealing with a FA conformation
+				runtime_assert( conformation.is_fullatom() );
+
+				chemical::ResidueTypeSetCOP restype_set( conformation.residue_type_set_for_conf( chemical::FULL_ATOM_t ) );
+
+				// Break existing disulfide bonds to lower
+				if ( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) ) { // full atom residue
+
+					// In rare cases this connection-matching logic breaks.
+					// A disulfide bond can be reciprocal even if the other residue's disulfide connection number
+					// is different (for example: if you have no LOWER or UPPER or something)
+
+					std::string lcatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
+					Size const connect_atom( conformation.residue( lower_res ).atom_index( lcatom ) );
+					Size other_res( 0 );
+					Size conn(0);
+					for ( conn = conformation.residue( lower_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+						if ( Size( conformation.residue(lower_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
+							other_res = conformation.residue( lower_res ).connect_map( conn ).resid();
+							break;
+						}
+					}
+					if ( other_res == 0 ) {
+						if ( TR.Error.visible() ) TR.Error << "Residue " << lower_res << " was disulfide bonded but had no partner" << std::endl;
+						utility_exit();
+					}
+
+					if ( other_res == upper_res ) {
+						// Already a disulfide bond:
+						// A better "reciprocal" test: is its lower_res connect_atom() its disulfide atom?
+						// This way the ATOM contains the constant upper_res information.
+						TR.Trace << "Connect atom on " << upper_res << " was " << conformation.residue_type( upper_res ).atom_name( conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) << std::endl;
+						runtime_assert_msg( ObjexxFCL::stripped(
+									conformation.residue_type( upper_res ).atom_name(
+										conformation.residue( upper_res ).connect_atom( conformation.residue( lower_res ) ) ) )
+								== conformation.residue_type( upper_res ).get_disulfide_atom_name(),
+								"Error: Disulfide bond wasn't reciprocal");
+						//runtime_assert_msg(conformation.residue( upper_res ).connect_map( conn ).resid() == lower_res,
+						// "Error: Disulfide bond wasn't reciprocal");
+						//return;
+					}
+
+					// Break the disulfide bond to upper_res
+					bool result = change_cys_state( other_res, "", conformation );
+					runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
+				} else {
+					form_disulfide_helper(conformation, lower_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the lower_res residue to a disulfide-forming variant, preserving other variant types in the process.
+				}
+				// Break existing disulfide bonds to upper
+				if ( !upper_is_symm_equivalent_of_lower( conformation, lower_res, upper_res ) ) { //If the upper residue is the symmetric equivalent of the lower residue, then we've already altered its disulfide type, and can skip the next few steps.
+					if ( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) ) {
+						std::string ucatom = conformation.residue_type(lower_res).get_disulfide_atom_name();
+						Size const connect_atom( conformation.residue( upper_res ).atom_index( ucatom ) );
+						Size other_res( 0 );
+						Size conn(0);
+						for ( conn = conformation.residue( upper_res ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+							if ( Size ( conformation.residue(upper_res).type().residue_connection(conn).atomno() ) == connect_atom ) {
+								other_res = conformation.residue( upper_res ).connect_map( conn ).resid();
+								break;
+							}
+						}
+						if ( other_res == 0 ) {
+							if ( TR.Error.visible() ) TR.Error << "Residue " << upper_res << " was disulfide bonded but had no partner" << std::endl;
+							utility_exit();
+						}
+
+						// Break the disulfide bond to lower_res
+						bool result = change_cys_state( other_res, "", conformation );
+						runtime_assert_msg(result,"Error removing disulfide variant from "+conformation.residue(other_res).name3());
+					} else {
+						form_disulfide_helper(conformation, upper_res, restype_set, preserve_d_residues, force_d_residues); //This mutates the upper_res residue to a disulfide-forming variant, preserving other variant types in the process.
+					}
+				} //If !upper_is_symm_equivalent_of_lower()
+
+				// Both residues are now CYD
+				runtime_assert( conformation.residue( lower_res ).has_variant_type( chemical::DISULFIDE ) );
+				runtime_assert( conformation.residue( upper_res ).has_variant_type( chemical::DISULFIDE ) );
+
+				//form the bond between the two residues
+				// NOW we still need to get the lc and uc atoms, because we couldn't get them before
+				// since this function doesn't necessarily start with a cys type
+				// (damn this function!)
+				std::string const & lcatom = conformation.residue_type( lower_res ).get_disulfide_atom_name();
+				std::string const & ucatom = conformation.residue_type( upper_res ).get_disulfide_atom_name();
+				conformation.declare_chemical_bond( lower_res, lcatom, upper_res, ucatom );
+			}
+
+		/// @brief Helper function for the form_disulfide function.
+		/// @details This function ensures that as a residue is mutated to a disulfide-bonding residue type,
+		/// all other variant types are preserved; it is used to avoid code duplication.
+		/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
+		void form_disulfide_helper(
+				core::conformation::Conformation &conformation,
+				core::Size const res_index,
+				core::chemical::ResidueTypeSetCOP restype_set,
+				bool const preserve_d_residues,
+				bool const force_d_residues
+				) {
+			using namespace core::chemical;
+			AA query_type( aa_cys );
+
+			// AMW: This was not explicit enough to me and I briefly altered this function's semantics!
+			// If the residues aren't already a disulfide-forming type, we must make them one. Functions like
+			// disulfide insertion mover assume we do this.
+			// VKM: This was failing to act properly on residues that were thiol-containing.  I'm taking out the
+			// unncessary check for !thiol-containing and !disulfide-bonded.
+			if ( force_d_residues ) {
+				if ( conformation.residue_type(res_index).is_alpha_aa() ) {
+					query_type = aa_dcs;
+				} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
+					query_type = aa_b3c;
+				}
 			} else {
-				query_type = aa_dcs;
+				if ( conformation.residue_type(res_index).is_alpha_aa() ) {
+					if ( !conformation.residue_type(res_index).is_d_aa() || !preserve_d_residues ) {
+						query_type = aa_cys;
+					} else {
+						query_type = aa_dcs;
+					}
+				} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
+					query_type = aa_b3c;
+				}
 			}
-		} else if ( conformation.residue_type(res_index).is_beta_aa() ) {
-			query_type = aa_b3c;
-		}
-	}
 
-	//Get the list of variant types for this residue, so that the replacement has the same variant types.
-	utility::vector1< std::string > variant_types = conformation.residue(res_index).type().properties().get_list_of_variants();
+			//Get the list of variant types for this residue, so that the replacement has the same variant types.
+			utility::vector1< std::string > variant_types = conformation.residue(res_index).type().properties().get_list_of_variants();
 
-	//Add a disulfide variant type to the list, since we're turning CYS into CYD and so forth.
-	bool has_disulfide(false);
-	for ( core::Size i = 1, imax = variant_types.size(); i <= imax; ++i ) {
-		if ( variant_types[ i ] == "DISULFIDE" ) {
-			has_disulfide = true;
-			break;
-		}
-	}
-	if ( !has_disulfide ) variant_types.push_back( "DISULFIDE" );
-
-	if ( conformation.residue_type(res_index).is_beta_aa() && ( conformation.residue_type(res_index).is_d_aa() || force_d_residues ) ) {
-		variant_types.push_back( "D" );
-	}
-
-	//Get the suitable variant type, and create a residue with it:
-	ResidueOP lower_cyd( ResidueFactory::create_residue( *(restype_set->get_representative_type_aa( query_type, variant_types )), conformation.residue( res_index ), conformation ) );
-
-	copy_residue_coordinates_and_rebuild_missing_atoms( conformation.residue(res_index), *lower_cyd, conformation, true );
-	conformation.replace_residue(res_index, *lower_cyd, false /*backbone already oriented*/); // doug
-
-	return;
-}
-
-/// @brief Another helper function for the form_disulfide function.
-/// @details Returns true if and only if the conformation is symmetric and upper_res is a symmetric copy of lower_res.
-/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
-bool
-upper_is_symm_equivalent_of_lower(
-	core::conformation::Conformation const &conformation,
-	core::Size const lower_res,
-	core::Size const upper_res
-) {
-	core::conformation::symmetry::SymmetricConformationCOP sym_conf( utility::pointer::dynamic_pointer_cast< core::conformation::symmetry::SymmetricConformation const >(conformation.get_self_ptr()) );
-	if ( !sym_conf ) return false;
-	//From now on, can assume conformation IS symmetric.
-
-	if ( sym_conf->Symmetry_Info()->bb_is_independent( lower_res ) ) {
-		if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) return false; //If both residues are independent, they're not equivalent.
-		if ( sym_conf->Symmetry_Info()->bb_follows( upper_res ) == lower_res ) return true;  //If the upper res follows the lower, then these ARE equivalent residues.
-		return false; //Otherwise they're not, if the lower res is independent.
-	}
-	//From now on, assume lower_res depends on something
-	if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) {
-		if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == upper_res ) return true; //If the lower res follows the upper, then these ARE equivalent residues.
-		return false; //Otherwise they're not, if the upper is independent.
-	}
-
-	//From now on, lower_res and upper_res can be assumed to depend on something.  If they depend on the same thing, they're equivalent.
-	if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == sym_conf->Symmetry_Info()->bb_follows(upper_res) ) return true;
-
-	return false;
-}
-
-/// @brief Find whether there is a disulfide defined between two residues
-///
-/// @details We define a disulfide to exist between a pair of residues iff
-///  -# They are both cysteines
-///  -# They are bonded by their sidechains
-bool
-is_disulfide_bond( conformation::Conformation const& conformation, Size residueA_pos, Size residueB_pos)
-{
-	Residue const& A = conformation.residue(residueA_pos);
-	Residue const& B = conformation.residue(residueB_pos);
-
-	if ( !A.is_protein() || !B.is_protein() ) {
-		return false;
-	}
-
-	//both Cys or CysD
-	//if( A.type().name1() != 'C' || B.type().name1() != 'C' )
-	if ( ( ! A.type().is_sidechain_thiol() && ! A.type().is_disulfide_bonded() )
-			|| ( ! B.type().is_sidechain_thiol() && ! B.type().is_disulfide_bonded() ) ) {
-		return false;
-	}
-
-	//std::string n1 = A.type().name3(); std::string n2 = B.type().name3();
-
-	//bonded
-	runtime_assert( A.type().has( A.type().get_disulfide_atom_name() ) ); //should be fa or centroid
-	Size a_connect_atom = A.atom_index( A.type().get_disulfide_atom_name() );
-
-	for ( Size connection = A.type().n_possible_residue_connections(); connection >= 1; --connection ) {
-		//check if A bonded to B
-		if ( (Size) A.type().residue_connection( connection ).atomno() == a_connect_atom && //bond to sg, not the backbone
-				A.connect_map( connection ).resid() == residueB_pos ) { //bonded to B
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/// @brief Generate a list of all disulfide bonds in the conformation
-void
-disulfide_bonds( conformation::Conformation const& conformation, utility::vector1< std::pair<Size,Size> > & disulfides )
-{
-	for ( Size i = 1; i<= conformation.size(); ++i ) {
-		Residue const& res(conformation.residue(i));
-
-		// Skip things besides CYD
-		//if( !(res.aa() == chemical::aa_cys && res.has_variant_type(chemical::DISULFIDE) ))
-		if ( !(res.type().is_disulfide_bonded() && res.has_variant_type(chemical::DISULFIDE) ) ) {
-			continue;
-		}
-		Size connect_atom( 0);
-		if ( res.type().get_disulfide_atom_name() == "NONE" ) {
-			if ( TR.Warning.visible() ) TR.Warning << "unable to establish which atom to use for the disulfide to residue " << i << std::endl;
-			continue;
-		} else {
-			connect_atom = res.atom_index( res.type().get_disulfide_atom_name() ) ;
-		}
-
-		Size other_res(0);
-		Size conn;
-		for ( conn = conformation.residue( i ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
-			if ( Size( conformation.residue( i ).type().residue_connection(conn).atomno() ) == connect_atom ) {
-				other_res = conformation.residue( i ).connect_map( conn ).resid();
-				break;
+			//Add a disulfide variant type to the list, since we're turning CYS into CYD and so forth.
+			bool has_disulfide(false);
+			for ( core::Size i = 1, imax = variant_types.size(); i <= imax; ++i ) {
+				if ( variant_types[ i ] == "DISULFIDE" ) {
+					has_disulfide = true;
+					break;
+				}
 			}
-		}
-		if ( other_res == 0 ) {
-			TR.Error << "Residue " << i << " was disulfide bonded but had no partner" << std::endl;
-			utility_exit();
-		}
+			if ( !has_disulfide ) variant_types.push_back( "DISULFIDE" );
 
-		// Output the pair once
-		if ( i < other_res ) {
-			disulfides.push_back( std::make_pair(i, other_res) );
-		}
-	}
-}
-
-
-/// @brief    Return a nearby TorsionID with approximately the same 3D orientation, selected from the give TorsionIDs.
-/// @details  The downstream effects of a torsion move can be minimized by twisting a nearby torsion in the opposite
-///           direction with the same magnitude, resulting in a net "shearing" motion, if and only if the orientation
-///           of the two bonds are similar, that is, if the two bonds are approximately parallel.  This function is
-///           useful for finding such a torsion from a supplied list of torsions.
-/// @param    <conf>            the Conformation
-/// @param    <torsions>        a list of torsions to search
-/// @param    <query_torsion>   the TorsionID to compare
-/// @author   Labonte <JWLabonte@jhu.edu>
-core::id::TorsionID
-find_bond_torsion_with_nearest_orientation(
-	core::conformation::Conformation const & conf,
-	utility::vector1< core::id::TorsionID > const & torsions,
-	core::id::TorsionID const & query_torsion )
-{
-	using namespace core;
-
-	Vector const ref_bond_vector( conf.bond_orientation( query_torsion ) );
-
-	Real max_dot_product( 0.0 );
-	id::TorsionID best_torsion;
-	for ( auto torsion : torsions ) {
-		if ( torsion == query_torsion ) { continue; }  // Do not compare to self.
-		Vector const query_bond_vector( conf.bond_orientation( torsion ) );
-		Real const dot_product( fabs( numeric::dot( query_bond_vector, ref_bond_vector ) ) );
-		if ( dot_product > max_dot_product ) {
-			max_dot_product = dot_product;
-			best_torsion = torsion;
-		}
-	}
-
-	return best_torsion;
-}
-
-
-// Ring-related Functions /////////////////////////////////////////////////////
-
-// What is the attachment position of the query atom on the given ring?
-core::uint
-position_of_atom_on_ring(
-	Residue const & residue,
-	core::uint query_atom,
-	utility::vector1< core::uint > const & ring_atoms )
-{
-	if ( ring_atoms.contains( query_atom ) ) {
-		return 0;
-	}
-	utility::vector1< uint > const bonded_heavy_atoms( residue.get_adjacent_heavy_atoms( query_atom ) );
-	Size const n_ring_atoms( ring_atoms.size() );
-	for ( uint position( 1 ); position <= n_ring_atoms; ++position ) {
-		for ( uint bonded_heavy_atom : bonded_heavy_atoms ) {
-			if ( ring_atoms[ position ] == bonded_heavy_atom ) {
-				return position;
+			if ( conformation.residue_type(res_index).is_beta_aa() && ( conformation.residue_type(res_index).is_d_aa() || force_d_residues ) ) {
+				variant_types.push_back( "D" );
 			}
+
+			//Get the suitable variant type, and create a residue with it:
+			ResidueOP lower_cyd( ResidueFactory::create_residue( *(restype_set->get_representative_type_aa( query_type, variant_types )), conformation.residue( res_index ), conformation ) );
+
+			copy_residue_coordinates_and_rebuild_missing_atoms( conformation.residue(res_index), *lower_cyd, conformation, true );
+			conformation.replace_residue(res_index, *lower_cyd, false /*backbone already oriented*/); // doug
+
+			return;
 		}
-	}
-	return 0;
-}
 
-// Is the query atom in this residue axial or equatorial to the given ring or neither?
-/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
-/// axial or equatorial to it (or neither).  The attachment atom is auto-detected.
-/// @param   <residue>:    The Residue containing the atoms in question.
-/// @param   <query_atom>: The index of the atom in question.
-/// @param   <ring_atoms>: A list of indices for the atoms of a monocyclic ring system in sequence.
-/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
-/// @author  Labonte <JWLabonte@jhu.edu>
-chemical::rings::AxEqDesignation
-is_atom_axial_or_equatorial_to_ring(
-	Residue const & residue,
-	core::uint query_atom,
-	utility::vector1< core::uint > const & ring_atoms )
-{
-	using namespace utility;
-	using namespace numeric;
+		/// @brief Another helper function for the form_disulfide function.
+		/// @details Returns true if and only if the conformation is symmetric and upper_res is a symmetric copy of lower_res.
+		/// @author Vikram K. Mulligan, Baker laboratory (vmullig@uw.edu)
+		bool
+			upper_is_symm_equivalent_of_lower(
+					core::conformation::Conformation const &conformation,
+					core::Size const lower_res,
+					core::Size const upper_res
+					) {
+				core::conformation::symmetry::SymmetricConformationCOP sym_conf( utility::pointer::dynamic_pointer_cast< core::conformation::symmetry::SymmetricConformation const >(conformation.get_self_ptr()) );
+				if ( !sym_conf ) return false;
+				//From now on, can assume conformation IS symmetric.
 
-	uint const attachment_point( position_of_atom_on_ring( residue, query_atom, ring_atoms) );
-	if ( attachment_point ) {
-		// We found an attachment point.
-		// Now we need to get the coordinates of all the important atoms and call the function that does the actual
-		// math.
-		xyzVector< Distance > const query_atom_coords( residue.xyz( query_atom ) );
-		xyzVector< Distance > const attachment_atom_coords( residue.xyz( ring_atoms[ attachment_point ] ) );
+				if ( sym_conf->Symmetry_Info()->bb_is_independent( lower_res ) ) {
+					if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) return false; //If both residues are independent, they're not equivalent.
+					if ( sym_conf->Symmetry_Info()->bb_follows( upper_res ) == lower_res ) return true;  //If the upper res follows the lower, then these ARE equivalent residues.
+					return false; //Otherwise they're not, if the lower res is independent.
+				}
+				//From now on, assume lower_res depends on something
+				if ( sym_conf->Symmetry_Info()->bb_is_independent( upper_res ) ) {
+					if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == upper_res ) return true; //If the lower res follows the upper, then these ARE equivalent residues.
+					return false; //Otherwise they're not, if the upper is independent.
+				}
 
-		Size const n_ring_atoms( ring_atoms.size() );
-		vector1< xyzVector< Distance > > ring_atom_coords( n_ring_atoms );
-		for ( uint j( 1 ); j <= n_ring_atoms; ++j ) {
-			ring_atom_coords[ j ] = residue.xyz( ring_atoms[ j ] );
-		}
-		return chemical::rings::is_atom_axial_or_equatorial_to_ring(
-			query_atom_coords, attachment_atom_coords, ring_atom_coords );
-	}
-	TR.Debug << "The attachment point for the query atom is not found in the ring; ";
-	TR.Debug << "an axial/equatorial designation is meaningless." << std::endl;
-	return chemical::rings::NEITHER;
-}
+				//From now on, lower_res and upper_res can be assumed to depend on something.  If they depend on the same thing, they're equivalent.
+				if ( sym_conf->Symmetry_Info()->bb_follows(lower_res) == sym_conf->Symmetry_Info()->bb_follows(upper_res) ) return true;
 
-// Is the query atom in this residue axial or equatorial or neither?
-/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
-/// axial or equatorial to it (or neither).  The ring is requested from the Residue.
-/// @param   <residue>:    The Residue containing the atoms in question, which must have exactly one ring.
-/// @param   <query_atom>: The index of the atom in question.
-/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
-/// @author  Labonte <JWLabonte@jhu.edu>
-chemical::rings::AxEqDesignation
-is_atom_axial_or_equatorial( Residue const & residue, uint query_atom )
-{
-	chemical::ResidueType const & rsd_type( residue.type() );
-	if ( rsd_type.n_rings() != 1 ) {
-		TR.Warning << "Queried atom must be on a cyclic residue with exactly one ring." << std::endl;
-		return chemical::rings::NEITHER;
-	}
+				return false;
+			}
 
-	return is_atom_axial_or_equatorial_to_ring( residue, query_atom, rsd_type.ring_atoms( 1 ) );
-}
+		/// @brief Find whether there is a disulfide defined between two residues
+		///
+		/// @details We define a disulfide to exist between a pair of residues iff
+		///  -# They are both cysteines
+		///  -# They are bonded by their sidechains
+		bool
+			is_disulfide_bond( conformation::Conformation const& conformation, Size residueA_pos, Size residueB_pos)
+			{
+				Residue const& A = conformation.residue(residueA_pos);
+				Residue const& B = conformation.residue(residueB_pos);
 
-chemical::ResidueTypeCOP
-virtual_type_for_conf( core::conformation::Conformation const & conformation ) {
-	core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
-	core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("VRT") );
-	if ( ! rsd_type ) {
-		// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
-		core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
-		if ( mode == core::chemical::MIXED_t ) {
-			mode = core::chemical::FULL_ATOM_t;
-		}
-		residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
-		rsd_type = residue_set->name_mapOP("VRT");
-		if ( ! rsd_type ) {
-			TR.Error << "Can't find residue type VRT in type set of mode " << mode << std::endl;
-			utility_exit_with_message("Cannot find residue type VRT" );
-		}
-	}
-	return rsd_type;
-}
+				if ( !A.is_protein() || !B.is_protein() ) {
+					return false;
+				}
 
-chemical::ResidueTypeCOP
-inv_virtual_type_for_conf( core::conformation::Conformation const &conformation ) {
-	core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
-	core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("INV_VRT") );
-	if ( ! rsd_type ) {
-		// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
-		core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
-		if ( mode == core::chemical::MIXED_t ) {
-			mode = core::chemical::FULL_ATOM_t;
-		}
-		residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
-		rsd_type = residue_set->name_mapOP("INV_VRT");
-		if ( ! rsd_type ) {
-			TR.Error << "Can't find residue type INV_VRT in type set of mode " << mode << std::endl;
-			utility_exit_with_message("Cannot find residue type INV_VRT" );
-		}
-	}
-	return rsd_type;
-}
+				//both Cys or CysD
+				//if( A.type().name1() != 'C' || B.type().name1() != 'C' )
+				if ( ( ! A.type().is_sidechain_thiol() && ! A.type().is_disulfide_bonded() )
+						|| ( ! B.type().is_sidechain_thiol() && ! B.type().is_disulfide_bonded() ) ) {
+					return false;
+				}
 
-core::Vector
-all_atom_center(
-	core::conformation::Residue const & rsd
-) {
+				//std::string n1 = A.type().name3(); std::string n2 = B.type().name3();
 
-	utility::vector1< core::Vector > coords;
+				//bonded
+				runtime_assert( A.type().has( A.type().get_disulfide_atom_name() ) ); //should be fa or centroid
+				Size a_connect_atom = A.atom_index( A.type().get_disulfide_atom_name() );
 
-	for ( Size jj(1); jj <= rsd.natoms(); ++ jj ) {
-		coords.push_back( rsd.xyz( jj ) );
-	}
+				for ( Size connection = A.type().n_possible_residue_connections(); connection >= 1; --connection ) {
+					//check if A bonded to B
+					if ( (Size) A.type().residue_connection( connection ).atomno() == a_connect_atom && //bond to sg, not the backbone
+							A.connect_map( connection ).resid() == residueB_pos ) { //bonded to B
+						return true;
+					}
+				}
 
-	if ( ! coords.size() ) { utility_exit_with_message( "Cannot compute center of mass for no atoms!" ); }
+				return false;
+			}
 
-	return numeric::center_of_mass( coords );
-}
+		/// @brief Generate a list of all disulfide bonds in the conformation
+		void
+			disulfide_bonds( conformation::Conformation const& conformation, utility::vector1< std::pair<Size,Size> > & disulfides )
+			{
+				for ( Size i = 1; i<= conformation.size(); ++i ) {
+					Residue const& res(conformation.residue(i));
 
-/// @brief Given a residue and a connection id, get the heavyatom adjacent to the atom that makes that connection.
-/// @details Chooses mainchain over non-mainchain, and heavyatoms over non-heavyatoms.  Returns true for FAILURE.
-/// @author Vikram K. Mulligan (vmullig@uw.edu).
-bool
-get_second_atom_from_connection(
-	core::Size & resno,
-	core::Size & atomno,
-	Residue const &rsd,
-	Conformation const &conformation,
-	core::Size const &conn_id
-) {
-	core::Size conn_atom( rsd.type().residue_connect_atom_index( conn_id ) );
-	for ( core::Size i(1), imax(rsd.natoms()); i<=imax; ++i ) {
-		if ( i == conn_atom ) continue;
-		if ( rsd.type().atoms_are_bonded( i, conn_atom ) ) {
-			resno = rsd.seqpos();
-			atomno = i;
-			return false; //SUCCESS
-		}
-	}
+					// Skip things besides CYD
+					//if( !(res.aa() == chemical::aa_cys && res.has_variant_type(chemical::DISULFIDE) ))
+					if ( !(res.type().is_disulfide_bonded() && res.has_variant_type(chemical::DISULFIDE) ) ) {
+						continue;
+					}
+					Size connect_atom( 0);
+					if ( res.type().get_disulfide_atom_name() == "NONE" ) {
+						if ( TR.Warning.visible() ) TR.Warning << "unable to establish which atom to use for the disulfide to residue " << i << std::endl;
+						continue;
+					} else {
+						connect_atom = res.atom_index( res.type().get_disulfide_atom_name() ) ;
+					}
 
-	//If we reach here, then we can't find an atom adjacent to the connection in the residue.  Could be a one-atom residue.
-	for ( core::Size i(1), imax(rsd.type().n_possible_residue_connections()); i<=imax; ++i ) {
-		if ( i == conn_id ) continue;
-		core::Size const connected_res( rsd.connected_residue_at_resconn( i ) );
-		if ( connected_res != 0 ) {
-			resno = connected_res;
-			atomno = conformation.residue( connected_res ).residue_connect_atom_index( rsd.residue_connection_conn_id( conn_id ) );
-			if ( atomno == 0 ) return true; //FAIL
-			return false; //SUCCESS
-		}
-	}
+					Size other_res(0);
+					Size conn;
+					for ( conn = conformation.residue( i ).type().n_possible_residue_connections(); conn >= 1; --conn ) {
+						if ( Size( conformation.residue( i ).type().residue_connection(conn).atomno() ) == connect_atom ) {
+							other_res = conformation.residue( i ).connect_map( conn ).resid();
+							break;
+						}
+					}
+					if ( other_res == 0 ) {
+						TR.Error << "Residue " << i << " was disulfide bonded but had no partner" << std::endl;
+						utility_exit();
+					}
 
-	return true; //FAILURE
-}
+					// Output the pair once
+					if ( i < other_res ) {
+						disulfides.push_back( std::make_pair(i, other_res) );
+					}
+				}
+			}
 
-conformation::ResidueOP
-get_residue_from_name(
-	std::string const & name,
-	std::string const & residue_type_set /* = "fa_standard" */ ) {
 
-	core::chemical::ResidueTypeSetCOP residue_set( core::chemical::ChemicalManager::get_instance()
-		->residue_type_set( residue_type_set ) );
-	core::chemical::ResidueTypeCOP rsd_type = residue_set->name_map( name ).get_self_ptr();
+		/// @brief    Return a nearby TorsionID with approximately the same 3D orientation, selected from the give TorsionIDs.
+		/// @details  The downstream effects of a torsion move can be minimized by twisting a nearby torsion in the opposite
+		///           direction with the same magnitude, resulting in a net "shearing" motion, if and only if the orientation
+		///           of the two bonds are similar, that is, if the two bonds are approximately parallel.  This function is
+		///           useful for finding such a torsion from a supplied list of torsions.
+		/// @param    <conf>            the Conformation
+		/// @param    <torsions>        a list of torsions to search
+		/// @param    <query_torsion>   the TorsionID to compare
+		/// @author   Labonte <JWLabonte@jhu.edu>
+		core::id::TorsionID
+			find_bond_torsion_with_nearest_orientation(
+					core::conformation::Conformation const & conf,
+					utility::vector1< core::id::TorsionID > const & torsions,
+					core::id::TorsionID const & query_torsion )
+			{
+				using namespace core;
 
-	return  conformation::ResidueFactory::create_residue( *rsd_type );
-}
+				Vector const ref_bond_vector( conf.bond_orientation( query_torsion ) );
 
-conformation::ResidueOP
-get_residue_from_name1(
-	char name1,
-	bool is_lower_terminus /*= false*/,
-	bool is_upper_terminus /*= false */,
-	bool d_aa /*= false */,
-	std::string const & residue_type_set /* = "fa_standard" */ ) {
+				Real max_dot_product( 0.0 );
+				id::TorsionID best_torsion;
+				for ( auto torsion : torsions ) {
+					if ( torsion == query_torsion ) { continue; }  // Do not compare to self.
+					Vector const query_bond_vector( conf.bond_orientation( torsion ) );
+					Real const dot_product( fabs( numeric::dot( query_bond_vector, ref_bond_vector ) ) );
+					if ( dot_product > max_dot_product ) {
+						max_dot_product = dot_product;
+						best_torsion = torsion;
+					}
+				}
 
-	chemical::ResidueTypeSetCOP residue_set( chemical::ChemicalManager::get_instance()
-		->residue_type_set( residue_type_set ) );
+				return best_torsion;
+			}
 
-	chemical::AA my_aa = chemical::aa_from_oneletter_code( name1 );
-	if ( d_aa ) {
-		my_aa = chemical::get_D_equivalent( my_aa );
-	}
 
-	// this part stolen from core/pose/annotated_sequence.cc to comply with library levels
-	chemical::ResidueTypeCOP rsd_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).get_representative_type();
-	utility::vector1< chemical::VariantType > variants;
-	if ( rsd_type->is_polymer() ) {
-		if ( is_lower_terminus ) variants.push_back( chemical::LOWER_TERMINUS_VARIANT );
-		if ( is_upper_terminus ) variants.push_back( chemical::UPPER_TERMINUS_VARIANT );
-	}
-	chemical::ResidueTypeCOP res_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).variants( variants ).get_representative_type();
+		// Ring-related Functions /////////////////////////////////////////////////////
 
-	return  conformation::ResidueFactory::create_residue( *res_type );
-}
+		// What is the attachment position of the query atom on the given ring?
+		core::uint
+			position_of_atom_on_ring(
+					Residue const & residue,
+					core::uint query_atom,
+					utility::vector1< core::uint > const & ring_atoms )
+			{
+				if ( ring_atoms.contains( query_atom ) ) {
+					return 0;
+				}
+				utility::vector1< uint > const bonded_heavy_atoms( residue.get_adjacent_heavy_atoms( query_atom ) );
+				Size const n_ring_atoms( ring_atoms.size() );
+				for ( uint position( 1 ); position <= n_ring_atoms; ++position ) {
+					for ( uint bonded_heavy_atom : bonded_heavy_atoms ) {
+						if ( ring_atoms[ position ] == bonded_heavy_atom ) {
+							return position;
+						}
+					}
+				}
+				return 0;
+			}
 
-core::kinematics::Stub
-get_stub_from_residue( core::conformation::Residue const & res ) {
-	Size center = 0;
-	Size nbr1 = 0;
-	Size nbr2 = 0;
-	res.select_orient_atoms( center, nbr1, nbr2 );
-	return core::kinematics::Stub(
-		res.xyz( center ),
-		res.xyz( nbr1 ),
-		res.xyz( nbr2 )
-	);
-}
+		// Is the query atom in this residue axial or equatorial to the given ring or neither?
+		/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
+		/// axial or equatorial to it (or neither).  The attachment atom is auto-detected.
+		/// @param   <residue>:    The Residue containing the atoms in question.
+		/// @param   <query_atom>: The index of the atom in question.
+		/// @param   <ring_atoms>: A list of indices for the atoms of a monocyclic ring system in sequence.
+		/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
+		/// @author  Labonte <JWLabonte@jhu.edu>
+		chemical::rings::AxEqDesignation
+			is_atom_axial_or_equatorial_to_ring(
+					Residue const & residue,
+					core::uint query_atom,
+					utility::vector1< core::uint > const & ring_atoms )
+			{
+				using namespace utility;
+				using namespace numeric;
 
-core::kinematics::RT
-get_rt_from_residue_pair(
-	core::conformation::Residue const & res1,
-	core::conformation::Residue const & res2
-) {
+				uint const attachment_point( position_of_atom_on_ring( residue, query_atom, ring_atoms) );
+				if ( attachment_point ) {
+					// We found an attachment point.
+					// Now we need to get the coordinates of all the important atoms and call the function that does the actual
+					// math.
+					xyzVector< Distance > const query_atom_coords( residue.xyz( query_atom ) );
+					xyzVector< Distance > const attachment_atom_coords( residue.xyz( ring_atoms[ attachment_point ] ) );
 
-	core::kinematics::Stub stub1 = get_stub_from_residue( res1 );
-	core::kinematics::Stub stub2 = get_stub_from_residue( res2 );
+					Size const n_ring_atoms( ring_atoms.size() );
+					vector1< xyzVector< Distance > > ring_atom_coords( n_ring_atoms );
+					for ( uint j( 1 ); j <= n_ring_atoms; ++j ) {
+						ring_atom_coords[ j ] = residue.xyz( ring_atoms[ j ] );
+					}
+					return chemical::rings::is_atom_axial_or_equatorial_to_ring(
+							query_atom_coords, attachment_atom_coords, ring_atom_coords );
+				}
+				TR.Debug << "The attachment point for the query atom is not found in the ring; ";
+				TR.Debug << "an axial/equatorial designation is meaningless." << std::endl;
+				return chemical::rings::NEITHER;
+			}
 
-	return core::kinematics::RT( stub1, stub2 );
-}
+		// Is the query atom in this residue axial or equatorial or neither?
+		/// @details This function calculates an average plane and determines whether the coordinates of a given atom are
+		/// axial or equatorial to it (or neither).  The ring is requested from the Residue.
+		/// @param   <residue>:    The Residue containing the atoms in question, which must have exactly one ring.
+		/// @param   <query_atom>: The index of the atom in question.
+		/// @return  An AxEqDesignation enum type value: AXIAL, EQUATORIAL, or NEITHER
+		/// @author  Labonte <JWLabonte@jhu.edu>
+		chemical::rings::AxEqDesignation
+			is_atom_axial_or_equatorial( Residue const & residue, uint query_atom )
+			{
+				chemical::ResidueType const & rsd_type( residue.type() );
+				if ( rsd_type.n_rings() != 1 ) {
+					TR.Warning << "Queried atom must be on a cyclic residue with exactly one ring." << std::endl;
+					return chemical::rings::NEITHER;
+				}
 
-} // namespace conformation
+				return is_atom_axial_or_equatorial_to_ring( residue, query_atom, rsd_type.ring_atoms( 1 ) );
+			}
+
+		chemical::ResidueTypeCOP
+			virtual_type_for_conf( core::conformation::Conformation const & conformation ) {
+				core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
+				core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("VRT") );
+				if ( ! rsd_type ) {
+					// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
+					core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
+					if ( mode == core::chemical::MIXED_t ) {
+						mode = core::chemical::FULL_ATOM_t;
+					}
+					residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
+					rsd_type = residue_set->name_mapOP("VRT");
+					if ( ! rsd_type ) {
+						TR.Error << "Can't find residue type VRT in type set of mode " << mode << std::endl;
+						utility_exit_with_message("Cannot find residue type VRT" );
+					}
+				}
+				return rsd_type;
+			}
+
+		chemical::ResidueTypeCOP
+			inv_virtual_type_for_conf( core::conformation::Conformation const &conformation ) {
+				core::chemical::ResidueTypeSetCOP residue_set( conformation.residue_type_set_for_conf() );
+				core::chemical::ResidueTypeCOP rsd_type( residue_set->name_mapOP("INV_VRT") );
+				if ( ! rsd_type ) {
+					// Have a fall-back to the Global TypeSet, in case the Conformation one is hiding it.
+					core::chemical::TypeSetMode mode( conformation.residue_typeset_mode() );
+					if ( mode == core::chemical::MIXED_t ) {
+						mode = core::chemical::FULL_ATOM_t;
+					}
+					residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( mode );
+					rsd_type = residue_set->name_mapOP("INV_VRT");
+					if ( ! rsd_type ) {
+						TR.Error << "Can't find residue type INV_VRT in type set of mode " << mode << std::endl;
+						utility_exit_with_message("Cannot find residue type INV_VRT" );
+					}
+				}
+				return rsd_type;
+			}
+
+		core::Vector
+			all_atom_center(
+					core::conformation::Residue const & rsd
+					) {
+
+				utility::vector1< core::Vector > coords;
+
+				for ( Size jj(1); jj <= rsd.natoms(); ++ jj ) {
+					coords.push_back( rsd.xyz( jj ) );
+				}
+
+				if ( ! coords.size() ) { utility_exit_with_message( "Cannot compute center of mass for no atoms!" ); }
+
+				return numeric::center_of_mass( coords );
+			}
+
+		/// @brief Given a residue and a connection id, get the heavyatom adjacent to the atom that makes that connection.
+		/// @details Chooses mainchain over non-mainchain, and heavyatoms over non-heavyatoms.  Returns true for FAILURE.
+		/// @author Vikram K. Mulligan (vmullig@uw.edu).
+		bool
+			get_second_atom_from_connection(
+					core::Size & resno,
+					core::Size & atomno,
+					Residue const &rsd,
+					Conformation const &conformation,
+					core::Size const &conn_id
+					) {
+				core::Size conn_atom( rsd.type().residue_connect_atom_index( conn_id ) );
+				for ( core::Size i(1), imax(rsd.natoms()); i<=imax; ++i ) {
+					if ( i == conn_atom ) continue;
+					if ( rsd.type().atoms_are_bonded( i, conn_atom ) ) {
+						resno = rsd.seqpos();
+						atomno = i;
+						return false; //SUCCESS
+					}
+				}
+
+				//If we reach here, then we can't find an atom adjacent to the connection in the residue.  Could be a one-atom residue.
+				for ( core::Size i(1), imax(rsd.type().n_possible_residue_connections()); i<=imax; ++i ) {
+					if ( i == conn_id ) continue;
+					core::Size const connected_res( rsd.connected_residue_at_resconn( i ) );
+					if ( connected_res != 0 ) {
+						resno = connected_res;
+						atomno = conformation.residue( connected_res ).residue_connect_atom_index( rsd.residue_connection_conn_id( conn_id ) );
+						if ( atomno == 0 ) return true; //FAIL
+						return false; //SUCCESS
+					}
+				}
+
+				return true; //FAILURE
+			}
+
+		conformation::ResidueOP
+			get_residue_from_name(
+					std::string const & name,
+					std::string const & residue_type_set /* = "fa_standard" */ ) {
+
+				core::chemical::ResidueTypeSetCOP residue_set( core::chemical::ChemicalManager::get_instance()
+						->residue_type_set( residue_type_set ) );
+				core::chemical::ResidueTypeCOP rsd_type = residue_set->name_map( name ).get_self_ptr();
+
+				return  conformation::ResidueFactory::create_residue( *rsd_type );
+			}
+
+		conformation::ResidueOP
+			get_residue_from_name1(
+					char name1,
+					bool is_lower_terminus /*= false*/,
+					bool is_upper_terminus /*= false */,
+					bool d_aa /*= false */,
+					std::string const & residue_type_set /* = "fa_standard" */ ) {
+
+				chemical::ResidueTypeSetCOP residue_set( chemical::ChemicalManager::get_instance()
+						->residue_type_set( residue_type_set ) );
+
+				chemical::AA my_aa = chemical::aa_from_oneletter_code( name1 );
+				if ( d_aa ) {
+					my_aa = chemical::get_D_equivalent( my_aa );
+				}
+
+				// this part stolen from core/pose/annotated_sequence.cc to comply with library levels
+				chemical::ResidueTypeCOP rsd_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).get_representative_type();
+				utility::vector1< chemical::VariantType > variants;
+				if ( rsd_type->is_polymer() ) {
+					if ( is_lower_terminus ) variants.push_back( chemical::LOWER_TERMINUS_VARIANT );
+					if ( is_upper_terminus ) variants.push_back( chemical::UPPER_TERMINUS_VARIANT );
+				}
+				chemical::ResidueTypeCOP res_type = chemical::ResidueTypeFinder( *residue_set ).aa( my_aa ).variants( variants ).get_representative_type();
+
+				return  conformation::ResidueFactory::create_residue( *res_type );
+			}
+
+		core::kinematics::Stub
+			get_stub_from_residue( core::conformation::Residue const & res ) {
+				Size center = 0;
+				Size nbr1 = 0;
+				Size nbr2 = 0;
+				res.select_orient_atoms( center, nbr1, nbr2 );
+				return core::kinematics::Stub(
+						res.xyz( center ),
+						res.xyz( nbr1 ),
+						res.xyz( nbr2 )
+						);
+			}
+
+		core::kinematics::RT
+			get_rt_from_residue_pair(
+					core::conformation::Residue const & res1,
+					core::conformation::Residue const & res2
+					) {
+
+				core::kinematics::Stub stub1 = get_stub_from_residue( res1 );
+				core::kinematics::Stub stub2 = get_stub_from_residue( res2 );
+
+				return core::kinematics::RT( stub1, stub2 );
+			}
+
+	} // namespace conformation
 } // namespace core

--- a/source/src/protocols/hybridization/HybridizeProtocol.cc
+++ b/source/src/protocols/hybridization/HybridizeProtocol.cc
@@ -156,2139 +156,2138 @@
 static basic::Tracer TR( "protocols.hybridization.HybridizeProtocol" );
 
 namespace protocols {
-	namespace hybridization {
+namespace hybridization {
 
 
-		using namespace core;
-		using namespace kinematics;
-		using namespace sequence;
-		using namespace pack;
-		using namespace task;
-		using namespace operation;
-		using namespace scoring;
-		using namespace constraints;
-		using namespace protocols::loops;
+using namespace core;
+using namespace kinematics;
+using namespace sequence;
+using namespace pack;
+using namespace task;
+using namespace operation;
+using namespace scoring;
+using namespace constraints;
+using namespace protocols::loops;
 
 
-		/////////////
-		// creator
+/////////////
+// creator
 
 
 
 
-		/////////////
-		// mover
-		HybridizeProtocol::HybridizeProtocol()
-		{
-			using namespace basic::options;
-			using namespace basic::options::OptionKeys;
+/////////////
+// mover
+HybridizeProtocol::HybridizeProtocol()
+{
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
 
-			init();
+	init();
+}
+
+
+// creator with data input
+HybridizeProtocol::HybridizeProtocol(
+	utility::vector1 <core::pose::PoseOP> templates_in,
+	utility::vector1 <core::Real> template_weights_in,
+	core::scoring::ScoreFunctionOP stage1_scorefxn_in,
+	core::scoring::ScoreFunctionOP stage2_scorefxn_in,
+	core::scoring::ScoreFunctionOP fa_scorefxn_in,
+	std::string const & frag3_fn,
+	std::string const & frag9_fn,
+	std::string const & cen_cst_in,
+	std::string const & fa_cst_in
+)
+{
+	if ( templates_in.size() != template_weights_in.size() ) {
+		throw CREATE_EXCEPTION(utility::excn::BadInput, "Error! Input templates and weights are in different sizes!");
+	}
+
+	stage1_probability_     = 1.;
+	stage1_increase_cycles_ = 1.;
+
+	stage1_1_cycles_    = 2000;
+	stage1_2_cycles_    = 2000;
+	stage1_3_cycles_    = 2000;
+	stage1_4_cycles_    = 400;
+
+	stage2_temperature_ = 2.;
+
+	add_hetatm_ = false;
+	realign_domains_ = true;
+	realign_domains_stage2_ = true;
+	add_non_init_chunks_ = 0.;
+	frag_weight_aligned_ = 0.;
+	auto_frag_insertion_weight_ = true;
+	max_registry_shift_ = 0;
+	frag_1mer_insertion_weight_ = 0.;
+	small_frag_insertion_weight_ = 0.;
+	big_frag_insertion_weight_ = 0.5;
+	chunk_insertion_weight_ = 1.;
+	hetatm_self_cst_weight_ = 10.;
+	hetatm_prot_cst_weight_ = 0.;
+	cartfrag_overlap_ = 2;
+	seqfrags_only_ = false;
+	skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
+	keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+
+	cenrot_ = false;
+
+	csts_from_frags_ = false;  // generate dihedral constraints from fragments
+	max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
+	min_after_stage1_ = false;   // tors min after stage1
+	fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
+	randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+
+
+	// domain parsing options
+	hcut_ = 0.18;
+	pcut_ = 0.81;
+	length_ = 38;
+
+
+	jump_move_ = false;
+	jump_move_repeat_ = 1;
+
+	stage2_increase_cycles_ = 1.;
+	stage25_increase_cycles_ = 1.;
+	no_global_frame_ = false;
+	linmin_only_ = false;
+
+	batch_relax_ = 1;
+	relax_repeats_ = 5;
+
+	// disulfide file
+	//    if ( option[ in::fix_disulf ].user() ) {
+	//        disulf_file_ = option[ in::fix_disulf ]();
+	//    }
+
+	// read fragments
+	using namespace core::fragment;
+	FragSetOP frags9 = FragmentIO().read_data( frag9_fn );
+	fragments_big_.push_back(frags9);
+
+	FragSetOP frags3 = FragmentIO().read_data( frag3_fn );
+	fragments_small_.push_back(frags3);
+
+	// scorefxns
+	set_stage1_scorefxn(stage1_scorefxn_in);
+	set_stage2_scorefxn(stage2_scorefxn_in);
+	set_fullatom_scorefxn(fa_scorefxn_in);
+
+	cen_cst_in_ = cen_cst_in;
+	fa_cst_in_ = fa_cst_in;
+	for ( core::Size i_template = 1; i_template <= templates_in.size(); ++i_template ) {
+		add_template(templates_in[i_template], "NONE", "", template_weights_in[i_template]);
+		// skip validate_template, for now
+	}
+}
+
+// sets default options
+void
+HybridizeProtocol::init() {
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
+
+	stage1_probability_ = option[cm::hybridize::stage1_probability]();
+	stage1_increase_cycles_ = option[cm::hybridize::stage1_increase_cycles]();
+	stage1_1_cycles_ = option[cm::hybridize::stage1_1_cycles]();
+	stage1_2_cycles_ = option[cm::hybridize::stage1_2_cycles]();
+	stage1_3_cycles_ = option[cm::hybridize::stage1_3_cycles]();
+	stage1_4_cycles_ = option[cm::hybridize::stage1_4_cycles]();
+	stage2_temperature_ = option[cm::hybridize::stage2_temperature]();
+	add_hetatm_ = false;
+	realign_domains_ = option[cm::hybridize::realign_domains]();
+	realign_domains_stage2_ = option[cm::hybridize::realign_domains_stage2]();
+	add_non_init_chunks_ = option[cm::hybridize::add_non_init_chunks]();
+	frag_weight_aligned_ = option[cm::hybridize::frag_weight_aligned]();
+	auto_frag_insertion_weight_ = option[cm::hybridize::auto_frag_insertion_weight]();
+	max_registry_shift_ = option[cm::hybridize::max_registry_shift]();
+	frag_1mer_insertion_weight_ = option[cm::hybridize::frag_1mer_insertion_weight]();
+	small_frag_insertion_weight_ = option[cm::hybridize::small_frag_insertion_weight]();
+	big_frag_insertion_weight_ = option[cm::hybridize::big_frag_insertion_weight]();
+	chunk_insertion_weight_ = 1.;
+	hetatm_self_cst_weight_ = 10.;
+	hetatm_prot_cst_weight_ = 0.;
+	cartfrag_overlap_ = 2;
+	seqfrags_only_ = false;
+	skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
+	keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+
+	include_loop_ss_chunks_ = option[cm::hybridize::include_loop_ss_chunks]();
+
+	cenrot_ = option[corrections::score::cenrot]();
+
+	csts_from_frags_ = false;  // generate dihedral constraints from fragments
+	max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
+	min_after_stage1_ = false;   // tors min after stage1
+	fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
+	randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+
+
+	// domain parsing options
+	hcut_ = 0.18;
+	pcut_ = 0.81;
+	length_ = 38;
+
+
+	jump_move_ = false;
+	jump_move_repeat_ = 1;
+
+	stage2_increase_cycles_ = option[cm::hybridize::stage2_increase_cycles]();
+	stage25_increase_cycles_ = option[cm::hybridize::stage2min_increase_cycles]();
+	no_global_frame_ = option[cm::hybridize::no_global_frame]();
+	linmin_only_ = option[cm::hybridize::linmin_only]();
+
+	// default scorefunctions
+	//    stage2 scorefunctions are initialized in CartesianHybridize
+	stage1_scorefxn_ = core::scoring::ScoreFunctionFactory::create_score_function( "score3" );
+	fa_scorefxn_ = core::scoring::get_score_function();
+
+	core::scoring::constraints::add_fa_constraints_from_cmdline_to_scorefxn( *fa_scorefxn_ );
+
+
+	if ( option[ OptionKeys::constraints::cst_fa_file ].user() ) {
+		utility::vector1< std::string > cst_files = option[ OptionKeys::constraints::cst_fa_file ]();
+		auto choice = core::Size( numeric::random::rg().random_range( 1, cst_files.size() ) );
+		fa_cst_fn_ = cst_files[choice];
+		TR.Info << "Fullatom Constraint choice: " << fa_cst_fn_ << std::endl;
+	}
+
+	batch_relax_ = option[ cm::hybridize::relax ]();
+	relax_repeats_ = option[ basic::options::OptionKeys::relax::default_repeats ]();
+
+	// disulfide file
+	if ( option[ in::fix_disulf ].user() ) {
+		disulf_file_ = option[ in::fix_disulf ]();
+	}
+
+	// read fragments
+	if ( option[ in::file::frag9 ].user() ) {
+		using namespace core::fragment;
+		FragSetOP frags = FragmentIO().read_data( option[ in::file::frag9 ]() );
+		fragments_big_.push_back(frags);
+	}
+	if ( option[ in::file::frag3 ].user() ) {
+		using namespace core::fragment;
+		FragSetOP frags = FragmentIO().read_data( option[ in::file::frag3 ]() );
+		fragments_small_.push_back(frags);
+	}
+
+	// native
+	if ( option[ in::file::native ].user() ) {
+		native_needs_load_ = true;
+	} else if ( option[ evaluation::align_rmsd_target ].user() ) {
+		native_needs_load_from_align_rmsd_target_ = true;
+	}
+
+	// strand pairings
+	pairings_file_ = option[jumps::pairing_file]();
+	if ( option[jumps::sheets].user() ) {
+		sheets_ = option[jumps::sheets]();
+	} else {
+		random_sheets_ = option[jumps::random_sheets]();
+	}
+	filter_templates_ = option[jumps::filter_templates]();
+}
+
+void
+HybridizeProtocol::check_and_create_fragments( core::pose::Pose & pose ) {
+	if ( fragments_big_.size() > 0 && fragments_small_.size() > 0 ) return;
+
+	core::Size fragbiglen=9;
+
+	if ( !fragments_big_.size() ) {
+		// number of residues
+		core::Size nres_tgt = pose.size();
+		core::conformation::symmetry::SymmetryInfoCOP symm_info;
+		if ( core::pose::symmetry::is_symmetric(pose) ) {
+			auto & SymmConf (
+				dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+			symm_info = SymmConf.Symmetry_Info();
+			nres_tgt = symm_info->num_independent_residues();
+		}
+		if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+		while ( !pose.residue(nres_tgt).is_protein() ) nres_tgt--;
+
+		fragbiglen = std::min( fragbiglen, nres_tgt );
+
+		core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >() );
+
+		// sequence
+		std::string tgt_seq = pose.sequence();
+		std::string tgt_ss(nres_tgt, '0');
+
+		using namespace basic::options;
+		using namespace basic::options::OptionKeys;
+		if ( option[ OptionKeys::in::file::psipred_ss2 ].user() ) {
+			utility::vector1< char > psipred = read_psipred_ss2_file( pose );
+			for ( core::Size j=1; j<=nres_tgt; ++j ) {
+				tgt_ss[j-1] = psipred[j];
+			}
+		} else {
+			// templates vote on secstruct
+			for ( core::Size i=1; i<=templates_.size(); ++i ) {
+				for ( core::Size j=1; j<=templates_[i]->size(); ++j ) {
+					if ( !templates_[i]->residue(j).is_protein() ) continue;
+					core::Size tgt_pos = templates_[i]->pdb_info()->number(j);
+
+					runtime_assert( tgt_pos<=nres_tgt );
+					char tgt_ss_j = templates_[i]->secstruct(j);
+
+					if ( tgt_ss[tgt_pos-1] == '0' ) {
+						tgt_ss[tgt_pos-1] = tgt_ss_j;
+					} else if ( tgt_ss[tgt_pos-1] != tgt_ss_j ) {
+						tgt_ss[tgt_pos-1] = 'D'; // templates disagree
+					}
+				}
+			}
+			for ( core::Size j=1; j<=nres_tgt; ++j ) {
+				if ( tgt_ss[j-1] == '0' ) tgt_ss[j-1] = 'D';
+			}
 		}
 
+		// pick from vall based on template SS + target sequence
+		for ( core::Size j=1; j<=nres_tgt-fragbiglen+1; ++j ) {
+			core::fragment::FrameOP frame( utility::pointer::make_shared< core::fragment::Frame >(j, fragbiglen) );
 
-		// creator with data input
-		HybridizeProtocol::HybridizeProtocol(
-				utility::vector1 <core::pose::PoseOP> templates_in,
-				utility::vector1 <core::Real> template_weights_in,
-				core::scoring::ScoreFunctionOP stage1_scorefxn_in,
-				core::scoring::ScoreFunctionOP stage2_scorefxn_in,
-				core::scoring::ScoreFunctionOP fa_scorefxn_in,
-				std::string const & frag3_fn,
-				std::string const & frag9_fn,
-				std::string const & cen_cst_in,
-				std::string const & fa_cst_in
-				)
-		{
-			if ( templates_in.size() != template_weights_in.size() ) {
-				throw CREATE_EXCEPTION(utility::excn::BadInput, "Error! Input templates and weights are in different sizes!");
+			if ( j > residue_sample_abinitio_.size() || residue_sample_abinitio_[j] ) {
+				frame->add_fragment(
+					core::fragment::picking_old::vall::pick_fragments_by_ss_plus_aa(
+					tgt_ss.substr( j-1, fragbiglen ), tgt_seq.substr( j-1, fragbiglen ), 25, true, core::fragment::IndependentBBTorsionSRFD() ) );
+				frags->add( frame );
 			}
+		}
+		fragments_big_.push_back( frags );
+	}
+	if ( !fragments_small_.size() ) {
+		core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >(3) );
 
-			stage1_probability_     = 1.;
-			stage1_increase_cycles_ = 1.;
+		// make them from big fragments
+		core::fragment::chop_fragments( *fragments_big_[1], *frags );
+		fragments_small_.push_back( frags );
+	}
+}
 
-			stage1_1_cycles_    = 2000;
-			stage1_2_cycles_    = 2000;
-			stage1_3_cycles_    = 2000;
-			stage1_4_cycles_    = 400;
+//fpd add fragment-derived constraints
+void
+HybridizeProtocol::add_fragment_csts( core::pose::Pose &pose ) {
+	TR << "Adding fragment constraints" << std::endl;
 
-			stage2_temperature_ = 2.;
+	core::fragment::FragSetOP frags = fragments_small_[1];
 
-			add_hetatm_ = false;
-			realign_domains_ = true;
-			realign_domains_stage2_ = true;
-			add_non_init_chunks_ = 0.;
-			frag_weight_aligned_ = 0.;
-			auto_frag_insertion_weight_ = true;
-			max_registry_shift_ = 0;
-			frag_1mer_insertion_weight_ = 0.;
-			small_frag_insertion_weight_ = 0.;
-			big_frag_insertion_weight_ = 0.5;
-			chunk_insertion_weight_ = 1.;
-			hetatm_self_cst_weight_ = 10.;
-			hetatm_prot_cst_weight_ = 0.;
-			cartfrag_overlap_ = 2;
-			seqfrags_only_ = false;
-			skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
-			keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+	// stolen from SecondaryStructure.cc
+	if ( frags->global_offset() != 0 ) {
+		TR.Error << "SecondaryStructure computations must be carried out with local coordinates (global offset of fragments must be 0)." << std::endl;
+		TR.Error << "   value of global offset of fragments: " << frags->global_offset() << std::endl;
+		utility_exit_with_message("SecondaryStructure computations not in local coordinates!");
+	}
 
-			cenrot_ = false;
+	// 1 - collect fragment statistics
+	core::Size frag_nres = frags->max_pos();
+	utility::vector1< utility::vector1< core::Real > > phi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
+	utility::vector1< utility::vector1< core::Real > > psi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
+	utility::vector1< int > N( frag_nres, 0 );
 
-			csts_from_frags_ = false;  // generate dihedral constraints from fragments
-			max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
-			min_after_stage1_ = false;   // tors min after stage1
-			fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
-			randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+	for ( core::fragment::FragID_Iterator it=frags->begin(), eit=frags->end(); it!=eit; ++it ) { //carefully checked that I don't change FrameData
+		core::Size loop_start = 1;
+		core::Size loop_end = it->frame().length();
+		for ( core::Size fpos = loop_start; fpos <= loop_end; ++fpos ) {
+			core::fragment::BBTorsionSRFDCOP res_i =
+				utility::pointer::dynamic_pointer_cast<const core::fragment::BBTorsionSRFD> (it->fragment().get_residue( fpos ) );
 
+			core::Size pos = it->frame().seqpos( fpos );
+			core::Real phi = std::fmod( res_i->torsion(1), 360.0 ); if ( phi<0 ) phi +=360.0;
+			core::Real psi = std::fmod( res_i->torsion(2), 360.0 ); if ( psi<0 ) psi +=360.0;
 
-			// domain parsing options
-			hcut_ = 0.18;
-			pcut_ = 0.81;
-			length_ = 38;
+			auto phibin = (core::Size) std::floor( phi/10.0 ); if ( phibin == 36 ) phibin=0;
+			auto psibin = (core::Size) std::floor( psi/10.0 ); if ( psibin == 36 ) psibin=0;
 
+			phi_distr[pos][phibin+1]+=1.0;
+			psi_distr[pos][psibin+1]+=1.0;
+			N[pos]++;
+		}
+	}
 
-			jump_move_ = false;
-			jump_move_repeat_ = 1;
+	// smoothing
+	//core::Real smoothing[7] = {0.09, 0.14, 0.175, 0.19, 0.175, 0.14, 0.09};  // very soft
+	core::Real smoothing[7] = {0.01, 0.05, 0.24, 0.40, 0.24, 0.05, 0.01}; // less soft
+	for ( int i=1; i<=(int)frag_nres; ++i ) {
+		utility::vector1< core::Real > phi_i = phi_distr[i];
+		utility::vector1< core::Real > psi_i = psi_distr[i];
+		for ( int j=1; j<=36; ++j ) {
+			phi_distr[i][j] = smoothing[0]*phi_i[1+((j+32)%36)]
+				+ smoothing[1]*phi_i[1+((j+33)%36)]
+				+ smoothing[2]*phi_i[1+((j+34)%36)]
+				+ smoothing[3]*phi_i[1+((j+35)%36)]
+				+ smoothing[4]*phi_i[1+((j+0)%36)]
+				+ smoothing[5]*phi_i[1+((j+1)%36)]
+				+ smoothing[6]*phi_i[1+((j+2)%36)];
 
-			stage2_increase_cycles_ = 1.;
-			stage25_increase_cycles_ = 1.;
-			no_global_frame_ = false;
-			linmin_only_ = false;
+			psi_distr[i][j] = smoothing[0]*psi_i[1+((j+32)%36)]
+				+ smoothing[1]*psi_i[1+((j+33)%36)]
+				+ smoothing[2]*psi_i[1+((j+34)%36)]
+				+ smoothing[3]*psi_i[1+((j+35)%36)]
+				+ smoothing[4]*psi_i[1+((j+0)%36)]
+				+ smoothing[5]*psi_i[1+((j+1)%36)]
+				+ smoothing[6]*psi_i[1+((j+2)%36)];
 
-			batch_relax_ = 1;
-			relax_repeats_ = 5;
+			phi_distr[i][j] /= N[i];
+			psi_distr[i][j] /= N[i];
+		}
+	}
 
-			// disulfide file
-			//    if ( option[ in::fix_disulf ].user() ) {
-			//        disulf_file_ = option[ in::fix_disulf ]();
-			//    }
+	// convert to energy
+	core::Real mest=0.1;
+	for ( int i=1; i<=(int)frag_nres; ++i ) {
+		for ( int j=1; j<=36; ++j ) {
+			// shift so max is 0
+			phi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*phi_distr[i][j] ) + std::log( mest/36.0 ) ;
+			psi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*psi_distr[i][j] ) + std::log( mest/36.0 ) ;
+		}
 
-			// read fragments
-			using namespace core::fragment;
-			FragSetOP frags9 = FragmentIO().read_data( frag9_fn );
-			fragments_big_.push_back(frags9);
+		//TR << "phi " << i;
+		//for (int j=1; j<=36; ++j) TR << " " << phi_distr[i][j];
+		//TR << std::endl;
 
-			FragSetOP frags3 = FragmentIO().read_data( frag3_fn );
-			fragments_small_.push_back(frags3);
+		//TR << "psi " << i;
+		//for (int j=1; j<=36; ++j) TR << " " << psi_distr[i][j];
+		//TR << std::endl;
+	}
 
-			// scorefxns
-			set_stage1_scorefxn(stage1_scorefxn_in);
-			set_stage2_scorefxn(stage2_scorefxn_in);
-			set_fullatom_scorefxn(fa_scorefxn_in);
+	// finally .. add constraints
+	for ( int i=1; i<=(int)frag_nres; ++i ) {
+		using namespace core::scoring::func;
+		using namespace core::scoring::constraints;
 
-			cen_cst_in_ = cen_cst_in;
-			fa_cst_in_ = fa_cst_in;
-			for ( core::Size i_template = 1; i_template <= templates_in.size(); ++i_template ) {
-				add_template(templates_in[i_template], "NONE", "", template_weights_in[i_template]);
-				// skip validate_template, for now
+		if ( !pose.residue(i).is_protein() ) continue;
+
+		if ( i>1 && pose.residue(i-1).is_protein() ) {
+			FuncOP phi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, phi_distr[i] ) );
+			ConstraintOP phi_cst( utility::pointer::make_shared< DihedralConstraint >(
+				core::id::AtomID(3,i-1),core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i), phi_func  ) );
+			pose.add_constraint( scoring::constraints::ConstraintCOP( phi_cst ) );
+		}
+
+		if ( i<(int)frag_nres && pose.residue(i+1).is_protein() ) {
+			FuncOP psi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, psi_distr[i] ) );
+			ConstraintOP psi_cst( utility::pointer::make_shared< DihedralConstraint >(
+				core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i),core::id::AtomID(1,i+1), psi_func  ) );
+			pose.add_constraint( scoring::constraints::ConstraintCOP( psi_cst ) );
+		}
+	}
+}
+
+void
+HybridizeProtocol::initialize_and_sample_loops(
+	core::pose::Pose &pose,
+	core::pose::PoseOP chosen_templ,
+	protocols::loops::Loops template_contigs,
+	core::scoring::ScoreFunctionOP scorefxn)
+{
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
+
+	// xyz copy starting model
+	for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
+		for ( core::Size j=1; j<=chosen_templ->residue(i).natoms(); ++j ) {
+			core::id::AtomID src(j,i), tgt(j, chosen_templ->pdb_info()->number(i));
+			pose.set_xyz( tgt, chosen_templ->xyz( src ) );
+		}
+	}
+
+	// make loops as inverse of template_contigs
+	TR << "CONTIGS" << std::endl << template_contigs << std::endl;
+	//core::Size ncontigs = template_contigs.size();
+	core::Size nres_tgt = pose.size();
+
+	//symmetry
+	core::conformation::symmetry::SymmetryInfoCOP symm_info;
+	if ( core::pose::symmetry::is_symmetric(pose) ) {
+		auto & SymmConf (
+			dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+		symm_info = SymmConf.Symmetry_Info();
+		nres_tgt = symm_info->num_independent_residues();
+	}
+
+	if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+
+	protocols::loops::LoopsOP loops( utility::pointer::make_shared< protocols::loops::Loops >() );
+	utility::vector1< bool > templ_coverage(nres_tgt, false);
+
+	for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
+		core::Size cres = chosen_templ->pdb_info()->number(i);
+		templ_coverage[cres] = true;
+	}
+
+	// remove 1-3 residue "segments"
+	for ( core::Size i=1; i<=nres_tgt-2; ++i ) {
+		if ( !templ_coverage[i] && templ_coverage[i+1] && !templ_coverage[i+2] ) {
+			templ_coverage[i+1]=false;
+		} else if ( i<=nres_tgt-3 && !templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && !templ_coverage[i+3] ) {
+			templ_coverage[i+1]=false;
+			templ_coverage[i+2]=false;
+		} else if ( i<=nres_tgt-4 &&
+				!templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && templ_coverage[i+3] && !templ_coverage[i+4] ) {
+			templ_coverage[i+1]=false;
+			templ_coverage[i+2]=false;
+			templ_coverage[i+3]=false;
+		}
+	}
+	// make loopfile
+	bool inloop=!templ_coverage[1];
+	core::Size loopstart=1, loopstop;
+	for ( core::Size i=2; i<=nres_tgt; ++i ) {
+		if ( templ_coverage[i] && inloop ) {
+			inloop = false;
+			loopstop = i;
+			if ( loopstop < loopstart + 2 ) {
+				if ( loopstart>1 ) loopstart--;
+				if ( loopstop<nres_tgt ) loopstop++;
+			}
+			loops->add_loop( loopstart,loopstop );
+		} else if ( !templ_coverage[i] && !inloop ) {
+			// start loop
+			inloop = true;
+			loopstart = i-1;
+		}
+	}
+	if ( inloop ) {
+		// end loop
+		loopstop = nres_tgt;
+		while ( loopstop < loopstart + 2 ) { loopstart--; }
+		loops->add_loop( loopstart,loopstop );
+	}
+	TR << "LOOPS" << std::endl << *loops << std::endl;
+
+	// now do insertions
+	if ( loops->size() != 0 ) {
+		// set foldtree + variants
+		loops->auto_choose_cutpoints(pose);
+		core::kinematics::FoldTree f_in=pose.fold_tree(), f_new;
+		protocols::loops::fold_tree_from_loops( pose, *loops, f_new);
+		pose.fold_tree( f_new );
+		protocols::loops::add_cutpoint_variants( pose );
+
+		// set movemap
+		core::kinematics::MoveMapOP mm_loop( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+		for ( auto const & it : *loops ) {
+			for ( core::Size i=it.start(); i<=it.stop(); ++i ) {
+				mm_loop->set_bb(i, true);
+				mm_loop->set_chi(i, true); // chi of loop residues
 			}
 		}
 
-		// sets default options
-		void
-			HybridizeProtocol::init() {
-				using namespace basic::options;
-				using namespace basic::options::OptionKeys;
+		// setup fragment movers
+		protocols::simple_moves::ClassicFragmentMoverOP frag3mover, frag9mover;
+		core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
+		core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
+		TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
+		TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
+		frag3mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_small, mm_loop );
+		frag3mover->set_check_ss( false ); frag3mover->enable_end_bias_check( false );
+		frag9mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_big, mm_loop );
+		frag9mover->set_check_ss( false ); frag9mover->enable_end_bias_check( false );
 
-				stage1_probability_ = option[cm::hybridize::stage1_probability]();
-				stage1_increase_cycles_ = option[cm::hybridize::stage1_increase_cycles]();
-				stage1_1_cycles_ = option[cm::hybridize::stage1_1_cycles]();
-				stage1_2_cycles_ = option[cm::hybridize::stage1_2_cycles]();
-				stage1_3_cycles_ = option[cm::hybridize::stage1_3_cycles]();
-				stage1_4_cycles_ = option[cm::hybridize::stage1_4_cycles]();
-				stage2_temperature_ = option[cm::hybridize::stage2_temperature]();
-				add_hetatm_ = false;
-				realign_domains_ = option[cm::hybridize::realign_domains]();
-				realign_domains_stage2_ = option[cm::hybridize::realign_domains_stage2]();
-				add_non_init_chunks_ = option[cm::hybridize::add_non_init_chunks]();
-				frag_weight_aligned_ = option[cm::hybridize::frag_weight_aligned]();
-				auto_frag_insertion_weight_ = option[cm::hybridize::auto_frag_insertion_weight]();
-				max_registry_shift_ = option[cm::hybridize::max_registry_shift]();
-				frag_1mer_insertion_weight_ = option[cm::hybridize::frag_1mer_insertion_weight]();
-				small_frag_insertion_weight_ = option[cm::hybridize::small_frag_insertion_weight]();
-				big_frag_insertion_weight_ = option[cm::hybridize::big_frag_insertion_weight]();
-				chunk_insertion_weight_ = 1.;
-				hetatm_self_cst_weight_ = 10.;
-				hetatm_prot_cst_weight_ = 0.;
-				cartfrag_overlap_ = 2;
-				seqfrags_only_ = false;
-				skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
-				keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+		// extend + idealize loops
+		for ( auto const & it : *loops ) {
+			protocols::loops::Loop to_idealize( it );
+			protocols::loops::set_extended_torsions( pose, it );
+		}
 
-				include_loop_ss_chunks_ = option[cm::hybridize::include_loop_ss_chunks]();
+		// setup MC
+		scorefxn->set_weight( core::scoring::linear_chainbreak, 0.5 );
+		(*scorefxn)(pose);
+		protocols::moves::MonteCarloOP mc1( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
 
-				cenrot_ = option[corrections::score::cenrot]();
+		auto neffcycles = (core::Size)(1000*option[cm::hybridize::stage1_increase_cycles]());
+		for ( core::Size n=1; n<=neffcycles; ++n ) {
+			frag9mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag9" );
+			frag3mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag3" );
 
-				csts_from_frags_ = false;  // generate dihedral constraints from fragments
-				max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
-				min_after_stage1_ = false;   // tors min after stage1
-				fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
-				randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+			if ( n%100 == 0 ) {
+				mc1->show_scores();
+				mc1->show_counters();
+			}
+		}
+		mc1->recover_low( pose );
 
+		scorefxn->set_weight( core::scoring::linear_chainbreak, 2.0 );
+		(*scorefxn)(pose);
+		protocols::moves::MonteCarloOP mc2( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
+		for ( core::Size n=1; n<=neffcycles; ++n ) {
+			frag9mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag9" );
+			frag3mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag3" );
 
-				// domain parsing options
-				hcut_ = 0.18;
-				pcut_ = 0.81;
-				length_ = 38;
+			if ( n%100 == 0 ) {
+				mc2->show_scores();
+				mc2->show_counters();
+			}
+		}
 
-
-				jump_move_ = false;
-				jump_move_repeat_ = 1;
-
-				stage2_increase_cycles_ = option[cm::hybridize::stage2_increase_cycles]();
-				stage25_increase_cycles_ = option[cm::hybridize::stage2min_increase_cycles]();
-				no_global_frame_ = option[cm::hybridize::no_global_frame]();
-				linmin_only_ = option[cm::hybridize::linmin_only]();
-
-				// default scorefunctions
-				//    stage2 scorefunctions are initialized in CartesianHybridize
-				stage1_scorefxn_ = core::scoring::ScoreFunctionFactory::create_score_function( "score3" );
-				fa_scorefxn_ = core::scoring::get_score_function();
-
-				core::scoring::constraints::add_fa_constraints_from_cmdline_to_scorefxn( *fa_scorefxn_ );
+		// restore input ft
+		mc2->recover_low( pose );
+		protocols::loops::remove_cutpoint_variants( pose );
+		pose.fold_tree( f_in );
+	}
+}
 
 
-				if ( option[ OptionKeys::constraints::cst_fa_file ].user() ) {
-					utility::vector1< std::string > cst_files = option[ OptionKeys::constraints::cst_fa_file ]();
-					auto choice = core::Size( numeric::random::rg().random_range( 1, cst_files.size() ) );
-					fa_cst_fn_ = cst_files[choice];
-					TR.Info << "Fullatom Constraint choice: " << fa_cst_fn_ << std::endl;
+void HybridizeProtocol::add_template(
+	std::string const & template_fn,
+	std::string const & cst_fn,
+	std::string const & symm_file,
+	core::Real const weight,
+	utility::vector1<char> const & randchains,
+	bool const align_pdb_info)
+{
+	core::chemical::ResidueTypeSetCOP const residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
+
+	core::pose::PoseOP template_pose( utility::pointer::make_shared< core::pose::Pose >() );
+	if ( template_fn == "extended" ) {
+		// auto constraints make no sense
+		if ( cst_fn == "AUTO" ) {
+			TR.Error << "Warning!  Turning off auto constraints for extended pose" << std::endl;
+		}
+		add_null_template( template_pose, "NONE", symm_file, weight );
+	} else {
+		core::import_pose::pose_from_file( *template_pose, *residue_set, template_fn , core::import_pose::PDB_file);
+		add_template( template_pose, cst_fn, symm_file, weight, randchains, template_fn, align_pdb_info);
+	}
+}
+
+
+void HybridizeProtocol::add_null_template(
+	core::pose::PoseOP template_pose,
+	std::string cst_fn,
+	std::string symm_file,
+	core::Real weight)
+{
+	template_fns_.push_back("null");
+	templates_.push_back(template_pose);
+	templates_aln_.push_back(template_pose); // shallow copy
+	template_cst_fn_.push_back(cst_fn);
+	symmdef_files_.push_back(symm_file);
+	template_weights_.push_back(weight);
+	template_chunks_.push_back(protocols::loops::Loops());
+	template_contigs_.push_back(protocols::loops::Loops());
+	randomize_chains_.push_back(utility::vector1<char>(0));
+}
+
+void HybridizeProtocol::add_template(
+	core::pose::PoseOP template_pose,
+	std::string const & cst_fn,
+	std::string const & symm_file,
+	core::Real const weight,
+	utility::vector1<char> const & rand_chains,
+	std::string const & filename,
+	bool const align_pdb_info)
+{
+	// add secondary structure information to the template pose
+	core::scoring::dssp::Dssp dssp_obj( *template_pose );
+	dssp_obj.insert_ss_into_pose( *template_pose );
+
+	// find ss chunks in template
+	protocols::loops::Loops contigs = protocols::loops::extract_continuous_chunks(*template_pose);
+	protocols::loops::Loops chunks;
+	if ( include_loop_ss_chunks_ ) {
+		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
+	} else {
+		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
+	}
+
+	// if there are no SS elts in the pose, use contigs
+	if ( chunks.num_loop() == 0 ) chunks = contigs;
+
+	TR.Debug << "Chunks from template\n" << chunks << std::endl;
+	TR.Debug << "Contigs from template\n" << contigs << std::endl;
+
+	template_fns_.push_back(filename);
+	templates_.push_back(template_pose);
+	templates_aln_.push_back(template_pose); // shallow copy
+	template_cst_fn_.push_back(cst_fn);
+	symmdef_files_.push_back(symm_file);
+	template_weights_.push_back(weight);
+	template_chunks_.push_back(chunks);
+	template_contigs_.push_back(contigs);
+	randomize_chains_.push_back(rand_chains);
+	should_align_pdb_infos_.push_back(align_pdb_info);
+
+	non_null_template_indices_.push_back( templates_.size() );
+}
+
+void HybridizeProtocol::update_template(core::Size const template_idx )
+{
+	core::pose::PoseOP const template_pose(templates_[template_idx]);
+
+	// add secondary structure information to the template pose
+	core::scoring::dssp::Dssp dssp_obj( *template_pose );
+	dssp_obj.insert_ss_into_pose( *template_pose );
+
+	// find ss chunks in template
+	protocols::loops::Loops const contigs = protocols::loops::extract_continuous_chunks(*template_pose);
+
+	protocols::loops::Loops chunks;
+	if ( include_loop_ss_chunks_ ) {
+		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
+	} else {
+		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
+	}
+	if ( chunks.num_loop() == 0 ) chunks = contigs;
+
+	template_chunks_[template_idx] = chunks;
+	template_contigs_[template_idx] = contigs;
+}
+
+
+// validate input templates match input sequence
+// TO DO: if only sequences mismatch try realigning
+void HybridizeProtocol::validate_template(
+	std::string const & filename,
+	std::string const & fasta,
+	core::pose::PoseOP template_pose,
+	bool & align_pdb_info)
+{
+	core::Size nres_fasta = fasta.length(), nres_templ = template_pose->size();
+	core::Size next_ligand = nres_fasta+1; // ligands must be sequentially numbered
+
+	bool requires_alignment = false;
+	for ( core::Size i=1; i<=nres_templ; ++i ) {
+		char templ_aa = template_pose->residue(i).name1();
+		core::Size i_fasta = template_pose->pdb_info()->number(i);
+		bool is_ligand = !template_pose->residue(i).is_protein();
+
+		// ligands
+		if ( i_fasta > nres_fasta || is_ligand ) {
+			if ( !is_ligand ) {
+				TR.Error << "   Residue number " << i_fasta << " is outside of input fasta range." << std::endl;
+				requires_alignment = true;
+				break;
+			} else {
+				template_pose->pdb_info()->number(i,next_ligand);
+			}
+			next_ligand++;
+		} else {
+			char fasta_aa = fasta[i_fasta-1];
+			if ( fasta_aa != templ_aa ) {
+				TR.Error << "Sequence mismatch between input fasta and template " << filename
+					<< " at residue " << i_fasta << std::endl;
+				TR.Error << "   Expected: " << fasta_aa << "   Saw: " << templ_aa << std::endl;
+				if ( !align_pdb_info ) utility_exit_with_message("Issue validating template in HybridizeProtocol.");
+				requires_alignment = true;
+				break;
+			}
+		}
+	}
+	if ( requires_alignment ) {
+		TR.Error << "THE PDB INFO IS NOT IN SYNC WITH THE FASTA. ATTEMPTING TO RESOLVE THE ISSUE AUTOMATICALLY" << std::endl;
+		//this block code shouldn't be needed since hybrid needs asymmetric poses anyway but it doesn't hurt
+		core::pose::Pose pose_for_seq;
+		core::pose::symmetry::extract_asymmetric_unit(*template_pose, pose_for_seq, false);
+
+		core::sequence::SequenceOP full_length_seq( utility::pointer::make_shared< core::sequence::Sequence >( fasta, "target" ));
+		core::sequence::SequenceOP t_pdb_seq( utility::pointer::make_shared< core::sequence::Sequence >( pose_for_seq.sequence(), "pose_seq" ));
+		core::sequence::SWAligner sw_align;
+		core::sequence::ScoringSchemeOP ss(  utility::pointer::make_shared< core::sequence::SimpleScoringScheme >(120, 0, -100, 0));
+		core::sequence::SequenceAlignment fasta2template;
+
+		fasta2template = sw_align.align(full_length_seq, t_pdb_seq, ss);
+
+		TR << fasta2template << std::endl;
+
+		core::id::SequenceMapping sequencemap = fasta2template.sequence_mapping(1,2);
+		sequencemap.reverse();
+		core::Size ndel = 0;
+		core::Size counter = 1;
+		core::Size nres = template_pose->size();
+		for ( core::Size i=1; i<=nres; i++ ) {
+			if ( ! template_pose->residue(counter).is_protein() ) {
+				// will get fixed later
+				counter++;
+				continue;
+			}
+
+			core::Size pdbnumber = template_pose->pdb_info()->number(counter);
+			core::Size fastanumber = sequencemap[i];
+			if ( fastanumber == 0 ) { // extra residues in template
+				template_pose->delete_residue_range_slow( counter,counter );
+				ndel++;
+				continue;
+			}
+			if ( pdbnumber != fastanumber ) {
+				template_pose->pdb_info()->number(counter,fastanumber);
+			}
+			counter++;
+		}
+		if ( ndel > 0 ) {
+			TR.Error << "WARNING! Realignment removed " << ndel << " residues!" << std::endl;
+		}
+	} else {
+		align_pdb_info = false;
+	}
+}
+
+
+core::Size HybridizeProtocol::pick_starting_template( ) {
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
+
+	numeric::random::WeightedSampler weighted_sampler;
+	weighted_sampler.weights(template_weights_);
+	return weighted_sampler.random_sample(numeric::random::rg());
+}
+
+void HybridizeProtocol::domain_parse_templates(core::Size nres) {
+	if ( domains_all_templ_.size() == templates_.size() ) {
+		return;
+	}
+
+	DDomainParse ddom(pcut_,hcut_,length_);
+
+	domains_all_templ_.resize( templates_.size() );
+	for ( core::Size i_template=1; i_template<=templates_.size(); ++i_template ) {
+		if ( templates_[i_template]->size() < 3 ) {
+			continue;  // ???
+		}
+
+		domains_all_templ_[i_template] = ddom.split( *templates_[i_template] );
+
+		// convert domain numbering to target pose numbering
+		protocols::loops::Loops all_domains;
+		for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
+			for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
+				core::Size seqpos_start_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].start());
+
+				if ( seqpos_start_pose > nres ) continue; // sometimes dna can do this
+
+				domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
+
+				core::Size seqpos_stop_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].stop());
+				domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
+
+				all_domains.add_loop( seqpos_start_pose, seqpos_stop_pose );
+			}
+		}
+
+		// extend to cover full-length seq
+		// assumes no overlap in domain defs!
+		all_domains.sequential_order();
+		if ( all_domains.num_loop() == 0 ) continue;
+
+		std::map<core::Size,core::Size> remap_endpoints;
+		remap_endpoints [ all_domains[1].start() ] = 1;
+		remap_endpoints [ all_domains[all_domains.num_loop()].stop() ] = nres;
+		for ( core::Size iloops=2; iloops<=all_domains.size(); ++iloops ) {
+			core::Size start_i = (all_domains[iloops-1].stop() + all_domains[iloops].start() + 1)/2;
+			remap_endpoints [ all_domains[iloops-1].stop() ] = start_i-1;
+			remap_endpoints [ all_domains[iloops].start() ] = start_i;
+		}
+
+		for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
+			for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
+				core::Size seqpos_start_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].start() ];
+				domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
+
+				core::Size seqpos_stop_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].stop() ];
+				domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
+			}
+		}
+
+		TR << "Found " << domains_all_templ_[i_template].size() << " domains using template " << template_fns_[i_template] << std::endl;
+		for ( core::Size i=1; i<=domains_all_templ_[i_template].size(); ++i ) {
+			TR << "domain " << i << ": " << domains_all_templ_[i_template][i] << std::endl;
+		}
+	}
+}
+
+void
+HybridizeProtocol::setup_templates_and_sampling_options( core::pose::Pose const & pose ) {
+	std::string const & pose_sequence(pose.sequence());
+	if ( coord_cst_res_.size() ) {
+		user_csts_ = core::pose::get_resnum_list_ordered( coord_cst_res_, pose );
+	}
+	for ( core::Size i=1; i<=template_fns_.size(); ++i ) {
+		bool align_pdb_info = should_align_pdb_infos_[i];
+		validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
+
+		if ( align_pdb_info ) {
+			align_pdb_info = false;
+			validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
+			update_template(i);
+		}
+	}
+
+	core::Size const nres_nonvirt = get_num_residues_nonvirt(pose);
+	if ( detailed_controls_settings_.size() ) {
+		residue_sample_template_.resize(nres_nonvirt, true);
+		residue_sample_abinitio_.resize(nres_nonvirt, true);
+	}
+	for ( auto const & detailed_control_settings : detailed_controls_settings_ ) {
+		if ( detailed_control_settings.type_ == "task_operations" ) {
+			core::pack::task::PackerTaskOP task = detailed_control_settings.taskFactOP_->create_task_and_apply_taskoperations( pose );
+			for ( core::Size ires = 1; ires <= nres_nonvirt; ++ires ) {
+				if ( !task->residue_task( ires ).being_packed() ) {
+					residue_sample_template_[ires] = false;
+					residue_sample_abinitio_[ires] = false;
+				}
+			}
+		} else {
+			core::Size const stop_res(detailed_control_settings.stop_res_ == 0 ? nres_nonvirt : detailed_control_settings.stop_res_);
+			if ( detailed_control_settings.sample_template_ != sampleEnum::unset ) {
+				for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
+					residue_sample_template_[ires] = (detailed_control_settings.sample_template_ == sampleEnum::off ? false : true);
+				}
+			}
+			if ( detailed_control_settings.sample_abinitio_ != sampleEnum::unset ) {
+				for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
+					residue_sample_abinitio_[ires] = (detailed_control_settings.sample_abinitio_ == sampleEnum::off ? false : true);
+				}
+			}
+		}
+	}
+}
+
+void HybridizeProtocol::apply( core::pose::Pose & pose )
+{
+	using namespace protocols::moves;
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
+	using namespace core::pose::datacache;
+	using namespace core::io::silent;
+	using namespace ObjexxFCL::format;
+
+	if ( native_ == nullptr ) {
+		if ( native_needs_load_ ) {
+			native_ = utility::pointer::make_shared< core::pose::Pose >();
+			if ( option[in::file::fullatom]() ) {
+				core::import_pose::pose_from_file( *native_, option[ in::file::native ]() , core::import_pose::PDB_file);
+			} else {
+				core::chemical::ResidueTypeSetCOP residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
+				core::import_pose::pose_from_file( *native_, *residue_set, option[ in::file::native ]()  , core::import_pose::PDB_file);
+			}
+			native_needs_load_ = false;
+		} else if ( native_needs_load_from_align_rmsd_target_ ) {
+			native_ = utility::pointer::make_shared< core::pose::Pose >();
+			utility::vector1< std::string > const & align_rmsd_target( option[ evaluation::align_rmsd_target ]() );
+			core::import_pose::pose_from_file( *native_, align_rmsd_target[1] , core::import_pose::PDB_file); // just use the first one for now
+			native_needs_load_from_align_rmsd_target_ = false;
+		}
+	}
+
+	setup_templates_and_sampling_options(pose);
+
+	// number of residues in asu without VRTs
+	core::Size nres_tgt = pose.size();
+	core::Size nres_protein_tgt = pose.size();
+	core::conformation::symmetry::SymmetryInfoCOP symm_info;
+	if ( core::pose::symmetry::is_symmetric(pose) ) {
+		auto & SymmConf (
+			dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+		symm_info = SymmConf.Symmetry_Info();
+		nres_tgt = symm_info->num_independent_residues();
+		nres_protein_tgt = symm_info->num_independent_residues();
+	}
+	if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+	while ( !pose.residue(nres_protein_tgt).is_protein() ) nres_protein_tgt--;
+
+	//save necessary constraint in pose
+	core::scoring::constraints::ConstraintSetOP save_pose_constraint_set( utility::pointer::make_shared< core::scoring::constraints::ConstraintSet >() ) ;
+	if ( keep_pose_constraint_ ) {
+		save_pose_constraint_set = pose.constraint_set()->clone();
+		core::scoring::constraints::remove_nonbb_constraints(pose);
+	}
+
+	if ( pose.is_fullatom() ) {
+		protocols::moves::MoverOP tocen( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::CENTROID ) );
+		tocen->apply(pose);
+	}
+
+	// make fragments if we don't have them at this point
+	check_and_create_fragments( pose );
+
+	// domain parse templates if we do not have domain definitions
+	domain_parse_templates(nres_tgt);
+
+	// select random fragment sets if >2 are provided
+	core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
+	core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
+	TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
+	TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
+
+	// starting structure pool (for batch relax)
+	std::vector < SilentStructOP > post_centroid_structs;
+	bool need_more_samples = true;
+
+	// main centroid generation loop
+	core::Real gdtmm = 0.0;
+	if ( stage2_scorefxn_ == nullptr ) {
+		utility_exit_with_message("Stage 2 Scorefxn must be set!!!");
+	}
+
+	while ( need_more_samples ) {
+		need_more_samples = false;
+
+		// pick starting template
+		core::Size initial_template_index = pick_starting_template();
+		TR << "Using initial template: " << I(4,initial_template_index) << " " << template_fns_[initial_template_index] << std::endl;
+
+		// ensure
+		//    1)that no CONTIGS cross multiple CHAINS
+		//    2)that every input CHAIN has a chunk in it
+		// if not, add the corresponding contig as a chunk
+		utility::vector1< int > cuts = pose.fold_tree().cutpoints();
+		protocols::loops::Loops const &contigs_old = template_contigs_[initial_template_index];
+		protocols::loops::Loops contigs_new;
+		for ( core::Size j=1; j<=contigs_old.num_loop(); ++j ) {
+			protocols::loops::Loop contig_j = contigs_old[j];
+
+			for ( core::Size i=1; i<=cuts.size(); ++i ) {
+				int nextcut = cuts[i];
+				if ( nextcut > (int)nres_protein_tgt ) break;
+
+				core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
+				core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
+
+				if ( (int)start <= nextcut && (int)stop > nextcut ) {
+					// find template res corresponding to cut
+					for ( core::Size k=contig_j.start(); k<=contig_j.stop(); ++k ) {
+						if ( templates_[initial_template_index]->pdb_info()->number(k) == nextcut ) {
+							// ensure contig >= 3 res
+							if ( k > contig_j.start()+1 ) {
+								contigs_new.push_back( protocols::loops::Loop(contig_j.start(), k) );
+							}
+							TR << "Split contig ("<<contig_j.start()<<","<<contig_j.stop()<< ") at " << k << " [pdbnum: "<<start<<"/"<<stop<<"/" << nextcut << "]" << std::endl;
+							contig_j.set_start( k+1 );
+						}
+					}
+
+				}
+			}
+			// ensure contig >= 3 res
+			if ( contig_j.stop() > contig_j.start()+1 ) {
+				contigs_new.push_back( contig_j );
+			}
+		}
+		template_contigs_[initial_template_index] = contigs_new;
+
+		protocols::loops::Loops &chunks = template_chunks_[initial_template_index];
+		for ( core::Size i=0; i<=cuts.size(); ++i ) {
+			int prevcut = (i==0) ? 1 : cuts[i];
+			int nextcut = (i==cuts.size()) ? nres_protein_tgt : cuts[i+1];
+			if ( nextcut > (int)nres_protein_tgt ) break;
+			bool haschunk = false;
+			for ( core::Size j=1; j<=chunks.num_loop() && !haschunk; ++j ) {
+				protocols::loops::Loop const &chunk_j = chunks[j];
+				core::Size start = templates_[initial_template_index]->pdb_info()->number(chunk_j.start());
+				core::Size stop  = templates_[initial_template_index]->pdb_info()->number(chunk_j.stop());
+				if ( (int)start > prevcut && (int)stop <= nextcut ) haschunk=true;
+			}
+
+			if ( ! haschunk ) {
+				TR << "Segment ("<<prevcut<<","<<nextcut<<") has no chunks!  Adding contigs!" << std::endl;
+				bool hascontig=false;
+				for ( core::Size j=1; j<=contigs_new.num_loop(); ++j ) {
+					protocols::loops::Loop const &contig_j = contigs_new[j];
+					core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
+					core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
+					if ( (int)start > prevcut && (int)stop <= nextcut ) {
+						hascontig = true;
+						chunks.push_back( contig_j );
+					}
+				}
+				if ( !hascontig ) {
+					TR << "Warning!  No contigs found for segment!" << std::endl;
+					TR << "If you are not using the 'randomize=X' option there is likely something wrong with your input and models will not be reasonable!" << std::endl;
+				}
+			}
+		}
+
+		// (0) randomize chains
+		if ( randomize_chains_[initial_template_index].size() > 0 ) {
+			runtime_assert ( templates_[initial_template_index]->pdb_info() );
+			numeric::xyzVector< core::Real > comFixed(0,0,0), comMoving(0,0,0);
+			core::Real nFixed=0, nMoving=0;
+
+			TR << "Randomize >" << randomize_chains_[initial_template_index].size() << "<" << std::endl;
+			for ( core::Size q=1; q<=randomize_chains_[initial_template_index].size(); ++q ) {
+				TR << "Randomize >" << randomize_chains_[initial_template_index][q] << "<" << std::endl;
+			}
+
+			for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
+				char chain = templates_[initial_template_index]->pdb_info()->chain(i);
+				if ( std::find(
+						randomize_chains_[initial_template_index].begin(),
+						randomize_chains_[initial_template_index].end(),
+						chain) != randomize_chains_[initial_template_index].end()
+						) {
+					comMoving += templates_[initial_template_index]->residue(i).xyz(2);
+					nMoving++;
+				} else {
+					comFixed += templates_[initial_template_index]->residue(i).xyz(2);
+					nFixed++;
+				}
+			}
+
+			// sanity check
+			if ( nMoving == 0 ) {
+				utility_exit_with_message("Randomize chain enabled but chain(s) not found!");
+			}
+
+			comMoving /= nMoving;
+			comFixed /= nFixed;
+
+			// randomize orientation
+			numeric::xyzMatrix< core::Real > R = protocols::geometry::random_reorientation_matrix( 360, 360 );
+
+			// randomize offset
+			numeric::xyzVector< core::Real > T = numeric::random::random_point_on_unit_sphere< core::Real >( numeric::random::rg() );
+
+			// perturb & slide into contact
+			bool done=false, compacting=false;
+			core::Real DIST = 100.0;
+			core::scoring::ScoreFunction sf_vdw;
+			core::Real vdw_score = -1.0, step_size = -2.0, min_step_size = 0.25;
+			sf_vdw.set_weight( core::scoring::vdw, 1.0 );
+			core::pose::Pose template_orig = *(templates_[initial_template_index]);
+			while ( !done && DIST > 0 ) {
+				utility::vector1< id::AtomID > atm_ids;
+				utility::vector1< numeric::xyzVector< core::Real> > atm_xyzs;
+
+				for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
+					core::conformation::Residue const & rsd_i = template_orig.residue(i);
+					char chain = templates_[initial_template_index]->pdb_info()->chain(i);
+					if ( std::find(
+							randomize_chains_[initial_template_index].begin(),
+							randomize_chains_[initial_template_index].end(),
+							chain) != randomize_chains_[initial_template_index].end()
+							) {
+						for ( core::Size j = 1; j <= rsd_i.natoms(); ++j ) {
+							id::AtomID id( j,i );
+							atm_ids.push_back( id );
+							numeric::xyzVector< core::Real > new_ij = R*(rsd_i.xyz(j) - comMoving) + comFixed + DIST * T;
+							atm_xyzs.push_back( new_ij );
+						}
+					}
+				}
+				templates_[initial_template_index]->batch_set_xyz( atm_ids, atm_xyzs );
+				core::Real score_d = sf_vdw( *(templates_[initial_template_index]) );
+				if ( vdw_score < 0 ) vdw_score = score_d;
+
+				if ( !compacting && score_d > vdw_score + 2.0 ) {
+					compacting = true;
+					step_size = min_step_size;
+				} else if ( compacting  && vdw_score <= score_d + 2.0 ) {
+					done = true;
 				}
 
-				batch_relax_ = option[ cm::hybridize::relax ]();
-				relax_repeats_ = option[ basic::options::OptionKeys::relax::default_repeats ]();
+				TR << "D=" << DIST << " score=" << score_d << std::endl;
 
-				// disulfide file
-				if ( option[ in::fix_disulf ].user() ) {
-					disulf_file_ = option[ in::fix_disulf ]();
-				}
+				DIST += step_size;
+			}
+		}
 
-				// read fragments
-				if ( option[ in::file::frag9 ].user() ) {
-					using namespace core::fragment;
-					FragSetOP frags = FragmentIO().read_data( option[ in::file::frag9 ]() );
-					fragments_big_.push_back(frags);
-				}
-				if ( option[ in::file::frag3 ].user() ) {
-					using namespace core::fragment;
-					FragSetOP frags = FragmentIO().read_data( option[ in::file::frag3 ]() );
-					fragments_small_.push_back(frags);
-				}
+		// (1) steal hetatms from template
+		utility::vector1< std::pair< core::Size,core::Size > > hetatms;
+		if ( add_hetatm_ ) {
+			for ( core::Size ires=1; ires <= templates_[initial_template_index]->size(); ++ires ) {
+				if ( templates_[initial_template_index]->pdb_info()->number(ires) > (int)nres_tgt ) {
+					TR.Debug << "Insert hetero residue: " << templates_[initial_template_index]->residue(ires).name3() << std::endl;
+					if ( templates_[initial_template_index]->residue(ires).is_carbohydrate() ) {
+						if ( !templates_[initial_template_index]->residue(ires).is_lower_terminus() ) {
+							core::Size offset = pose.size() + 1 - ires;
+							core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( templates_[initial_template_index]->residue(ires) ) );
+							int self_lower=0;
+							int parent_upper=0;
+							//self_lower = templates_[initial_template_index]->residue(ires).lower_connect_id();
+							//parent_upper = templates_[initial_template_index]->residue(parent_res_seqpos).connect_atom( templates_[initial_template_index]->residue(ires) );
+							for ( core::Size i(1); i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i ) {
+								TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+								if ( templates_[initial_template_index]->residue(ires).connect_map( i ).resid() == parent_res_seqpos ) {
+									//self_lower = templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
+									self_lower = i;
+									parent_upper=templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
+									//parent_upper=templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i);
+								}
+							}
+							parent_res_seqpos += offset;
+							TR.Debug <<"  appending by bond "<<pose.size()+1<<" lower "<<self_lower<<" anchor "<<parent_res_seqpos<<" parent upper "<<parent_upper<<std::endl;
+							pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires), false, self_lower, parent_res_seqpos, parent_upper, false, false);
+						} else {
+							TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
+							for ( core::Size i(1); i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i ) {
+								TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+							}
+							pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
 
-				// native
-				if ( option[ in::file::native ].user() ) {
-					native_needs_load_ = true;
-				} else if ( option[ evaluation::align_rmsd_target ].user() ) {
-					native_needs_load_from_align_rmsd_target_ = true;
+						}
+					} else if ( templates_[initial_template_index]->residue(ires).is_polymer()
+							&& !templates_[initial_template_index]->residue(ires).is_lower_terminus()
+							&& !pose.residue(pose.size()).is_upper_terminus() ) {
+						TR.Debug <<"  appending by bond "<<ires<<std::endl;
+						pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires));
+						for ( core::Size i(1); i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i ) {
+							TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+						}
+					} else {
+						TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
+						pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
+						for ( core::Size i(1); i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i ) {
+							TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+						}
+					}
+					hetatms.push_back( std::make_pair( ires, pose.size() ) );
 				}
+			}
+			pose.conformation().chains_from_termini();
+		}
+
+		// (2) realign structures per-domain
+		if ( realign_domains_ ) {
+			//
+			if ( std::find( non_null_template_indices_.begin(), non_null_template_indices_.end(), initial_template_index )
+					!= non_null_template_indices_.end() ) {
+				align_templates_by_domain(templates_[initial_template_index], domains_all_templ_[initial_template_index]);
+			} else {
+				if ( non_null_template_indices_.size() == 0 ) {
+					TR << "No non-extended templates.  Skipping alignment." << std::endl;
+				} else {
+					TR << "Cannot align to extended template! Choosing a random template instead." << std::endl;
+					core::Size aln_target = numeric::random::random_range(1, non_null_template_indices_.size() );
+					align_templates_by_domain(templates_[aln_target], domains_all_templ_[aln_target]);
+				}
+			}
+		}
+
+		// (3) apply symmetry
+		std::string symmdef_file = symmdef_files_[initial_template_index];
+		if ( !symmdef_file.empty() && symmdef_file != "NULL" ) {
+			protocols::symmetry::SetupForSymmetryMover makeSymm( symmdef_file );
+			makeSymm.apply(pose);
+
+			//fpd   to get the right rotamer set we need to do this
+			basic::options::option[basic::options::OptionKeys::symmetry::symmetry_definition].value( "dummy" );
+
+			// xyz copy hetatms (properly handle cases where scoring subunit is not the first)
+			if ( add_hetatm_ ) {
+				for ( core::Size ihet=1; ihet <= hetatms.size(); ++ihet ) {
+					core::conformation::Residue const &res_in = templates_[initial_template_index]->residue(hetatms[ihet].first);
+					for ( core::Size iatm=1; iatm<=res_in.natoms(); ++iatm ) {
+						core::id::AtomID tgt(iatm,hetatms[ihet].second);
+						pose.set_xyz( tgt, res_in.xyz( iatm ) );
+					}
+				}
+			}
+		}
+
+		// (4) add a virtual if we have a map or coord csts
+		//     keep after symm
+		//     should we check if a map is loaded (or density scoring is on) instead??
+		if ( option[ OptionKeys::edensity::mapfile ].user() || user_csts_.size() > 0 ) {
+			MoverOP dens( utility::pointer::make_shared< protocols::electron_density::SetupForDensityScoringMover >() );
+			dens->apply( pose );
+		}
+
+		// (5) initialize template history
+		//     keep after symm
+		TemplateHistoryOP history( utility::pointer::make_shared< TemplateHistory >(pose) );
+		history->setall( initial_template_index );
+		pose.data().set( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY, history );
+
+		// (6) allowed movement
+		utility::vector1<bool> allowed_to_move;
+		allowed_to_move.resize(pose.size(),true);
+		for ( int i=1; i<=(int)residue_sample_template_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_template_[i];
+		for ( int i=1; i<=(int)residue_sample_abinitio_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_abinitio_[i];
+
+		// STAGE 1
+		//fpd constraints are handled a little bit weird
+		//  * foldtree hybridize sets chainbreak variants then applies constraints (so c-beta csts are treated properly)
+		//  * after chainbreak variants are removed, csts are removed and reapplied in this function
+		//  * finally after switch to fullatom CSTs are reapplied again (optionally using a different CST file)
+		// If "AUTO" is specified for cen_csts automatic centroid csts are generated
+		// If "AUTO" is specified for fa_csts automatic fa csts are generated
+		// If "NONE" is specified for fa_csts, cen csts are used (AUTO or otherwise)
+		// An empty string is treated as equivalent to "NONE"
+
+		// fold tree hybridize
+		if ( numeric::random::rg().uniform() < stage1_probability_ ) {
+
+			for ( core::Size repeatstage1=0; repeatstage1 < jump_move_repeat_; ++repeatstage1 ) {
+
+				std::string cst_fn = template_cst_fn_[initial_template_index];
+
+				FoldTreeHybridizeOP ft_hybridize(
+					utility::pointer::make_shared< FoldTreeHybridize >(
+					initial_template_index, templates_aln_, template_weights_,
+					template_chunks_, frags_small, frags_big) ) ;
+
+				ft_hybridize->set_constraint_file( cst_fn );
+				ft_hybridize->set_constraint( cen_cst_in_ );
+				ft_hybridize->set_scorefunction( stage1_scorefxn_ );
+
+				// options
+				ft_hybridize->set_increase_cycles( stage1_increase_cycles_ );
+				ft_hybridize->set_stage1_1_cycles( stage1_1_cycles_ );
+				ft_hybridize->set_stage1_2_cycles( stage1_2_cycles_ );
+				ft_hybridize->set_stage1_3_cycles( stage1_3_cycles_ );
+				ft_hybridize->set_stage1_4_cycles( stage1_4_cycles_ );
+				ft_hybridize->set_add_non_init_chunks( add_non_init_chunks_ );
+				ft_hybridize->set_add_hetatm( add_hetatm_, hetatm_self_cst_weight_, hetatm_prot_cst_weight_ );
+				ft_hybridize->set_frag_1mer_insertion_weight( frag_1mer_insertion_weight_ );
+				ft_hybridize->set_small_frag_insertion_weight( small_frag_insertion_weight_ );
+				ft_hybridize->set_big_frag_insertion_weight( big_frag_insertion_weight_ );
+				ft_hybridize->set_chunk_insertion_weight( chunk_insertion_weight_ );
+				ft_hybridize->set_frag_weight_aligned( frag_weight_aligned_ );
+				ft_hybridize->set_auto_frag_insertion_weight( auto_frag_insertion_weight_ );
+				ft_hybridize->set_max_registry_shift( max_registry_shift_ );
 
 				// strand pairings
-				pairings_file_ = option[jumps::pairing_file]();
-				if ( option[jumps::sheets].user() ) {
-					sheets_ = option[jumps::sheets]();
+				ft_hybridize->set_pairings_file( pairings_file_ );
+				ft_hybridize->set_sheets( sheets_ );
+				ft_hybridize->set_random_sheets( random_sheets_ );
+				ft_hybridize->set_filter_templates( filter_templates_ );
+
+				// allowed movement
+				ft_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
+				ft_hybridize->set_minimize_at_end( min_after_stage1_ );
+				ft_hybridize->set_minimize_sf( stage2_scorefxn_ );
+
+				// max insertion
+				ft_hybridize->set_max_insertion( max_contig_insertion_ );
+
+				// other cst stuff
+				ft_hybridize->set_user_csts( user_csts_ );
+
+				// finally run stage 1
+				ft_hybridize->apply(pose);
+
+				// get strand pairings if they exist for constraints in later stages
+				strand_pairs_ = ft_hybridize->get_strand_pairs();
+
+				//jump perturbation and minimization
+				//fpd!  these docking moves should be incorporated as part of stage 1!
+				if ( jump_move_ ) {
+					do_intrastage_docking( pose );
+				}
+			} //end of repeatstage1
+
+		} else {
+			// just do frag insertion in unaligned regions
+			core::pose::PoseOP chosen_templ = templates_aln_[initial_template_index];
+			protocols::loops::Loops chosen_contigs = template_contigs_[initial_template_index];
+			initialize_and_sample_loops(pose, chosen_templ, chosen_contigs, stage1_scorefxn_);
+		}
+
+		// realign domains to the output of stage 1
+		if ( jump_move_ || realign_domains_stage2_ ) {
+			TR << "Realigning template domains to stage1 pose." << std::endl;
+			core::pose::PoseOP stage1pose( utility::pointer::make_shared< core::pose::Pose >( pose ) );
+			align_templates_by_domain(stage1pose); // don't use stored domains; recompute parse from model
+		}
+
+		//write gdtmm to output
+		if ( native_ && native_->size() ) {
+			gdtmm = get_gdtmm(*native_, pose, aln_);
+			core::pose::setPoseExtraScore( pose, "GDTMM_after_stage1", gdtmm);
+			TR << "GDTMM_after_stage1" << F(8,3,gdtmm) << std::endl;
+		}
+
+		// STAGE 2
+		// apply constraints
+		if ( stage2_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
+			std::string cst_fn = template_cst_fn_[initial_template_index];
+			if ( !keep_pose_constraint_ ) {
+				if ( ! cen_cst_in_.empty() ) {
+					setup_constraints(pose, cen_cst_in_);
 				} else {
-					random_sheets_ = option[jumps::random_sheets]();
-				}
-				filter_templates_ = option[jumps::filter_templates]();
-			}
-
-		void
-			HybridizeProtocol::check_and_create_fragments( core::pose::Pose & pose ) {
-				if ( fragments_big_.size() > 0 && fragments_small_.size() > 0 ) return;
-
-				core::Size fragbiglen=9;
-
-				if ( !fragments_big_.size() ) {
-					// number of residues
-					core::Size nres_tgt = pose.size();
-					core::conformation::symmetry::SymmetryInfoCOP symm_info;
-					if ( core::pose::symmetry::is_symmetric(pose) ) {
-						auto & SymmConf (
-								dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-						symm_info = SymmConf.Symmetry_Info();
-						nres_tgt = symm_info->num_independent_residues();
-					}
-					if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-					while ( !pose.residue(nres_tgt).is_protein() ) nres_tgt--;
-
-					fragbiglen = std::min( fragbiglen, nres_tgt );
-
-					core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >() );
-
-					// sequence
-					std::string tgt_seq = pose.sequence();
-					std::string tgt_ss(nres_tgt, '0');
-
-					using namespace basic::options;
-					using namespace basic::options::OptionKeys;
-					if ( option[ OptionKeys::in::file::psipred_ss2 ].user() ) {
-						utility::vector1< char > psipred = read_psipred_ss2_file( pose );
-						for ( core::Size j=1; j<=nres_tgt; ++j ) {
-							tgt_ss[j-1] = psipred[j];
-						}
-					} else {
-						// templates vote on secstruct
-						for ( core::Size i=1; i<=templates_.size(); ++i ) {
-							for ( core::Size j=1; j<=templates_[i]->size(); ++j ) {
-								if ( !templates_[i]->residue(j).is_protein() ) continue;
-								core::Size tgt_pos = templates_[i]->pdb_info()->number(j);
-
-								runtime_assert( tgt_pos<=nres_tgt );
-								char tgt_ss_j = templates_[i]->secstruct(j);
-
-								if ( tgt_ss[tgt_pos-1] == '0' ) {
-									tgt_ss[tgt_pos-1] = tgt_ss_j;
-								} else if ( tgt_ss[tgt_pos-1] != tgt_ss_j ) {
-									tgt_ss[tgt_pos-1] = 'D'; // templates disagree
-								}
-							}
-						}
-						for ( core::Size j=1; j<=nres_tgt; ++j ) {
-							if ( tgt_ss[j-1] == '0' ) tgt_ss[j-1] = 'D';
-						}
-					}
-
-					// pick from vall based on template SS + target sequence
-					for ( core::Size j=1; j<=nres_tgt-fragbiglen+1; ++j ) {
-						core::fragment::FrameOP frame( utility::pointer::make_shared< core::fragment::Frame >(j, fragbiglen) );
-
-						if ( j > residue_sample_abinitio_.size() || residue_sample_abinitio_[j] ) {
-							frame->add_fragment(
-									core::fragment::picking_old::vall::pick_fragments_by_ss_plus_aa(
-										tgt_ss.substr( j-1, fragbiglen ), tgt_seq.substr( j-1, fragbiglen ), 25, true, core::fragment::IndependentBBTorsionSRFD() ) );
-							frags->add( frame );
-						}
-					}
-					fragments_big_.push_back( frags );
-				}
-				if ( !fragments_small_.size() ) {
-					core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >(3) );
-
-					// make them from big fragments
-					core::fragment::chop_fragments( *fragments_big_[1], *frags );
-					fragments_small_.push_back( frags );
+					setup_centroid_constraints( pose, templates_aln_, template_weights_, cst_fn );
 				}
 			}
+			if ( add_hetatm_ ) {
+				add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
+			}
+			if ( strand_pairs_.size() ) {
+				add_strand_pairs_cst(pose, strand_pairs_);
+			}
+		}
 
-		//fpd add fragment-derived constraints
-		void
-			HybridizeProtocol::add_fragment_csts( core::pose::Pose &pose ) {
-				TR << "Adding fragment constraints" << std::endl;
+		// add torsion constraints derived from fragments
+		if ( csts_from_frags_ ) {
+			if ( stage2_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
+				add_fragment_csts( pose );
+			} else {
+				TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
+			}
+		}
 
-				core::fragment::FragSetOP frags = fragments_small_[1];
+		if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
+			if ( user_csts_.size() > 0 ) {
+				setup_user_coordinate_constraints(pose,user_csts_);
+			}
+		}
 
-				// stolen from SecondaryStructure.cc
-				if ( frags->global_offset() != 0 ) {
-					TR.Error << "SecondaryStructure computations must be carried out with local coordinates (global offset of fragments must be 0)." << std::endl;
-					TR.Error << "   value of global offset of fragments: " << frags->global_offset() << std::endl;
-					utility_exit_with_message("SecondaryStructure computations not in local coordinates!");
+		if ( !option[cm::hybridize::skip_stage2]() ) {
+			core::scoring::ScoreFunctionOP stage2_scorefxn_clone = stage2_scorefxn_->clone();
+
+			core::scoring::methods::EnergyMethodOptions lowres_options(stage2_scorefxn_clone->energy_method_options());
+			lowres_options.set_cartesian_bonded_linear(true);
+			stage2_scorefxn_clone->set_energy_method_options(lowres_options);
+
+			CartesianHybridizeOP cart_hybridize(
+				utility::pointer::make_shared< CartesianHybridize >( templates_aln_, template_weights_, template_chunks_,template_contigs_, frags_big ) );
+
+			// default scorefunctions (cenrot-compatable)
+			if ( stage2_scorefxn_!=nullptr ) cart_hybridize->set_scorefunction( stage2_scorefxn_ );
+			if ( stage2pack_scorefxn_!=nullptr ) cart_hybridize->set_pack_scorefunction( stage2pack_scorefxn_ );
+			if ( stage2min_scorefxn_!=nullptr ) cart_hybridize->set_min_scorefunction( stage2min_scorefxn_ );
+
+			// set options
+			cart_hybridize->set_increase_cycles( stage2_increase_cycles_ );
+			cart_hybridize->set_no_global_frame( no_global_frame_ );
+			cart_hybridize->set_linmin_only( linmin_only_ );
+			cart_hybridize->set_seqfrags_only( seqfrags_only_ );
+			cart_hybridize->set_cartfrag_overlap( cartfrag_overlap_ );
+			cart_hybridize->set_skip_long_min( skip_long_min_ );
+			cart_hybridize->set_cenrot( cenrot_ );
+			cart_hybridize->set_fragment_probs(fragprob_stage2_, randfragprob_stage2_);
+
+			// max insertion
+			cart_hybridize->set_max_insertion( max_contig_insertion_ );
+
+			// per-residue controls
+			cart_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
+
+			// finally run stage 2
+			cart_hybridize->apply(pose);
+		}
+
+		//write gdtmm to output
+		if ( native_ && native_->size() ) {
+			gdtmm = get_gdtmm(*native_, pose, aln_);
+			core::pose::setPoseExtraScore( pose, "GDTMM_after_stage2", gdtmm);
+			TR << "GDTMM_after_stage2" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
+		}
+		// get fragment history
+		runtime_assert( pose.data().has( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
+		history = utility::pointer::static_pointer_cast< TemplateHistory >( pose.data().get_ptr( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
+
+		TR << "History :";
+		for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4,i); }
+		TR << std::endl;
+		TR << "History :";
+		for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4, history->get(i)); }
+		TR << std::endl;
+
+		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+		mm->set_bb  ( true );
+		mm->set_chi ( true );
+		mm->set_jump( true );
+
+		//fpd -- in positions where no fragment insertions are allowed, also allow no minimization
+		if ( residue_sample_template_.size() > 0 && residue_sample_abinitio_.size() > 0 ) {
+			for ( int i=1; i<=(int)nres_tgt; ++i ) {
+				if ( !residue_sample_template_[i] && !residue_sample_abinitio_[i] ) {
+					TR.Trace << "locking residue " << i << std::endl;
+					mm->set_bb  ( i, false );
+					mm->set_chi ( i, false );
 				}
+			}
+		}
 
-				// 1 - collect fragment statistics
-				core::Size frag_nres = frags->max_pos();
-				utility::vector1< utility::vector1< core::Real > > phi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
-				utility::vector1< utility::vector1< core::Real > > psi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
-				utility::vector1< int > N( frag_nres, 0 );
+		if ( core::pose::symmetry::is_symmetric(pose) ) {
+			core::pose::symmetry::make_symmetric_movemap( pose, *mm );
+		}
 
-				for ( core::fragment::FragID_Iterator it=frags->begin(), eit=frags->end(); it!=eit; ++it ) { //carefully checked that I don't change FrameData
-					core::Size loop_start = 1;
-					core::Size loop_end = it->frame().length();
-					for ( core::Size fpos = loop_start; fpos <= loop_end; ++fpos ) {
-						core::fragment::BBTorsionSRFDCOP res_i =
-							utility::pointer::dynamic_pointer_cast<const core::fragment::BBTorsionSRFD> (it->fragment().get_residue( fpos ) );
+		// stage "2.5" .. minimize with centroid energy + full-strength cart bonded
+		if ( !option[cm::hybridize::skip_stage2]() ) {
+			core::optimization::MinimizerOptions options_lbfgs( "lbfgs_armijo_nonmonotone", 0.01, true, false, false );
+			core::optimization::CartesianMinimizer minimizer;
+			auto n_min_cycles =(core::Size) (200.*stage25_increase_cycles_);
+			options_lbfgs.max_iter(n_min_cycles);
+			(*stage2_scorefxn_)(pose); minimizer.run( pose, *mm, *stage2_scorefxn_, options_lbfgs );
+		}
 
-						core::Size pos = it->frame().seqpos( fpos );
-						core::Real phi = std::fmod( res_i->torsion(1), 360.0 ); if ( phi<0 ) phi +=360.0;
-						core::Real psi = std::fmod( res_i->torsion(2), 360.0 ); if ( psi<0 ) psi +=360.0;
-
-						auto phibin = (core::Size) std::floor( phi/10.0 ); if ( phibin == 36 ) phibin=0;
-						auto psibin = (core::Size) std::floor( psi/10.0 ); if ( psibin == 36 ) psibin=0;
-
-						phi_distr[pos][phibin+1]+=1.0;
-						psi_distr[pos][psibin+1]+=1.0;
-						N[pos]++;
-					}
-				}
-
-				// smoothing
-				//core::Real smoothing[7] = {0.09, 0.14, 0.175, 0.19, 0.175, 0.14, 0.09};  // very soft
-				core::Real smoothing[7] = {0.01, 0.05, 0.24, 0.40, 0.24, 0.05, 0.01}; // less soft
-				for ( int i=1; i<=(int)frag_nres; ++i ) {
-					utility::vector1< core::Real > phi_i = phi_distr[i];
-					utility::vector1< core::Real > psi_i = psi_distr[i];
-					for ( int j=1; j<=36; ++j ) {
-						phi_distr[i][j] = smoothing[0]*phi_i[1+((j+32)%36)]
-							+ smoothing[1]*phi_i[1+((j+33)%36)]
-							+ smoothing[2]*phi_i[1+((j+34)%36)]
-							+ smoothing[3]*phi_i[1+((j+35)%36)]
-							+ smoothing[4]*phi_i[1+((j+0)%36)]
-							+ smoothing[5]*phi_i[1+((j+1)%36)]
-							+ smoothing[6]*phi_i[1+((j+2)%36)];
-
-						psi_distr[i][j] = smoothing[0]*psi_i[1+((j+32)%36)]
-							+ smoothing[1]*psi_i[1+((j+33)%36)]
-							+ smoothing[2]*psi_i[1+((j+34)%36)]
-							+ smoothing[3]*psi_i[1+((j+35)%36)]
-							+ smoothing[4]*psi_i[1+((j+0)%36)]
-							+ smoothing[5]*psi_i[1+((j+1)%36)]
-							+ smoothing[6]*psi_i[1+((j+2)%36)];
-
-						phi_distr[i][j] /= N[i];
-						psi_distr[i][j] /= N[i];
-					}
-				}
-
-				// convert to energy
-				core::Real mest=0.1;
-				for ( int i=1; i<=(int)frag_nres; ++i ) {
-					for ( int j=1; j<=36; ++j ) {
-						// shift so max is 0
-						phi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*phi_distr[i][j] ) + std::log( mest/36.0 ) ;
-						psi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*psi_distr[i][j] ) + std::log( mest/36.0 ) ;
-					}
-
-					//TR << "phi " << i;
-					//for (int j=1; j<=36; ++j) TR << " " << phi_distr[i][j];
-					//TR << std::endl;
-
-					//TR << "psi " << i;
-					//for (int j=1; j<=36; ++j) TR << " " << psi_distr[i][j];
-					//TR << std::endl;
-				}
-
-				// finally .. add constraints
-				for ( int i=1; i<=(int)frag_nres; ++i ) {
-					using namespace core::scoring::func;
-					using namespace core::scoring::constraints;
-
+		// STAGE 3: RELAX
+		if ( batch_relax_ > 0 ) {
+			// set disulfides before going to FA
+			if ( disulf_file_.length() > 0 ) {
+				// delete current disulfides
+				for ( int i=1; i<=(int)pose.size(); ++i ) {
 					if ( !pose.residue(i).is_protein() ) continue;
-
-					if ( i>1 && pose.residue(i-1).is_protein() ) {
-						FuncOP phi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, phi_distr[i] ) );
-						ConstraintOP phi_cst( utility::pointer::make_shared< DihedralConstraint >(
-									core::id::AtomID(3,i-1),core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i), phi_func  ) );
-						pose.add_constraint( scoring::constraints::ConstraintCOP( phi_cst ) );
-					}
-
-					if ( i<(int)frag_nres && pose.residue(i+1).is_protein() ) {
-						FuncOP psi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, psi_distr[i] ) );
-						ConstraintOP psi_cst( utility::pointer::make_shared< DihedralConstraint >(
-									core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i),core::id::AtomID(1,i+1), psi_func  ) );
-						pose.add_constraint( scoring::constraints::ConstraintCOP( psi_cst ) );
-					}
-				}
-			}
-
-		void
-			HybridizeProtocol::initialize_and_sample_loops(
-					core::pose::Pose &pose,
-					core::pose::PoseOP chosen_templ,
-					protocols::loops::Loops template_contigs,
-					core::scoring::ScoreFunctionOP scorefxn)
-			{
-				using namespace basic::options;
-				using namespace basic::options::OptionKeys;
-
-				// xyz copy starting model
-				for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
-					for ( core::Size j=1; j<=chosen_templ->residue(i).natoms(); ++j ) {
-						core::id::AtomID src(j,i), tgt(j, chosen_templ->pdb_info()->number(i));
-						pose.set_xyz( tgt, chosen_templ->xyz( src ) );
+					if ( pose.residue(i).type().is_disulfide_bonded() ) {
+						core::conformation::change_cys_state( i, "CYS", pose.conformation() );
 					}
 				}
 
-				// make loops as inverse of template_contigs
-				TR << "CONTIGS" << std::endl << template_contigs << std::endl;
-				//core::Size ncontigs = template_contigs.size();
-				core::Size nres_tgt = pose.size();
-
-				//symmetry
-				core::conformation::symmetry::SymmetryInfoCOP symm_info;
-				if ( core::pose::symmetry::is_symmetric(pose) ) {
-					auto & SymmConf (
-							dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-					symm_info = SymmConf.Symmetry_Info();
-					nres_tgt = symm_info->num_independent_residues();
-				}
-
-				if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-
-				protocols::loops::LoopsOP loops( utility::pointer::make_shared< protocols::loops::Loops >() );
-				utility::vector1< bool > templ_coverage(nres_tgt, false);
-
-				for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
-					core::Size cres = chosen_templ->pdb_info()->number(i);
-					templ_coverage[cres] = true;
-				}
-
-				// remove 1-3 residue "segments"
-				for ( core::Size i=1; i<=nres_tgt-2; ++i ) {
-					if ( !templ_coverage[i] && templ_coverage[i+1] && !templ_coverage[i+2] ) {
-						templ_coverage[i+1]=false;
-					} else if ( i<=nres_tgt-3 && !templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && !templ_coverage[i+3] ) {
-						templ_coverage[i+1]=false;
-						templ_coverage[i+2]=false;
-					} else if ( i<=nres_tgt-4 &&
-							!templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && templ_coverage[i+3] && !templ_coverage[i+4] ) {
-						templ_coverage[i+1]=false;
-						templ_coverage[i+2]=false;
-						templ_coverage[i+3]=false;
-					}
-				}
-				// make loopfile
-				bool inloop=!templ_coverage[1];
-				core::Size loopstart=1, loopstop;
-				for ( core::Size i=2; i<=nres_tgt; ++i ) {
-					if ( templ_coverage[i] && inloop ) {
-						inloop = false;
-						loopstop = i;
-						if ( loopstop < loopstart + 2 ) {
-							if ( loopstart>1 ) loopstart--;
-							if ( loopstop<nres_tgt ) loopstop++;
-						}
-						loops->add_loop( loopstart,loopstop );
-					} else if ( !templ_coverage[i] && !inloop ) {
-						// start loop
-						inloop = true;
-						loopstart = i-1;
-					}
-				}
-				if ( inloop ) {
-					// end loop
-					loopstop = nres_tgt;
-					while ( loopstop < loopstart + 2 ) { loopstart--; }
-					loops->add_loop( loopstart,loopstop );
-				}
-				TR << "LOOPS" << std::endl << *loops << std::endl;
-
-				// now do insertions
-				if ( loops->size() != 0 ) {
-					// set foldtree + variants
-					loops->auto_choose_cutpoints(pose);
-					core::kinematics::FoldTree f_in=pose.fold_tree(), f_new;
-					protocols::loops::fold_tree_from_loops( pose, *loops, f_new);
-					pose.fold_tree( f_new );
-					protocols::loops::add_cutpoint_variants( pose );
-
-					// set movemap
-					core::kinematics::MoveMapOP mm_loop( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-					for ( auto const & it : *loops ) {
-						for ( core::Size i=it.start(); i<=it.stop(); ++i ) {
-							mm_loop->set_bb(i, true);
-							mm_loop->set_chi(i, true); // chi of loop residues
-						}
-					}
-
-					// setup fragment movers
-					protocols::simple_moves::ClassicFragmentMoverOP frag3mover, frag9mover;
-					core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
-					core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
-					TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
-					TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
-					frag3mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_small, mm_loop );
-					frag3mover->set_check_ss( false ); frag3mover->enable_end_bias_check( false );
-					frag9mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_big, mm_loop );
-					frag9mover->set_check_ss( false ); frag9mover->enable_end_bias_check( false );
-
-					// extend + idealize loops
-					for ( auto const & it : *loops ) {
-						protocols::loops::Loop to_idealize( it );
-						protocols::loops::set_extended_torsions( pose, it );
-					}
-
-					// setup MC
-					scorefxn->set_weight( core::scoring::linear_chainbreak, 0.5 );
-					(*scorefxn)(pose);
-					protocols::moves::MonteCarloOP mc1( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
-
-					auto neffcycles = (core::Size)(1000*option[cm::hybridize::stage1_increase_cycles]());
-					for ( core::Size n=1; n<=neffcycles; ++n ) {
-						frag9mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag9" );
-						frag3mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag3" );
-
-						if ( n%100 == 0 ) {
-							mc1->show_scores();
-							mc1->show_counters();
-						}
-					}
-					mc1->recover_low( pose );
-
-					scorefxn->set_weight( core::scoring::linear_chainbreak, 2.0 );
-					(*scorefxn)(pose);
-					protocols::moves::MonteCarloOP mc2( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
-					for ( core::Size n=1; n<=neffcycles; ++n ) {
-						frag9mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag9" );
-						frag3mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag3" );
-
-						if ( n%100 == 0 ) {
-							mc2->show_scores();
-							mc2->show_counters();
-						}
-					}
-
-					// restore input ft
-					mc2->recover_low( pose );
-					protocols::loops::remove_cutpoint_variants( pose );
-					pose.fold_tree( f_in );
-				}
-			}
-
-
-		void HybridizeProtocol::add_template(
-				std::string const & template_fn,
-				std::string const & cst_fn,
-				std::string const & symm_file,
-				core::Real const weight,
-				utility::vector1<char> const & randchains,
-				bool const align_pdb_info)
-		{
-			core::chemical::ResidueTypeSetCOP const residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
-
-			core::pose::PoseOP template_pose( utility::pointer::make_shared< core::pose::Pose >() );
-			if ( template_fn == "extended" ) {
-				// auto constraints make no sense
-				if ( cst_fn == "AUTO" ) {
-					TR.Error << "Warning!  Turning off auto constraints for extended pose" << std::endl;
-				}
-				add_null_template( template_pose, "NONE", symm_file, weight );
+				// manually add new ones
+				TR << " add disulfide: " << std::endl;
+				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].value(disulf_file_);
+				core::pose::initialize_disulfide_bonds(pose);
+				// must reset this since initialize_disulfide_bonds is used in pose io
+				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].deactivate();
+				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].to_default(); // reset to the default value
 			} else {
-				core::import_pose::pose_from_file( *template_pose, *residue_set, template_fn , core::import_pose::PDB_file);
-				add_template( template_pose, cst_fn, symm_file, weight, randchains, template_fn, align_pdb_info);
-			}
-		}
-
-
-		void HybridizeProtocol::add_null_template(
-				core::pose::PoseOP template_pose,
-				std::string cst_fn,
-				std::string symm_file,
-				core::Real weight)
-		{
-			template_fns_.push_back("null");
-			templates_.push_back(template_pose);
-			templates_aln_.push_back(template_pose); // shallow copy
-			template_cst_fn_.push_back(cst_fn);
-			symmdef_files_.push_back(symm_file);
-			template_weights_.push_back(weight);
-			template_chunks_.push_back(protocols::loops::Loops());
-			template_contigs_.push_back(protocols::loops::Loops());
-			randomize_chains_.push_back(utility::vector1<char>(0));
-		}
-
-		void HybridizeProtocol::add_template(
-				core::pose::PoseOP template_pose,
-				std::string const & cst_fn,
-				std::string const & symm_file,
-				core::Real const weight,
-				utility::vector1<char> const & rand_chains,
-				std::string const & filename,
-				bool const align_pdb_info)
-		{
-			// add secondary structure information to the template pose
-			core::scoring::dssp::Dssp dssp_obj( *template_pose );
-			dssp_obj.insert_ss_into_pose( *template_pose );
-
-			// find ss chunks in template
-			protocols::loops::Loops contigs = protocols::loops::extract_continuous_chunks(*template_pose);
-			protocols::loops::Loops chunks;
-			if ( include_loop_ss_chunks_ ) {
-				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
-			} else {
-				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
+				pose.conformation().detect_disulfides();
 			}
 
-			// if there are no SS elts in the pose, use contigs
-			if ( chunks.num_loop() == 0 ) chunks = contigs;
+			protocols::moves::MoverOP tofa( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::FA_STANDARD ) );
+			tofa->apply(pose);
 
-			TR.Debug << "Chunks from template\n" << chunks << std::endl;
-			TR.Debug << "Contigs from template\n" << contigs << std::endl;
-
-			template_fns_.push_back(filename);
-			templates_.push_back(template_pose);
-			templates_aln_.push_back(template_pose); // shallow copy
-			template_cst_fn_.push_back(cst_fn);
-			symmdef_files_.push_back(symm_file);
-			template_weights_.push_back(weight);
-			template_chunks_.push_back(chunks);
-			template_contigs_.push_back(contigs);
-			randomize_chains_.push_back(rand_chains);
-			should_align_pdb_infos_.push_back(align_pdb_info);
-
-			non_null_template_indices_.push_back( templates_.size() );
-		}
-
-		void HybridizeProtocol::update_template(core::Size const template_idx )
-		{
-			core::pose::PoseOP const template_pose(templates_[template_idx]);
-
-			// add secondary structure information to the template pose
-			core::scoring::dssp::Dssp dssp_obj( *template_pose );
-			dssp_obj.insert_ss_into_pose( *template_pose );
-
-			// find ss chunks in template
-			protocols::loops::Loops const contigs = protocols::loops::extract_continuous_chunks(*template_pose);
-
-			protocols::loops::Loops chunks;
-			if ( include_loop_ss_chunks_ ) {
-				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
-			} else {
-				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
-			}
-			if ( chunks.num_loop() == 0 ) chunks = contigs;
-
-			template_chunks_[template_idx] = chunks;
-			template_contigs_[template_idx] = contigs;
-		}
-
-
-		// validate input templates match input sequence
-		// TO DO: if only sequences mismatch try realigning
-		void HybridizeProtocol::validate_template(
-				std::string const & filename,
-				std::string const & fasta,
-				core::pose::PoseOP template_pose,
-				bool & align_pdb_info)
-		{
-			core::Size nres_fasta = fasta.length(), nres_templ = template_pose->size();
-			core::Size next_ligand = nres_fasta+1; // ligands must be sequentially numbered
-
-			bool requires_alignment = false;
-			for ( core::Size i=1; i<=nres_templ; ++i ) {
-				char templ_aa = template_pose->residue(i).name1();
-				core::Size i_fasta = template_pose->pdb_info()->number(i);
-				bool is_ligand = !template_pose->residue(i).is_protein();
-
-				// ligands
-				if ( i_fasta > nres_fasta || is_ligand ) {
-					if ( !is_ligand ) {
-						TR.Error << "   Residue number " << i_fasta << " is outside of input fasta range." << std::endl;
-						requires_alignment = true;
-						break;
+			// apply fa constraints
+			std::string cst_fn = template_cst_fn_[initial_template_index];
+			if ( fa_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
+				if ( !keep_pose_constraint_ ) {
+					if ( ! fa_cst_in_.empty() ) {
+						setup_constraints(pose, fa_cst_in_);
 					} else {
-						template_pose->pdb_info()->number(i,next_ligand);
+						setup_fullatom_constraints( pose, templates_aln_, template_weights_, cst_fn, fa_cst_fn_ );
 					}
-					next_ligand++;
 				} else {
-					char fasta_aa = fasta[i_fasta-1];
-					if ( fasta_aa != templ_aa ) {
-						TR.Error << "Sequence mismatch between input fasta and template " << filename
-							<< " at residue " << i_fasta << std::endl;
-						TR.Error << "   Expected: " << fasta_aa << "   Saw: " << templ_aa << std::endl;
-						if ( !align_pdb_info ) utility_exit_with_message("Issue validating template in HybridizeProtocol.");
-						requires_alignment = true;
-						break;
-					}
+					pose.constraint_set(save_pose_constraint_set);
 				}
-			}
-			if ( requires_alignment ) {
-				TR.Error << "THE PDB INFO IS NOT IN SYNC WITH THE FASTA. ATTEMPTING TO RESOLVE THE ISSUE AUTOMATICALLY" << std::endl;
-				//this block code shouldn't be needed since hybrid needs asymmetric poses anyway but it doesn't hurt
-				core::pose::Pose pose_for_seq;
-				core::pose::symmetry::extract_asymmetric_unit(*template_pose, pose_for_seq, false);
-
-				core::sequence::SequenceOP full_length_seq( utility::pointer::make_shared< core::sequence::Sequence >( fasta, "target" ));
-				core::sequence::SequenceOP t_pdb_seq( utility::pointer::make_shared< core::sequence::Sequence >( pose_for_seq.sequence(), "pose_seq" ));
-				core::sequence::SWAligner sw_align;
-				core::sequence::ScoringSchemeOP ss(  utility::pointer::make_shared< core::sequence::SimpleScoringScheme >(120, 0, -100, 0));
-				core::sequence::SequenceAlignment fasta2template;
-
-				fasta2template = sw_align.align(full_length_seq, t_pdb_seq, ss);
-
-				TR << fasta2template << std::endl;
-
-				core::id::SequenceMapping sequencemap = fasta2template.sequence_mapping(1,2);
-				sequencemap.reverse();
-				core::Size ndel = 0;
-				core::Size counter = 1;
-				core::Size nres = template_pose->size();
-				for ( core::Size i=1; i<=nres; i++ ) {
-					if ( ! template_pose->residue(counter).is_protein() ) {
-						// will get fixed later
-						counter++;
-						continue;
-					}
-
-					core::Size pdbnumber = template_pose->pdb_info()->number(counter);
-					core::Size fastanumber = sequencemap[i];
-					if ( fastanumber == 0 ) { // extra residues in template
-						template_pose->delete_residue_range_slow( counter,counter );
-						ndel++;
-						continue;
-					}
-					if ( pdbnumber != fastanumber ) {
-						template_pose->pdb_info()->number(counter,fastanumber);
-					}
-					counter++;
-				}
-				if ( ndel > 0 ) {
-					TR.Error << "WARNING! Realignment removed " << ndel << " residues!" << std::endl;
-				}
-			} else {
-				align_pdb_info = false;
-			}
-		}
-
-
-		core::Size HybridizeProtocol::pick_starting_template( ) {
-			using namespace basic::options;
-			using namespace basic::options::OptionKeys;
-
-			numeric::random::WeightedSampler weighted_sampler;
-			weighted_sampler.weights(template_weights_);
-			return weighted_sampler.random_sample(numeric::random::rg());
-		}
-
-		void HybridizeProtocol::domain_parse_templates(core::Size nres) {
-			if ( domains_all_templ_.size() == templates_.size() ) {
-				return;
-			}
-
-			DDomainParse ddom(pcut_,hcut_,length_);
-
-			domains_all_templ_.resize( templates_.size() );
-			for ( core::Size i_template=1; i_template<=templates_.size(); ++i_template ) {
-				if ( templates_[i_template]->size() < 3 ) {
-					continue;  // ???
-				}
-
-				domains_all_templ_[i_template] = ddom.split( *templates_[i_template] );
-
-				// convert domain numbering to target pose numbering
-				protocols::loops::Loops all_domains;
-				for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
-					for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
-						core::Size seqpos_start_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].start());
-
-						if ( seqpos_start_pose > nres ) continue; // sometimes dna can do this
-
-						domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
-
-						core::Size seqpos_stop_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].stop());
-						domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
-
-						all_domains.add_loop( seqpos_start_pose, seqpos_stop_pose );
-					}
-				}
-
-				// extend to cover full-length seq
-				// assumes no overlap in domain defs!
-				all_domains.sequential_order();
-				if ( all_domains.num_loop() == 0 ) continue;
-
-				std::map<core::Size,core::Size> remap_endpoints;
-				remap_endpoints [ all_domains[1].start() ] = 1;
-				remap_endpoints [ all_domains[all_domains.num_loop()].stop() ] = nres;
-				for ( core::Size iloops=2; iloops<=all_domains.size(); ++iloops ) {
-					core::Size start_i = (all_domains[iloops-1].stop() + all_domains[iloops].start() + 1)/2;
-					remap_endpoints [ all_domains[iloops-1].stop() ] = start_i-1;
-					remap_endpoints [ all_domains[iloops].start() ] = start_i;
-				}
-
-				for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
-					for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
-						core::Size seqpos_start_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].start() ];
-						domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
-
-						core::Size seqpos_stop_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].stop() ];
-						domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
-					}
-				}
-
-				TR << "Found " << domains_all_templ_[i_template].size() << " domains using template " << template_fns_[i_template] << std::endl;
-				for ( core::Size i=1; i<=domains_all_templ_[i_template].size(); ++i ) {
-					TR << "domain " << i << ": " << domains_all_templ_[i_template][i] << std::endl;
-				}
-			}
-		}
-
-		void
-			HybridizeProtocol::setup_templates_and_sampling_options( core::pose::Pose const & pose ) {
-				std::string const & pose_sequence(pose.sequence());
-				if ( coord_cst_res_.size() ) {
-					user_csts_ = core::pose::get_resnum_list_ordered( coord_cst_res_, pose );
-				}
-				for ( core::Size i=1; i<=template_fns_.size(); ++i ) {
-					bool align_pdb_info = should_align_pdb_infos_[i];
-					validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
-
-					if ( align_pdb_info ) {
-						align_pdb_info = false;
-						validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
-						update_template(i);
-					}
-				}
-
-				core::Size const nres_nonvirt = get_num_residues_nonvirt(pose);
-				if ( detailed_controls_settings_.size() ) {
-					residue_sample_template_.resize(nres_nonvirt, true);
-					residue_sample_abinitio_.resize(nres_nonvirt, true);
-				}
-				for ( auto const & detailed_control_settings : detailed_controls_settings_ ) {
-					if ( detailed_control_settings.type_ == "task_operations" ) {
-						core::pack::task::PackerTaskOP task = detailed_control_settings.taskFactOP_->create_task_and_apply_taskoperations( pose );
-						for ( core::Size ires = 1; ires <= nres_nonvirt; ++ires ) {
-							if ( !task->residue_task( ires ).being_packed() ) {
-								residue_sample_template_[ires] = false;
-								residue_sample_abinitio_[ires] = false;
-							}
-						}
-					} else {
-						core::Size const stop_res(detailed_control_settings.stop_res_ == 0 ? nres_nonvirt : detailed_control_settings.stop_res_);
-						if ( detailed_control_settings.sample_template_ != sampleEnum::unset ) {
-							for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
-								residue_sample_template_[ires] = (detailed_control_settings.sample_template_ == sampleEnum::off ? false : true);
-							}
-						}
-						if ( detailed_control_settings.sample_abinitio_ != sampleEnum::unset ) {
-							for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
-								residue_sample_abinitio_[ires] = (detailed_control_settings.sample_abinitio_ == sampleEnum::off ? false : true);
-							}
-						}
-					}
-				}
-			}
-
-		void HybridizeProtocol::apply( core::pose::Pose & pose )
-		{
-			using namespace protocols::moves;
-			using namespace basic::options;
-			using namespace basic::options::OptionKeys;
-			using namespace core::pose::datacache;
-			using namespace core::io::silent;
-			using namespace ObjexxFCL::format;
-
-			if ( native_ == nullptr ) {
-				if ( native_needs_load_ ) {
-					native_ = utility::pointer::make_shared< core::pose::Pose >();
-					if ( option[in::file::fullatom]() ) {
-						core::import_pose::pose_from_file( *native_, option[ in::file::native ]() , core::import_pose::PDB_file);
-					} else {
-						core::chemical::ResidueTypeSetCOP residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
-						core::import_pose::pose_from_file( *native_, *residue_set, option[ in::file::native ]()  , core::import_pose::PDB_file);
-					}
-					native_needs_load_ = false;
-				} else if ( native_needs_load_from_align_rmsd_target_ ) {
-					native_ = utility::pointer::make_shared< core::pose::Pose >();
-					utility::vector1< std::string > const & align_rmsd_target( option[ evaluation::align_rmsd_target ]() );
-					core::import_pose::pose_from_file( *native_, align_rmsd_target[1] , core::import_pose::PDB_file); // just use the first one for now
-					native_needs_load_from_align_rmsd_target_ = false;
-				}
-			}
-
-			setup_templates_and_sampling_options(pose);
-
-			// number of residues in asu without VRTs
-			core::Size nres_tgt = pose.size();
-			core::Size nres_protein_tgt = pose.size();
-			core::conformation::symmetry::SymmetryInfoCOP symm_info;
-			if ( core::pose::symmetry::is_symmetric(pose) ) {
-				auto & SymmConf (
-						dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-				symm_info = SymmConf.Symmetry_Info();
-				nres_tgt = symm_info->num_independent_residues();
-				nres_protein_tgt = symm_info->num_independent_residues();
-			}
-			if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-			while ( !pose.residue(nres_protein_tgt).is_protein() ) nres_protein_tgt--;
-
-			//save necessary constraint in pose
-			core::scoring::constraints::ConstraintSetOP save_pose_constraint_set( utility::pointer::make_shared< core::scoring::constraints::ConstraintSet >() ) ;
-			if ( keep_pose_constraint_ ) {
-				save_pose_constraint_set = pose.constraint_set()->clone();
-				core::scoring::constraints::remove_nonbb_constraints(pose);
-			}
-
-			if ( pose.is_fullatom() ) {
-				protocols::moves::MoverOP tocen( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::CENTROID ) );
-				tocen->apply(pose);
-			}
-
-			// make fragments if we don't have them at this point
-			check_and_create_fragments( pose );
-
-			// domain parse templates if we do not have domain definitions
-			domain_parse_templates(nres_tgt);
-
-			// select random fragment sets if >2 are provided
-			core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
-			core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
-			TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
-			TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
-
-			// starting structure pool (for batch relax)
-			std::vector < SilentStructOP > post_centroid_structs;
-			bool need_more_samples = true;
-
-			// main centroid generation loop
-			core::Real gdtmm = 0.0;
-			if ( stage2_scorefxn_ == nullptr ) {
-				utility_exit_with_message("Stage 2 Scorefxn must be set!!!");
-			}
-
-			while ( need_more_samples ) {
-				need_more_samples = false;
-
-				// pick starting template
-				core::Size initial_template_index = pick_starting_template();
-				TR << "Using initial template: " << I(4,initial_template_index) << " " << template_fns_[initial_template_index] << std::endl;
-
-				// ensure
-				//    1)that no CONTIGS cross multiple CHAINS
-				//    2)that every input CHAIN has a chunk in it
-				// if not, add the corresponding contig as a chunk
-				utility::vector1< int > cuts = pose.fold_tree().cutpoints();
-				protocols::loops::Loops const &contigs_old = template_contigs_[initial_template_index];
-				protocols::loops::Loops contigs_new;
-				for ( core::Size j=1; j<=contigs_old.num_loop(); ++j ) {
-					protocols::loops::Loop contig_j = contigs_old[j];
-
-					for ( core::Size i=1; i<=cuts.size(); ++i ) {
-						int nextcut = cuts[i];
-						if ( nextcut > (int)nres_protein_tgt ) break;
-
-						core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
-						core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
-
-						if ( (int)start <= nextcut && (int)stop > nextcut ) {
-							// find template res corresponding to cut
-							for ( core::Size k=contig_j.start(); k<=contig_j.stop(); ++k ) {
-								if ( templates_[initial_template_index]->pdb_info()->number(k) == nextcut ) {
-									// ensure contig >= 3 res
-									if ( k > contig_j.start()+1 ) {
-										contigs_new.push_back( protocols::loops::Loop(contig_j.start(), k) );
-									}
-									TR << "Split contig ("<<contig_j.start()<<","<<contig_j.stop()<< ") at " << k << " [pdbnum: "<<start<<"/"<<stop<<"/" << nextcut << "]" << std::endl;
-									contig_j.set_start( k+1 );
-								}
-							}
-
-						}
-					}
-					// ensure contig >= 3 res
-					if ( contig_j.stop() > contig_j.start()+1 ) {
-						contigs_new.push_back( contig_j );
-					}
-				}
-				template_contigs_[initial_template_index] = contigs_new;
-
-				protocols::loops::Loops &chunks = template_chunks_[initial_template_index];
-				for ( core::Size i=0; i<=cuts.size(); ++i ) {
-					int prevcut = (i==0) ? 1 : cuts[i];
-					int nextcut = (i==cuts.size()) ? nres_protein_tgt : cuts[i+1];
-					if ( nextcut > (int)nres_protein_tgt ) break;
-					bool haschunk = false;
-					for ( core::Size j=1; j<=chunks.num_loop() && !haschunk; ++j ) {
-						protocols::loops::Loop const &chunk_j = chunks[j];
-						core::Size start = templates_[initial_template_index]->pdb_info()->number(chunk_j.start());
-						core::Size stop  = templates_[initial_template_index]->pdb_info()->number(chunk_j.stop());
-						if ( (int)start > prevcut && (int)stop <= nextcut ) haschunk=true;
-					}
-
-					if ( ! haschunk ) {
-						TR << "Segment ("<<prevcut<<","<<nextcut<<") has no chunks!  Adding contigs!" << std::endl;
-						bool hascontig=false;
-						for ( core::Size j=1; j<=contigs_new.num_loop(); ++j ) {
-							protocols::loops::Loop const &contig_j = contigs_new[j];
-							core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
-							core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
-							if ( (int)start > prevcut && (int)stop <= nextcut ) {
-								hascontig = true;
-								chunks.push_back( contig_j );
-							}
-						}
-						if ( !hascontig ) {
-							TR << "Warning!  No contigs found for segment!" << std::endl;
-							TR << "If you are not using the 'randomize=X' option there is likely something wrong with your input and models will not be reasonable!" << std::endl;
-						}
-					}
-				}
-
-				// (0) randomize chains
-				if ( randomize_chains_[initial_template_index].size() > 0 ) {
-					runtime_assert ( templates_[initial_template_index]->pdb_info() );
-					numeric::xyzVector< core::Real > comFixed(0,0,0), comMoving(0,0,0);
-					core::Real nFixed=0, nMoving=0;
-
-					TR << "Randomize >" << randomize_chains_[initial_template_index].size() << "<" << std::endl;
-					for ( core::Size q=1; q<=randomize_chains_[initial_template_index].size(); ++q ) {
-						TR << "Randomize >" << randomize_chains_[initial_template_index][q] << "<" << std::endl;
-					}
-
-					for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
-						char chain = templates_[initial_template_index]->pdb_info()->chain(i);
-						if ( std::find(
-									randomize_chains_[initial_template_index].begin(),
-									randomize_chains_[initial_template_index].end(),
-									chain) != randomize_chains_[initial_template_index].end()
-							 ) {
-							comMoving += templates_[initial_template_index]->residue(i).xyz(2);
-							nMoving++;
-						} else {
-							comFixed += templates_[initial_template_index]->residue(i).xyz(2);
-							nFixed++;
-						}
-					}
-
-					// sanity check
-					if ( nMoving == 0 ) {
-						utility_exit_with_message("Randomize chain enabled but chain(s) not found!");
-					}
-
-					comMoving /= nMoving;
-					comFixed /= nFixed;
-
-					// randomize orientation
-					numeric::xyzMatrix< core::Real > R = protocols::geometry::random_reorientation_matrix( 360, 360 );
-
-					// randomize offset
-					numeric::xyzVector< core::Real > T = numeric::random::random_point_on_unit_sphere< core::Real >( numeric::random::rg() );
-
-					// perturb & slide into contact
-					bool done=false, compacting=false;
-					core::Real DIST = 100.0;
-					core::scoring::ScoreFunction sf_vdw;
-					core::Real vdw_score = -1.0, step_size = -2.0, min_step_size = 0.25;
-					sf_vdw.set_weight( core::scoring::vdw, 1.0 );
-					core::pose::Pose template_orig = *(templates_[initial_template_index]);
-					while ( !done && DIST > 0 ) {
-						utility::vector1< id::AtomID > atm_ids;
-						utility::vector1< numeric::xyzVector< core::Real> > atm_xyzs;
-
-						for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
-							core::conformation::Residue const & rsd_i = template_orig.residue(i);
-							char chain = templates_[initial_template_index]->pdb_info()->chain(i);
-							if ( std::find(
-										randomize_chains_[initial_template_index].begin(),
-										randomize_chains_[initial_template_index].end(),
-										chain) != randomize_chains_[initial_template_index].end()
-								 ) {
-								for ( core::Size j = 1; j <= rsd_i.natoms(); ++j ) {
-									id::AtomID id( j,i );
-									atm_ids.push_back( id );
-									numeric::xyzVector< core::Real > new_ij = R*(rsd_i.xyz(j) - comMoving) + comFixed + DIST * T;
-									atm_xyzs.push_back( new_ij );
-								}
-							}
-						}
-						templates_[initial_template_index]->batch_set_xyz( atm_ids, atm_xyzs );
-						core::Real score_d = sf_vdw( *(templates_[initial_template_index]) );
-						if ( vdw_score < 0 ) vdw_score = score_d;
-
-						if ( !compacting && score_d > vdw_score + 2.0 ) {
-							compacting = true;
-							step_size = min_step_size;
-						} else if ( compacting  && vdw_score <= score_d + 2.0 ) {
-							done = true;
-						}
-
-						TR << "D=" << DIST << " score=" << score_d << std::endl;
-
-						DIST += step_size;
-					}
-				}
-
-				// (1) steal hetatms from template
-				utility::vector1< std::pair< core::Size,core::Size > > hetatms;
 				if ( add_hetatm_ ) {
-					for ( core::Size ires=1; ires <= templates_[initial_template_index]->size(); ++ires ) {
-						if ( templates_[initial_template_index]->pdb_info()->number(ires) > (int)nres_tgt ) {
-							TR.Debug << "Insert hetero residue: " << templates_[initial_template_index]->residue(ires).name3() << std::endl;
-							if(templates_[initial_template_index]->residue(ires).is_carbohydrate()){
-								if (!templates_[initial_template_index]->residue(ires).is_lower_terminus()){
-									core::Size offset = pose.size() + 1 - ires;
-									core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( templates_[initial_template_index]->residue(ires) ) );
-									int self_lower=0;
-									int parent_upper=0;
-									//self_lower = templates_[initial_template_index]->residue(ires).lower_connect_id();
-									//parent_upper = templates_[initial_template_index]->residue(parent_res_seqpos).connect_atom( templates_[initial_template_index]->residue(ires) );
-									for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
-										TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
-										if (templates_[initial_template_index]->residue(ires).connect_map( i ).resid() == parent_res_seqpos){
-											//self_lower = templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
-											self_lower = i;
-											parent_upper=templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
-											//parent_upper=templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i);
-										}
-									}
-									parent_res_seqpos += offset;
-									TR.Debug <<"  appending by bond "<<pose.size()+1<<" lower "<<self_lower<<" anchor "<<parent_res_seqpos<<" parent upper "<<parent_upper<<std::endl;
-									pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires), false, self_lower, parent_res_seqpos, parent_upper, false, false);
-								} else {
-									TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
-									for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
-										TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
-									}
-									pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
-
-								}
-							}
-							else if ( templates_[initial_template_index]->residue(ires).is_polymer()
-									&& !templates_[initial_template_index]->residue(ires).is_lower_terminus()
-									&& !pose.residue(pose.size()).is_upper_terminus() ) {
-								TR.Debug <<"  appending by bond "<<ires<<std::endl;
-								pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires));
-								for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
-									TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
-								}
-							} else {
-								TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
-								pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
-								for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
-									TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
-								}
-							}
-							hetatms.push_back( std::make_pair( ires, pose.size() ) );
-						}
-					}
-					pose.conformation().chains_from_termini();
+					add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
 				}
-
-				// (2) realign structures per-domain
-				if ( realign_domains_ ) {
-					//
-					if ( std::find( non_null_template_indices_.begin(), non_null_template_indices_.end(), initial_template_index )
-							!= non_null_template_indices_.end() ) {
-						align_templates_by_domain(templates_[initial_template_index], domains_all_templ_[initial_template_index]);
-					} else {
-						if ( non_null_template_indices_.size() == 0 ) {
-							TR << "No non-extended templates.  Skipping alignment." << std::endl;
-						} else {
-							TR << "Cannot align to extended template! Choosing a random template instead." << std::endl;
-							core::Size aln_target = numeric::random::random_range(1, non_null_template_indices_.size() );
-							align_templates_by_domain(templates_[aln_target], domains_all_templ_[aln_target]);
-						}
-					}
-				}
-
-				// (3) apply symmetry
-				std::string symmdef_file = symmdef_files_[initial_template_index];
-				if ( !symmdef_file.empty() && symmdef_file != "NULL" ) {
-					protocols::symmetry::SetupForSymmetryMover makeSymm( symmdef_file );
-					makeSymm.apply(pose);
-
-					//fpd   to get the right rotamer set we need to do this
-					basic::options::option[basic::options::OptionKeys::symmetry::symmetry_definition].value( "dummy" );
-
-					// xyz copy hetatms (properly handle cases where scoring subunit is not the first)
-					if ( add_hetatm_ ) {
-						for ( core::Size ihet=1; ihet <= hetatms.size(); ++ihet ) {
-							core::conformation::Residue const &res_in = templates_[initial_template_index]->residue(hetatms[ihet].first);
-							for ( core::Size iatm=1; iatm<=res_in.natoms(); ++iatm ) {
-								core::id::AtomID tgt(iatm,hetatms[ihet].second);
-								pose.set_xyz( tgt, res_in.xyz( iatm ) );
-							}
-						}
-					}
-				}
-
-				// (4) add a virtual if we have a map or coord csts
-				//     keep after symm
-				//     should we check if a map is loaded (or density scoring is on) instead??
-				if ( option[ OptionKeys::edensity::mapfile ].user() || user_csts_.size() > 0 ) {
-					MoverOP dens( utility::pointer::make_shared< protocols::electron_density::SetupForDensityScoringMover >() );
-					dens->apply( pose );
-				}
-
-				// (5) initialize template history
-				//     keep after symm
-				TemplateHistoryOP history( utility::pointer::make_shared< TemplateHistory >(pose) );
-				history->setall( initial_template_index );
-				pose.data().set( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY, history );
-
-				// (6) allowed movement
-				utility::vector1<bool> allowed_to_move;
-				allowed_to_move.resize(pose.size(),true);
-				for ( int i=1; i<=(int)residue_sample_template_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_template_[i];
-				for ( int i=1; i<=(int)residue_sample_abinitio_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_abinitio_[i];
-
-				// STAGE 1
-				//fpd constraints are handled a little bit weird
-				//  * foldtree hybridize sets chainbreak variants then applies constraints (so c-beta csts are treated properly)
-				//  * after chainbreak variants are removed, csts are removed and reapplied in this function
-				//  * finally after switch to fullatom CSTs are reapplied again (optionally using a different CST file)
-				// If "AUTO" is specified for cen_csts automatic centroid csts are generated
-				// If "AUTO" is specified for fa_csts automatic fa csts are generated
-				// If "NONE" is specified for fa_csts, cen csts are used (AUTO or otherwise)
-				// An empty string is treated as equivalent to "NONE"
-
-				// fold tree hybridize
-				if ( numeric::random::rg().uniform() < stage1_probability_ ) {
-
-					for ( core::Size repeatstage1=0; repeatstage1 < jump_move_repeat_; ++repeatstage1 ) {
-
-						std::string cst_fn = template_cst_fn_[initial_template_index];
-
-						FoldTreeHybridizeOP ft_hybridize(
-								utility::pointer::make_shared< FoldTreeHybridize >(
-									initial_template_index, templates_aln_, template_weights_,
-									template_chunks_, frags_small, frags_big) ) ;
-
-						ft_hybridize->set_constraint_file( cst_fn );
-						ft_hybridize->set_constraint( cen_cst_in_ );
-						ft_hybridize->set_scorefunction( stage1_scorefxn_ );
-
-						// options
-						ft_hybridize->set_increase_cycles( stage1_increase_cycles_ );
-						ft_hybridize->set_stage1_1_cycles( stage1_1_cycles_ );
-						ft_hybridize->set_stage1_2_cycles( stage1_2_cycles_ );
-						ft_hybridize->set_stage1_3_cycles( stage1_3_cycles_ );
-						ft_hybridize->set_stage1_4_cycles( stage1_4_cycles_ );
-						ft_hybridize->set_add_non_init_chunks( add_non_init_chunks_ );
-						ft_hybridize->set_add_hetatm( add_hetatm_, hetatm_self_cst_weight_, hetatm_prot_cst_weight_ );
-						ft_hybridize->set_frag_1mer_insertion_weight( frag_1mer_insertion_weight_ );
-						ft_hybridize->set_small_frag_insertion_weight( small_frag_insertion_weight_ );
-						ft_hybridize->set_big_frag_insertion_weight( big_frag_insertion_weight_ );
-						ft_hybridize->set_chunk_insertion_weight( chunk_insertion_weight_ );
-						ft_hybridize->set_frag_weight_aligned( frag_weight_aligned_ );
-						ft_hybridize->set_auto_frag_insertion_weight( auto_frag_insertion_weight_ );
-						ft_hybridize->set_max_registry_shift( max_registry_shift_ );
-
-						// strand pairings
-						ft_hybridize->set_pairings_file( pairings_file_ );
-						ft_hybridize->set_sheets( sheets_ );
-						ft_hybridize->set_random_sheets( random_sheets_ );
-						ft_hybridize->set_filter_templates( filter_templates_ );
-
-						// allowed movement
-						ft_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
-						ft_hybridize->set_minimize_at_end( min_after_stage1_ );
-						ft_hybridize->set_minimize_sf( stage2_scorefxn_ );
-
-						// max insertion
-						ft_hybridize->set_max_insertion( max_contig_insertion_ );
-
-						// other cst stuff
-						ft_hybridize->set_user_csts( user_csts_ );
-
-						// finally run stage 1
-						ft_hybridize->apply(pose);
-
-						// get strand pairings if they exist for constraints in later stages
-						strand_pairs_ = ft_hybridize->get_strand_pairs();
-
-						//jump perturbation and minimization
-						//fpd!  these docking moves should be incorporated as part of stage 1!
-						if ( jump_move_ ) {
-							do_intrastage_docking( pose );
-						}
-					} //end of repeatstage1
-
-				} else {
-					// just do frag insertion in unaligned regions
-					core::pose::PoseOP chosen_templ = templates_aln_[initial_template_index];
-					protocols::loops::Loops chosen_contigs = template_contigs_[initial_template_index];
-					initialize_and_sample_loops(pose, chosen_templ, chosen_contigs, stage1_scorefxn_);
-				}
-
-				// realign domains to the output of stage 1
-				if ( jump_move_ || realign_domains_stage2_ ) {
-					TR << "Realigning template domains to stage1 pose." << std::endl;
-					core::pose::PoseOP stage1pose( utility::pointer::make_shared< core::pose::Pose >( pose ) );
-					align_templates_by_domain(stage1pose); // don't use stored domains; recompute parse from model
-				}
-
-				//write gdtmm to output
-				if ( native_ && native_->size() ) {
-					gdtmm = get_gdtmm(*native_, pose, aln_);
-					core::pose::setPoseExtraScore( pose, "GDTMM_after_stage1", gdtmm);
-					TR << "GDTMM_after_stage1" << F(8,3,gdtmm) << std::endl;
-				}
-
-				// STAGE 2
-				// apply constraints
-				if ( stage2_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
-					std::string cst_fn = template_cst_fn_[initial_template_index];
-					if ( !keep_pose_constraint_ ) {
-						if ( ! cen_cst_in_.empty() ) {
-							setup_constraints(pose, cen_cst_in_);
-						} else {
-							setup_centroid_constraints( pose, templates_aln_, template_weights_, cst_fn );
-						}
-					}
-					if ( add_hetatm_ ) {
-						add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
-					}
-					if ( strand_pairs_.size() ) {
-						add_strand_pairs_cst(pose, strand_pairs_);
-					}
-				}
-
-				// add torsion constraints derived from fragments
-				if ( csts_from_frags_ ) {
-					if ( stage2_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
-						add_fragment_csts( pose );
-					} else {
-						TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
-					}
-				}
-
-				if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
-					if ( user_csts_.size() > 0 ) {
-						setup_user_coordinate_constraints(pose,user_csts_);
-					}
-				}
-
-				if ( !option[cm::hybridize::skip_stage2]() ) {
-					core::scoring::ScoreFunctionOP stage2_scorefxn_clone = stage2_scorefxn_->clone();
-
-					core::scoring::methods::EnergyMethodOptions lowres_options(stage2_scorefxn_clone->energy_method_options());
-					lowres_options.set_cartesian_bonded_linear(true);
-					stage2_scorefxn_clone->set_energy_method_options(lowres_options);
-
-					CartesianHybridizeOP cart_hybridize(
-							utility::pointer::make_shared< CartesianHybridize >( templates_aln_, template_weights_, template_chunks_,template_contigs_, frags_big ) );
-
-					// default scorefunctions (cenrot-compatable)
-					if ( stage2_scorefxn_!=nullptr ) cart_hybridize->set_scorefunction( stage2_scorefxn_ );
-					if ( stage2pack_scorefxn_!=nullptr ) cart_hybridize->set_pack_scorefunction( stage2pack_scorefxn_ );
-					if ( stage2min_scorefxn_!=nullptr ) cart_hybridize->set_min_scorefunction( stage2min_scorefxn_ );
-
-					// set options
-					cart_hybridize->set_increase_cycles( stage2_increase_cycles_ );
-					cart_hybridize->set_no_global_frame( no_global_frame_ );
-					cart_hybridize->set_linmin_only( linmin_only_ );
-					cart_hybridize->set_seqfrags_only( seqfrags_only_ );
-					cart_hybridize->set_cartfrag_overlap( cartfrag_overlap_ );
-					cart_hybridize->set_skip_long_min( skip_long_min_ );
-					cart_hybridize->set_cenrot( cenrot_ );
-					cart_hybridize->set_fragment_probs(fragprob_stage2_, randfragprob_stage2_);
-
-					// max insertion
-					cart_hybridize->set_max_insertion( max_contig_insertion_ );
-
-					// per-residue controls
-					cart_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
-
-					// finally run stage 2
-					cart_hybridize->apply(pose);
-				}
-
-				//write gdtmm to output
-				if ( native_ && native_->size() ) {
-					gdtmm = get_gdtmm(*native_, pose, aln_);
-					core::pose::setPoseExtraScore( pose, "GDTMM_after_stage2", gdtmm);
-					TR << "GDTMM_after_stage2" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
-				}
-				// get fragment history
-				runtime_assert( pose.data().has( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
-				history = utility::pointer::static_pointer_cast< TemplateHistory >( pose.data().get_ptr( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
-
-				TR << "History :";
-				for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4,i); }
-				TR << std::endl;
-				TR << "History :";
-				for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4, history->get(i)); }
-				TR << std::endl;
-
-				core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-				mm->set_bb  ( true );
-				mm->set_chi ( true );
-				mm->set_jump( true );
-
-				//fpd -- in positions where no fragment insertions are allowed, also allow no minimization
-				if ( residue_sample_template_.size() > 0 && residue_sample_abinitio_.size() > 0 ) {
-					for ( int i=1; i<=(int)nres_tgt; ++i ) {
-						if ( !residue_sample_template_[i] && !residue_sample_abinitio_[i] ) {
-							TR.Trace << "locking residue " << i << std::endl;
-							mm->set_bb  ( i, false );
-							mm->set_chi ( i, false );
-						}
-					}
-				}
-
-				if ( core::pose::symmetry::is_symmetric(pose) ) {
-					core::pose::symmetry::make_symmetric_movemap( pose, *mm );
-				}
-
-				// stage "2.5" .. minimize with centroid energy + full-strength cart bonded
-				if ( !option[cm::hybridize::skip_stage2]() ) {
-					core::optimization::MinimizerOptions options_lbfgs( "lbfgs_armijo_nonmonotone", 0.01, true, false, false );
-					core::optimization::CartesianMinimizer minimizer;
-					auto n_min_cycles =(core::Size) (200.*stage25_increase_cycles_);
-					options_lbfgs.max_iter(n_min_cycles);
-					(*stage2_scorefxn_)(pose); minimizer.run( pose, *mm, *stage2_scorefxn_, options_lbfgs );
-				}
-
-				// STAGE 3: RELAX
-				if ( batch_relax_ > 0 ) {
-					// set disulfides before going to FA
-					if ( disulf_file_.length() > 0 ) {
-						// delete current disulfides
-						for ( int i=1; i<=(int)pose.size(); ++i ) {
-							if ( !pose.residue(i).is_protein() ) continue;
-							if ( pose.residue(i).type().is_disulfide_bonded() ) {
-								core::conformation::change_cys_state( i, "CYS", pose.conformation() );
-							}
-						}
-
-						// manually add new ones
-						TR << " add disulfide: " << std::endl;
-						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].value(disulf_file_);
-						core::pose::initialize_disulfide_bonds(pose);
-						// must reset this since initialize_disulfide_bonds is used in pose io
-						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].deactivate();
-						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].to_default(); // reset to the default value
-					} else {
-						pose.conformation().detect_disulfides();
-					}
-
-					protocols::moves::MoverOP tofa( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::FA_STANDARD ) );
-					tofa->apply(pose);
-
-					// apply fa constraints
-					std::string cst_fn = template_cst_fn_[initial_template_index];
-					if ( fa_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
-						if ( !keep_pose_constraint_ ) {
-							if ( ! fa_cst_in_.empty() ) {
-								setup_constraints(pose, fa_cst_in_);
-							} else {
-								setup_fullatom_constraints( pose, templates_aln_, template_weights_, cst_fn, fa_cst_fn_ );
-							}
-						} else {
-							pose.constraint_set(save_pose_constraint_set);
-						}
-						if ( add_hetatm_ ) {
-							add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
-						}
-						if ( strand_pairs_.size() ) {
-							add_strand_pairs_cst(pose, strand_pairs_);
-						}
-					}
-
-					// add torsion constraints derived from fragments
-					if ( csts_from_frags_ ) {
-						if ( fa_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
-							add_fragment_csts( pose );
-						} else {
-							TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
-						}
-					}
-
-					if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
-						// note that CSTs are updated based on stage 1 movement
-						//   this may or may not be desirable
-						if ( user_csts_.size() > 0 ) {
-							setup_user_coordinate_constraints(pose,user_csts_);
-						}
-					}
-
-					if ( batch_relax_ == 1 ) {
-						// standard relax
-						// do relax _without_ ramping down coordinate constraints
-						TR << " batch_relax 1 : " << std::endl;
-						protocols::relax::FastRelax relax_prot( fa_scorefxn_, relax_repeats_ ,"NO CST RAMPING" );
-						relax_prot.min_type("lbfgs_armijo_nonmonotone");
-						relax_prot.apply(pose);
-					} else {
-						// batch relax
-						// add stucture to queue
-						SilentFileOptions opts;
-						SilentStructOP new_struct = SilentStructFactory::get_instance()->get_silent_struct("binary",opts);
-						new_struct->fill_struct( pose );
-						new_struct->energies_from_pose( pose );
-						post_centroid_structs.push_back( new_struct );
-
-						if ( post_centroid_structs.size() == batch_relax_ ) {
-							protocols::relax::FastRelax relax_prot( fa_scorefxn_ );
-							relax_prot.min_type("lbfgs_armijo_nonmonotone");
-							relax_prot.set_force_nonideal(true);
-							relax_prot.set_script_to_batchrelax_default( relax_repeats_ );
-
-							// need to use a packer task factory to handle poses with different disulfide patterning
-							core::pack::task::TaskFactoryOP tf( utility::pointer::make_shared< core::pack::task::TaskFactory >() );
-							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::InitializeFromCommandline >() );
-							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::IncludeCurrent >() );
-							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::RestrictToRepacking >() );
-							relax_prot.set_task_factory( tf );
-
-							// notice! this assumes all poses in a set have the same constraints!
-							relax_prot.batch_apply(post_centroid_structs, pose.constraint_set()->clone());
-
-							// reinflate pose
-							post_centroid_structs[0]->fill_pose( pose );
-						} else {
-							protocols::moves::MoverOP tocen( new protocols::simple_moves::SwitchResidueTypeSetMover( core::chemical::CENTROID ) );
-							tocen->apply(pose);
-							need_more_samples = true;
-						}
-					}
-				} else {
-					// no fullatom sampling
-					(*stage2_scorefxn_)(pose);
+				if ( strand_pairs_.size() ) {
+					add_strand_pairs_cst(pose, strand_pairs_);
 				}
 			}
-			if ( native_ && native_->size() ) {
-				gdtmm = get_gdtmm(*native_, pose, aln_);
-				core::pose::setPoseExtraScore( pose, "GDTMM_final", gdtmm);
-				TR << "GDTMM_final" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
+
+			// add torsion constraints derived from fragments
+			if ( csts_from_frags_ ) {
+				if ( fa_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
+					add_fragment_csts( pose );
+				} else {
+					TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
+				}
+			}
+
+			if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
+				// note that CSTs are updated based on stage 1 movement
+				//   this may or may not be desirable
+				if ( user_csts_.size() > 0 ) {
+					setup_user_coordinate_constraints(pose,user_csts_);
+				}
+			}
+
+			if ( batch_relax_ == 1 ) {
+				// standard relax
+				// do relax _without_ ramping down coordinate constraints
+				TR << " batch_relax 1 : " << std::endl;
+				protocols::relax::FastRelax relax_prot( fa_scorefxn_, relax_repeats_ ,"NO CST RAMPING" );
+				relax_prot.min_type("lbfgs_armijo_nonmonotone");
+				relax_prot.apply(pose);
+			} else {
+				// batch relax
+				// add stucture to queue
+				SilentFileOptions opts;
+				SilentStructOP new_struct = SilentStructFactory::get_instance()->get_silent_struct("binary",opts);
+				new_struct->fill_struct( pose );
+				new_struct->energies_from_pose( pose );
+				post_centroid_structs.push_back( new_struct );
+
+				if ( post_centroid_structs.size() == batch_relax_ ) {
+					protocols::relax::FastRelax relax_prot( fa_scorefxn_ );
+					relax_prot.min_type("lbfgs_armijo_nonmonotone");
+					relax_prot.set_force_nonideal(true);
+					relax_prot.set_script_to_batchrelax_default( relax_repeats_ );
+
+					// need to use a packer task factory to handle poses with different disulfide patterning
+					core::pack::task::TaskFactoryOP tf( utility::pointer::make_shared< core::pack::task::TaskFactory >() );
+					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::InitializeFromCommandline >() );
+					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::IncludeCurrent >() );
+					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::RestrictToRepacking >() );
+					relax_prot.set_task_factory( tf );
+
+					// notice! this assumes all poses in a set have the same constraints!
+					relax_prot.batch_apply(post_centroid_structs, pose.constraint_set()->clone());
+
+					// reinflate pose
+					post_centroid_structs[0]->fill_pose( pose );
+				} else {
+					protocols::moves::MoverOP tocen( new protocols::simple_moves::SwitchResidueTypeSetMover( core::chemical::CENTROID ) );
+					tocen->apply(pose);
+					need_more_samples = true;
+				}
+			}
+		} else {
+			// no fullatom sampling
+			(*stage2_scorefxn_)(pose);
+		}
+	}
+	if ( native_ && native_->size() ) {
+		gdtmm = get_gdtmm(*native_, pose, aln_);
+		core::pose::setPoseExtraScore( pose, "GDTMM_final", gdtmm);
+		TR << "GDTMM_final" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
+	}
+}
+
+
+void
+HybridizeProtocol::align_templates_by_domain(core::pose::PoseOP & ref_pose, utility::vector1 <Loops> domains)
+{
+	// get domain parse if not specified
+	core::pose::PoseOP working_pose;
+	if ( core::pose::symmetry::is_symmetric(*ref_pose) ) {
+		working_pose = utility::pointer::make_shared< core::pose::Pose >();
+		core::pose::symmetry::extract_asymmetric_unit(*ref_pose, *working_pose);
+	} else {
+		working_pose = ref_pose;
+	}
+
+	if ( domains.size() == 0 ) {
+		DDomainParse ddom(pcut_,hcut_,length_);
+		utility::vector1 <Loops> domains = ddom.split( *working_pose );
+	}
+
+	// clone original poses -> copies for alignment
+	templates_aln_.clear();
+	for ( core::Size i_pose=1; i_pose <= templates_.size(); ++i_pose ) {
+		templates_aln_.push_back(
+			utility::pointer::make_shared< core::pose::Pose >( *templates_[i_pose] ) );
+	}
+
+	for ( core::Size i_pose=1; i_pose <= templates_aln_.size(); ++i_pose ) {
+		if ( templates_aln_[i_pose] == ref_pose ) continue; // compare pointers
+		align_by_domain(*templates_aln_[i_pose], *working_pose, domains);
+		//std::string out_fn = template_fns_[i_pose] + "_realigned.pdb";
+		//poses[i_pose]->dump_pdb(out_fn);
+	}
+}
+
+
+void
+HybridizeProtocol::align_by_domain(core::pose::Pose & pose, core::pose::Pose const & ref_pose, utility::vector1 <Loops> domains) {
+	// ASSUME:
+	//    domains cover the full pose (no gaps)
+	utility::vector1< core::Real > aln_cutoffs;
+	aln_cutoffs.push_back(6);
+	aln_cutoffs.push_back(4);
+	aln_cutoffs.push_back(3);
+	aln_cutoffs.push_back(2);
+	aln_cutoffs.push_back(1.5);
+	aln_cutoffs.push_back(1);
+	core::Real min_coverage = 0.2;
+
+	// find corresepondance of ligands to nearest residues (in moving pose)
+	core::Size last_protein_residue=pose.size();
+	while ( last_protein_residue>0 && !pose.residue_type(last_protein_residue).is_protein() ) last_protein_residue--;
+
+	if ( last_protein_residue == 0 ) return;
+
+	std::map< core::Size, core::Size > ligres_map;
+	for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
+		core::Real mindist = 999.0;
+		core::Size minj = 1;
+		for ( core::Size j=1; j<=last_protein_residue; ++j ) {
+			core::Real dist_ij = (pose.residue(i).xyz(1) - pose.residue(j).xyz(1)).length(); // hacky (using atom 1 only)
+			if ( dist_ij < mindist ) {
+				mindist = dist_ij;
+				minj = (pose.pdb_info()) ? pose.pdb_info()->number(j) : j;
+			}
+		}
+		ligres_map[i] = minj;
+	}
+
+
+	for ( core::Size i_domain = 1; i_domain <= domains.size() ; ++i_domain ) {
+		core::id::AtomID_Map< core::id::AtomID > atom_map;
+		core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
+
+		// find all residues in moving pose corresponding to this domain
+		std::list <core::Size> residue_list;
+		core::Size n_mapped_residues=0;
+		for ( core::Size ires=1; ires<=pose.size(); ++ires ) {
+			if ( !pose.residue_type(ires).is_protein() ) continue;
+			int pose_res = (pose.pdb_info()) ? pose.pdb_info()->number(ires) : ires;
+			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+				if ( pose_res < (int)domains[i_domain][iloop].start() || pose_res > (int)domains[i_domain][iloop].stop() ) continue;
+				residue_list.push_back(ires);
 			}
 		}
 
+		// find all residues in reference pose corresponding to this domain
+		std::list <core::Size> ref_residue_list;
+		for ( core::Size jres=1; jres<=ref_pose.size(); ++jres ) {
+			if ( !ref_pose.residue_type(jres).is_protein() ) continue;
+			int ref_pose_res = (ref_pose.pdb_info()) ? ref_pose.pdb_info()->number(jres) : jres;
+			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+				if ( ref_pose_res < (int)domains[i_domain][iloop].start() || ref_pose_res > (int)domains[i_domain][iloop].stop() ) continue;
+				ref_residue_list.push_back(jres);
+			}
+		}
 
-		void
-			HybridizeProtocol::align_templates_by_domain(core::pose::PoseOP & ref_pose, utility::vector1 <Loops> domains)
-			{
-				// get domain parse if not specified
-				core::pose::PoseOP working_pose;
-				if ( core::pose::symmetry::is_symmetric(*ref_pose) ) {
-					working_pose = utility::pointer::make_shared< core::pose::Pose >();
-					core::pose::symmetry::extract_asymmetric_unit(*ref_pose, *working_pose);
-				} else {
-					working_pose = ref_pose;
-				}
+		// get tmalign sequence mapping
+		TMalign tm_align;
+		std::string seq_pose, seq_ref, aligned;
+		int reval = tm_align.apply(pose, ref_pose, residue_list, ref_residue_list);
+		if ( reval != 0 ) continue;  // TO DO: remove this domain
 
-				if ( domains.size() == 0 ) {
-					DDomainParse ddom(pcut_,hcut_,length_);
-					utility::vector1 <Loops> domains = ddom.split( *working_pose );
-				}
+		tm_align.alignment2AtomMap(pose, ref_pose, residue_list, ref_residue_list, n_mapped_residues, atom_map);
+		tm_align.alignment2strings(seq_pose, seq_ref, aligned);
 
-				// clone original poses -> copies for alignment
-				templates_aln_.clear();
-				for ( core::Size i_pose=1; i_pose <= templates_.size(); ++i_pose ) {
-					templates_aln_.push_back(
-							utility::pointer::make_shared< core::pose::Pose >( *templates_[i_pose] ) );
-				}
+		using namespace ObjexxFCL::format;
+		core::Size norm_length = residue_list.size() < ref_residue_list.size() ? residue_list.size():ref_residue_list.size();
+		TR << "Align domain with TMscore of " << F(8,3,tm_align.TMscore(norm_length)) << std::endl;
+		TR << seq_pose << std::endl;
+		TR << aligned << std::endl;
+		TR << seq_ref << std::endl;
 
-				for ( core::Size i_pose=1; i_pose <= templates_aln_.size(); ++i_pose ) {
-					if ( templates_aln_[i_pose] == ref_pose ) continue; // compare pointers
-					align_by_domain(*templates_aln_[i_pose], *working_pose, domains);
-					//std::string out_fn = template_fns_[i_pose] + "_realigned.pdb";
-					//poses[i_pose]->dump_pdb(out_fn);
+		if ( n_mapped_residues < 6 ) continue;  // TO DO: remove this domain
+
+		// add in ligand residues
+		for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
+			core::Size res_controlling_i = ligres_map[i];
+			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+				if ( res_controlling_i < domains[i_domain][iloop].start() || res_controlling_i > domains[i_domain][iloop].stop() ) continue;
+				residue_list.push_back(i);
+			}
+		}
+
+		partial_align(pose, ref_pose, atom_map, residue_list, true, aln_cutoffs, min_coverage); // iterate_convergence = true
+	}
+}
+
+
+void
+HybridizeProtocol::do_intrastage_docking(core::pose::Pose & pose) {
+	// call docking or symm docking
+	if ( core::pose::symmetry::is_symmetric(pose) ) {
+		/////
+		/////  SYMM LOGIC
+		protocols::symmetric_docking::SymDockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::symmetric_docking::SymDockingLowRes >(stage1_scorefxn_) );
+		docking_lowres_mover->apply(pose);
+
+		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap>() );
+		mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( true );
+		core::pose::symmetry::make_symmetric_movemap( pose, *mm );
+
+		protocols::minimization_packing::MinMoverOP min_mover(
+			utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
+		min_mover->apply(pose);
+	} else {
+		/////
+		/////  ASYMM LOGIC
+		core::Size const rb_move_jump = 1; // use the first jump as the one between partners <<<< fpd: MAKE THIS A PARSIBLE OPTION
+		protocols::docking::DockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::docking::DockingLowRes >( stage1_scorefxn_, rb_move_jump ) );
+		docking_lowres_mover->apply(pose);
+
+		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+		mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( rb_move_jump, true );
+		protocols::minimization_packing::MinMoverOP min_mover( utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
+		min_mover->apply(pose);
+	}
+}
+
+protocols::moves::MoverOP HybridizeProtocol::clone() const { return utility::pointer::make_shared< HybridizeProtocol >( *this ); }
+protocols::moves::MoverOP HybridizeProtocol::fresh_instance() const { return utility::pointer::make_shared< HybridizeProtocol >(); }
+
+
+void
+HybridizeProtocol::parse_my_tag(
+	utility::tag::TagCOP tag,
+	basic::datacache::DataMap & data
+)
+{
+	// basic options
+	stage1_increase_cycles_ = tag->getOption< core::Real >( "stage1_increase_cycles", 1. );
+	stage2_increase_cycles_ = tag->getOption< core::Real >( "stage2_increase_cycles", 1. );
+	stage2_temperature_ = tag->getOption< core::Real >( "stage2_temperature", 2. );
+	stage25_increase_cycles_ = tag->getOption< core::Real >( "stage2.5_increase_cycles", 1. );
+	fa_cst_fn_ = tag->getOption< std::string >( "fa_cst_file", "" );
+	batch_relax_ = tag->getOption< core::Size >( "batch" , 1 );
+	jump_move_= tag->getOption< bool >( "jump_move" , false );
+	jump_move_repeat_= tag->getOption< core::Size >( "jump_move_repeat" , 1 );
+	keep_pose_constraint_= tag->getOption< bool >( "keep_pose_constraint" , false );
+	cenrot_= tag->getOption< bool >( "cenrot" , false );
+
+	//if( tag->hasOption( "task_operations" ) ){
+	//FPD   remove this option, it was used as a residue selector and not as options controlling packing
+	//      the 'DetailedControls' tag should replace one part of this, and a separate mover should generate interface constraints
+
+	// force starting template
+	//FPD   removed this option; it is redundant with weights! (set weight to 0 for templates we do not start with)
+
+
+	if ( tag->hasOption( "csts_from_frags" ) ) {
+		csts_from_frags_ = tag->getOption< bool >( "csts_from_frags" );
+	}
+	if ( tag->hasOption( "max_contig_insertion" ) ) {
+		max_contig_insertion_ = tag->getOption< int >( "max_contig_insertion" );
+	}
+
+	if ( tag->hasOption( "min_after_stage1" ) ) {
+		min_after_stage1_ = tag->getOption< bool >( "min_after_stage1" );
+	}
+	if ( tag->hasOption( "fragprob_stage2" ) ) {
+		fragprob_stage2_ = tag->getOption< core::Real >( "fragprob_stage2" );
+	}
+	if ( tag->hasOption( "randfragprob_stage2" ) ) {
+		randfragprob_stage2_ = tag->getOption< core::Real >( "randfragprob_stage2" );
+	}
+
+
+	// tons of ab initio options
+	if ( tag->hasOption( "stage1_1_cycles" ) ) {
+		stage1_1_cycles_ = tag->getOption< core::Size >( "stage1_1_cycles" );
+	}
+	if ( tag->hasOption( "stage1_2_cycles" ) ) {
+		stage1_2_cycles_ = tag->getOption< core::Size >( "stage1_2_cycles" );
+	}
+	if ( tag->hasOption( "stage1_3_cycles" ) ) {
+		stage1_3_cycles_ = tag->getOption< core::Size >( "stage1_3_cycles" );
+	}
+	if ( tag->hasOption( "stage1_4_cycles" ) ) {
+		stage1_4_cycles_ = tag->getOption< core::Size >( "stage1_4_cycles" );
+	}
+	if ( tag->hasOption( "stage1_probability" ) ) {
+		stage1_probability_ = tag->getOption< core::Real >( "stage1_probability" );
+	}
+	if ( tag->hasOption( "add_hetatm" ) ) {
+		add_hetatm_ = tag->getOption< bool >( "add_hetatm" );
+	}
+	if ( tag->hasOption( "hetatm_cst_weight" ) ) {
+		hetatm_self_cst_weight_ = tag->getOption< core::Real >( "hetatm_cst_weight" );
+	}
+	if ( tag->hasOption( "hetatm_to_protein_cst_weight" ) ) {
+		hetatm_prot_cst_weight_ = tag->getOption< core::Real >( "hetatm_to_protein_cst_weight" );
+	}
+	if ( tag->hasOption( "realign_domains" ) ) {
+		realign_domains_ = tag->getOption< bool >( "realign_domains" );
+	}
+	if ( tag->hasOption( "realign_domains_stage2" ) ) {
+		realign_domains_stage2_ = tag->getOption< bool >( "realign_domains_stage2" );
+	}
+	if ( tag->hasOption( "add_non_init_chunks" ) ) {
+		add_non_init_chunks_ = tag->getOption< core::Real >( "add_non_init_chunks" );
+	}
+	if ( tag->hasOption( "frag_1mer_insertion_weight" ) ) {
+		frag_1mer_insertion_weight_ = tag->getOption< core::Real >( "frag_1mer_insertion_weight" );
+	}
+	if ( tag->hasOption( "small_frag_insertion_weight" ) ) {
+		small_frag_insertion_weight_ = tag->getOption< core::Real >( "small_frag_insertion_weight" );
+	}
+	if ( tag->hasOption( "big_frag_insertion_weight" ) ) {
+		big_frag_insertion_weight_ = tag->getOption< core::Real >( "big_frag_insertion_weight" );
+	}
+	if ( tag->hasOption( "chunk_insertion_weight" ) ) {
+		chunk_insertion_weight_ = tag->getOption< core::Real >( "chunk_insertion_weight" );
+	}
+	if ( tag->hasOption( "frag_weight_aligned" ) ) {
+		frag_weight_aligned_ = tag->getOption< core::Real >( "frag_weight_aligned" );
+	}
+	if ( tag->hasOption( "auto_frag_insertion_weight" ) ) {
+		auto_frag_insertion_weight_ = tag->getOption< bool >( "auto_frag_insertion_weight" );
+	}
+	if ( tag->hasOption( "max_registry_shift" ) ) {
+		max_registry_shift_ = tag->getOption< core::Size >( "max_registry_shift" );
+	}
+	if ( tag->hasOption( "repeats" ) ) {
+		relax_repeats_ = tag->getOption< core::Size >( "repeats" );
+	}
+	if ( tag->hasOption( "disulf_file" ) ) {
+		disulf_file_ = tag->getOption< std::string >( "disulf_file" );
+	}
+
+	// stage 2-specific options
+	if ( tag->hasOption( "no_global_frame" ) ) {
+		no_global_frame_ = tag->getOption< bool >( "no_global_frame" );
+	}
+	if ( tag->hasOption( "linmin_only" ) ) {
+		linmin_only_ = tag->getOption< bool >( "linmin_only" );
+	}
+	if ( tag->hasOption( "cartfrag_overlap" ) ) {
+		cartfrag_overlap_ = tag->getOption< core::Size >( "cartfrag_overlap" );
+	}
+	if ( tag->hasOption( "seqfrags_only" ) ) {
+		seqfrags_only_ = tag->getOption< core::Size >( "seqfrags_only" );
+	}
+	if ( tag->hasOption( "skip_long_min" ) ) {
+		skip_long_min_ = tag->getOption< core::Size >( "skip_long_min" );
+	}
+
+
+	// scorefxns
+	if ( tag->hasOption( "stage1_scorefxn" ) ) {
+		std::string const scorefxn_name( tag->getOption<std::string>( "stage1_scorefxn" ) );
+		stage1_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+	}
+	if ( tag->hasOption( "stage2_scorefxn" ) ) {
+		std::string const scorefxn_name( tag->getOption<std::string>( "stage2_scorefxn" ) );
+		stage2_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+	}
+	if ( tag->hasOption( "stage2_min_scorefxn" ) ) {
+		std::string const scorefxn_name( tag->getOption<std::string>( "stage2_min_scorefxn" ) );
+		stage2min_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+	}
+	if ( tag->hasOption( "stage2_pack_scorefxn" ) ) {
+		if ( !cenrot_ ) {
+			TR << "Warning! Ignoring stage2_pack_scorefxn declaration since cenrot is not set." << std::endl;
+		} else {
+			std::string const scorefxn_name( tag->getOption<std::string>( "stage2_pack_scorefxn" ) );
+			stage2pack_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+		}
+	}
+	if ( tag->hasOption( "fa_scorefxn" ) ) {
+		std::string const scorefxn_name( tag->getOption<std::string>( "fa_scorefxn" ) );
+		fa_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+	}
+
+	// ddomain options
+	hcut_ = tag->getOption< core::Real >( "domain_hcut" , 0.18);
+	pcut_ = tag->getOption< core::Real >( "domain_pcut" , 0.81);
+	length_ = tag->getOption< core::Size >( "domain_length" , 38);
+
+	// user constraints
+	coord_cst_res_ = tag->getOption<std::string>( "coord_cst_res", "" );
+
+	// if user constraints are defined, make sure coord_csts are defined in at least one stage
+	if ( coord_cst_res_.size() > 0 ) {
+		runtime_assert(
+			stage1_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
+			stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
+			fa_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 );
+	}
+
+	// fragments
+	utility::vector1< utility::tag::TagCOP > const branch_tags( tag->getTags() );
+	utility::vector1< utility::tag::TagCOP >::const_iterator tag_it;
+	for ( tag_it = branch_tags.begin(); tag_it != branch_tags.end(); ++tag_it ) {
+		if ( (*tag_it)->getName() == "Fragments" ) {
+			using namespace core::fragment;
+			if ( (*tag_it)->hasOption( "three_mers" ) ) {
+				core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "three_mers" )  );
+				fragments_small_.push_back(frags);
+			} else if ( (*tag_it)->hasOption( "small" ) ) {
+				utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "small" ), ',');
+				for ( core::Size i=1; i<= frag_files.size(); ++i ) {
+					fragments_small_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
 				}
 			}
-
-
-		void
-			HybridizeProtocol::align_by_domain(core::pose::Pose & pose, core::pose::Pose const & ref_pose, utility::vector1 <Loops> domains) {
-				// ASSUME:
-				//    domains cover the full pose (no gaps)
-				utility::vector1< core::Real > aln_cutoffs;
-				aln_cutoffs.push_back(6);
-				aln_cutoffs.push_back(4);
-				aln_cutoffs.push_back(3);
-				aln_cutoffs.push_back(2);
-				aln_cutoffs.push_back(1.5);
-				aln_cutoffs.push_back(1);
-				core::Real min_coverage = 0.2;
-
-				// find corresepondance of ligands to nearest residues (in moving pose)
-				core::Size last_protein_residue=pose.size();
-				while ( last_protein_residue>0 && !pose.residue_type(last_protein_residue).is_protein() ) last_protein_residue--;
-
-				if ( last_protein_residue == 0 ) return;
-
-				std::map< core::Size, core::Size > ligres_map;
-				for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
-					core::Real mindist = 999.0;
-					core::Size minj = 1;
-					for ( core::Size j=1; j<=last_protein_residue; ++j ) {
-						core::Real dist_ij = (pose.residue(i).xyz(1) - pose.residue(j).xyz(1)).length(); // hacky (using atom 1 only)
-						if ( dist_ij < mindist ) {
-							mindist = dist_ij;
-							minj = (pose.pdb_info()) ? pose.pdb_info()->number(j) : j;
-						}
-					}
-					ligres_map[i] = minj;
-				}
-
-
-				for ( core::Size i_domain = 1; i_domain <= domains.size() ; ++i_domain ) {
-					core::id::AtomID_Map< core::id::AtomID > atom_map;
-					core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
-
-					// find all residues in moving pose corresponding to this domain
-					std::list <core::Size> residue_list;
-					core::Size n_mapped_residues=0;
-					for ( core::Size ires=1; ires<=pose.size(); ++ires ) {
-						if ( !pose.residue_type(ires).is_protein() ) continue;
-						int pose_res = (pose.pdb_info()) ? pose.pdb_info()->number(ires) : ires;
-						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-							if ( pose_res < (int)domains[i_domain][iloop].start() || pose_res > (int)domains[i_domain][iloop].stop() ) continue;
-							residue_list.push_back(ires);
-						}
-					}
-
-					// find all residues in reference pose corresponding to this domain
-					std::list <core::Size> ref_residue_list;
-					for ( core::Size jres=1; jres<=ref_pose.size(); ++jres ) {
-						if ( !ref_pose.residue_type(jres).is_protein() ) continue;
-						int ref_pose_res = (ref_pose.pdb_info()) ? ref_pose.pdb_info()->number(jres) : jres;
-						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-							if ( ref_pose_res < (int)domains[i_domain][iloop].start() || ref_pose_res > (int)domains[i_domain][iloop].stop() ) continue;
-							ref_residue_list.push_back(jres);
-						}
-					}
-
-					// get tmalign sequence mapping
-					TMalign tm_align;
-					std::string seq_pose, seq_ref, aligned;
-					int reval = tm_align.apply(pose, ref_pose, residue_list, ref_residue_list);
-					if ( reval != 0 ) continue;  // TO DO: remove this domain
-
-					tm_align.alignment2AtomMap(pose, ref_pose, residue_list, ref_residue_list, n_mapped_residues, atom_map);
-					tm_align.alignment2strings(seq_pose, seq_ref, aligned);
-
-					using namespace ObjexxFCL::format;
-					core::Size norm_length = residue_list.size() < ref_residue_list.size() ? residue_list.size():ref_residue_list.size();
-					TR << "Align domain with TMscore of " << F(8,3,tm_align.TMscore(norm_length)) << std::endl;
-					TR << seq_pose << std::endl;
-					TR << aligned << std::endl;
-					TR << seq_ref << std::endl;
-
-					if ( n_mapped_residues < 6 ) continue;  // TO DO: remove this domain
-
-					// add in ligand residues
-					for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
-						core::Size res_controlling_i = ligres_map[i];
-						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-							if ( res_controlling_i < domains[i_domain][iloop].start() || res_controlling_i > domains[i_domain][iloop].stop() ) continue;
-							residue_list.push_back(i);
-						}
-					}
-
-					partial_align(pose, ref_pose, atom_map, residue_list, true, aln_cutoffs, min_coverage); // iterate_convergence = true
+			if ( (*tag_it)->hasOption( "nine_mers" ) ) {
+				core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "nine_mers" ) );
+				fragments_big_.push_back(frags);
+			} else if ( (*tag_it)->hasOption( "big" ) ) {
+				utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "big" ), ',');
+				for ( core::Size i=1; i<= frag_files.size(); ++i ) {
+					fragments_big_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
 				}
 			}
+		}
 
+		if ( (*tag_it)->getName() == "Template" ) {
+			std::string const template_fn = (*tag_it)->getOption<std::string>( "pdb" );
+			std::string const cst_fn = (*tag_it)->getOption<std::string>( "cst_file", "AUTO" );  // should this be NONE?
+			auto const weight = (*tag_it)->getOption<core::Real>( "weight", 1.0 );
+			std::string const symm_file = (*tag_it)->getOption<std::string>( "symmdef", "" );
 
-		void
-			HybridizeProtocol::do_intrastage_docking(core::pose::Pose & pose) {
-				// call docking or symm docking
-				if ( core::pose::symmetry::is_symmetric(pose) ) {
-					/////
-					/////  SYMM LOGIC
-					protocols::symmetric_docking::SymDockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::symmetric_docking::SymDockingLowRes >(stage1_scorefxn_) );
-					docking_lowres_mover->apply(pose);
-
-					core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap>() );
-					mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( true );
-					core::pose::symmetry::make_symmetric_movemap( pose, *mm );
-
-					protocols::minimization_packing::MinMoverOP min_mover(
-							utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
-					min_mover->apply(pose);
-				} else {
-					/////
-					/////  ASYMM LOGIC
-					core::Size const rb_move_jump = 1; // use the first jump as the one between partners <<<< fpd: MAKE THIS A PARSIBLE OPTION
-					protocols::docking::DockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::docking::DockingLowRes >( stage1_scorefxn_, rb_move_jump ) );
-					docking_lowres_mover->apply(pose);
-
-					core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-					mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( rb_move_jump, true );
-					protocols::minimization_packing::MinMoverOP min_mover( utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
-					min_mover->apply(pose);
-				}
-			}
-
-		protocols::moves::MoverOP HybridizeProtocol::clone() const { return utility::pointer::make_shared< HybridizeProtocol >( *this ); }
-		protocols::moves::MoverOP HybridizeProtocol::fresh_instance() const { return utility::pointer::make_shared< HybridizeProtocol >(); }
-
-
-		void
-			HybridizeProtocol::parse_my_tag(
-					utility::tag::TagCOP tag,
-					basic::datacache::DataMap & data
-					)
-			{
-				// basic options
-				stage1_increase_cycles_ = tag->getOption< core::Real >( "stage1_increase_cycles", 1. );
-				stage2_increase_cycles_ = tag->getOption< core::Real >( "stage2_increase_cycles", 1. );
-				stage2_temperature_ = tag->getOption< core::Real >( "stage2_temperature", 2. );
-				stage25_increase_cycles_ = tag->getOption< core::Real >( "stage2.5_increase_cycles", 1. );
-				fa_cst_fn_ = tag->getOption< std::string >( "fa_cst_file", "" );
-				batch_relax_ = tag->getOption< core::Size >( "batch" , 1 );
-				jump_move_= tag->getOption< bool >( "jump_move" , false );
-				jump_move_repeat_= tag->getOption< core::Size >( "jump_move_repeat" , 1 );
-				keep_pose_constraint_= tag->getOption< bool >( "keep_pose_constraint" , false );
-				cenrot_= tag->getOption< bool >( "cenrot" , false );
-
-				//if( tag->hasOption( "task_operations" ) ){
-				//FPD   remove this option, it was used as a residue selector and not as options controlling packing
-				//      the 'DetailedControls' tag should replace one part of this, and a separate mover should generate interface constraints
-
-				// force starting template
-				//FPD   removed this option; it is redundant with weights! (set weight to 0 for templates we do not start with)
-
-
-				if ( tag->hasOption( "csts_from_frags" ) ) {
-					csts_from_frags_ = tag->getOption< bool >( "csts_from_frags" );
-				}
-				if ( tag->hasOption( "max_contig_insertion" ) ) {
-					max_contig_insertion_ = tag->getOption< int >( "max_contig_insertion" );
-				}
-
-				if ( tag->hasOption( "min_after_stage1" ) ) {
-					min_after_stage1_ = tag->getOption< bool >( "min_after_stage1" );
-				}
-				if ( tag->hasOption( "fragprob_stage2" ) ) {
-					fragprob_stage2_ = tag->getOption< core::Real >( "fragprob_stage2" );
-				}
-				if ( tag->hasOption( "randfragprob_stage2" ) ) {
-					randfragprob_stage2_ = tag->getOption< core::Real >( "randfragprob_stage2" );
-				}
-
-
-				// tons of ab initio options
-				if ( tag->hasOption( "stage1_1_cycles" ) ) {
-					stage1_1_cycles_ = tag->getOption< core::Size >( "stage1_1_cycles" );
-				}
-				if ( tag->hasOption( "stage1_2_cycles" ) ) {
-					stage1_2_cycles_ = tag->getOption< core::Size >( "stage1_2_cycles" );
-				}
-				if ( tag->hasOption( "stage1_3_cycles" ) ) {
-					stage1_3_cycles_ = tag->getOption< core::Size >( "stage1_3_cycles" );
-				}
-				if ( tag->hasOption( "stage1_4_cycles" ) ) {
-					stage1_4_cycles_ = tag->getOption< core::Size >( "stage1_4_cycles" );
-				}
-				if ( tag->hasOption( "stage1_probability" ) ) {
-					stage1_probability_ = tag->getOption< core::Real >( "stage1_probability" );
-				}
-				if ( tag->hasOption( "add_hetatm" ) ) {
-					add_hetatm_ = tag->getOption< bool >( "add_hetatm" );
-				}
-				if ( tag->hasOption( "hetatm_cst_weight" ) ) {
-					hetatm_self_cst_weight_ = tag->getOption< core::Real >( "hetatm_cst_weight" );
-				}
-				if ( tag->hasOption( "hetatm_to_protein_cst_weight" ) ) {
-					hetatm_prot_cst_weight_ = tag->getOption< core::Real >( "hetatm_to_protein_cst_weight" );
-				}
-				if ( tag->hasOption( "realign_domains" ) ) {
-					realign_domains_ = tag->getOption< bool >( "realign_domains" );
-				}
-				if ( tag->hasOption( "realign_domains_stage2" ) ) {
-					realign_domains_stage2_ = tag->getOption< bool >( "realign_domains_stage2" );
-				}
-				if ( tag->hasOption( "add_non_init_chunks" ) ) {
-					add_non_init_chunks_ = tag->getOption< core::Real >( "add_non_init_chunks" );
-				}
-				if ( tag->hasOption( "frag_1mer_insertion_weight" ) ) {
-					frag_1mer_insertion_weight_ = tag->getOption< core::Real >( "frag_1mer_insertion_weight" );
-				}
-				if ( tag->hasOption( "small_frag_insertion_weight" ) ) {
-					small_frag_insertion_weight_ = tag->getOption< core::Real >( "small_frag_insertion_weight" );
-				}
-				if ( tag->hasOption( "big_frag_insertion_weight" ) ) {
-					big_frag_insertion_weight_ = tag->getOption< core::Real >( "big_frag_insertion_weight" );
-				}
-				if ( tag->hasOption( "chunk_insertion_weight" ) ) {
-					chunk_insertion_weight_ = tag->getOption< core::Real >( "chunk_insertion_weight" );
-				}
-				if ( tag->hasOption( "frag_weight_aligned" ) ) {
-					frag_weight_aligned_ = tag->getOption< core::Real >( "frag_weight_aligned" );
-				}
-				if ( tag->hasOption( "auto_frag_insertion_weight" ) ) {
-					auto_frag_insertion_weight_ = tag->getOption< bool >( "auto_frag_insertion_weight" );
-				}
-				if ( tag->hasOption( "max_registry_shift" ) ) {
-					max_registry_shift_ = tag->getOption< core::Size >( "max_registry_shift" );
-				}
-				if ( tag->hasOption( "repeats" ) ) {
-					relax_repeats_ = tag->getOption< core::Size >( "repeats" );
-				}
-				if ( tag->hasOption( "disulf_file" ) ) {
-					disulf_file_ = tag->getOption< std::string >( "disulf_file" );
-				}
-
-				// stage 2-specific options
-				if ( tag->hasOption( "no_global_frame" ) ) {
-					no_global_frame_ = tag->getOption< bool >( "no_global_frame" );
-				}
-				if ( tag->hasOption( "linmin_only" ) ) {
-					linmin_only_ = tag->getOption< bool >( "linmin_only" );
-				}
-				if ( tag->hasOption( "cartfrag_overlap" ) ) {
-					cartfrag_overlap_ = tag->getOption< core::Size >( "cartfrag_overlap" );
-				}
-				if ( tag->hasOption( "seqfrags_only" ) ) {
-					seqfrags_only_ = tag->getOption< core::Size >( "seqfrags_only" );
-				}
-				if ( tag->hasOption( "skip_long_min" ) ) {
-					skip_long_min_ = tag->getOption< core::Size >( "skip_long_min" );
-				}
-
-
-				// scorefxns
-				if ( tag->hasOption( "stage1_scorefxn" ) ) {
-					std::string const scorefxn_name( tag->getOption<std::string>( "stage1_scorefxn" ) );
-					stage1_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-				}
-				if ( tag->hasOption( "stage2_scorefxn" ) ) {
-					std::string const scorefxn_name( tag->getOption<std::string>( "stage2_scorefxn" ) );
-					stage2_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-				}
-				if ( tag->hasOption( "stage2_min_scorefxn" ) ) {
-					std::string const scorefxn_name( tag->getOption<std::string>( "stage2_min_scorefxn" ) );
-					stage2min_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-				}
-				if ( tag->hasOption( "stage2_pack_scorefxn" ) ) {
-					if ( !cenrot_ ) {
-						TR << "Warning! Ignoring stage2_pack_scorefxn declaration since cenrot is not set." << std::endl;
-					} else {
-						std::string const scorefxn_name( tag->getOption<std::string>( "stage2_pack_scorefxn" ) );
-						stage2pack_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+			// randomize some chains
+			utility::vector1< char > rand_chains;
+			if ( (*tag_it)->hasOption( "randomize" ) ) {
+				std::string rand_chain_str = (*tag_it)->getOption<std::string>( "randomize", "" );
+				utility::vector1< std::string > rand_chain_strs = utility::string_split( rand_chain_str, ',');
+				for ( core::Size j = 1; j<=rand_chain_strs.size(); ++j ) {
+					if ( rand_chain_strs[j].length() != 0 ) {
+						rand_chains.push_back( rand_chain_strs[j][0] );
 					}
 				}
-				if ( tag->hasOption( "fa_scorefxn" ) ) {
-					std::string const scorefxn_name( tag->getOption<std::string>( "fa_scorefxn" ) );
-					fa_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+			}
+			bool const align_pdb_info = (*tag_it)->getOption<bool>( "auto_align", true );
+			add_template(template_fn, cst_fn, symm_file, weight, rand_chains, align_pdb_info);
+		}
+
+		// strand pairings
+		if ( (*tag_it)->getName() == "Pairings" ) {
+			pairings_file_ = (*tag_it)->getOption< std::string >( "file", "" );
+			if ( (*tag_it)->hasOption("sheets") ) {
+				auto sheets = (*tag_it)->getOption< core::Size >( "sheets" );
+				sheets_.clear();
+				random_sheets_.clear();
+				sheets_.push_back(sheets);
+			} else if ( (*tag_it)->hasOption("random_sheets") ) {
+				auto random_sheets = (*tag_it)->getOption< core::Size >( "random_sheets" );
+				sheets_.clear();
+				random_sheets_.clear();
+				random_sheets_.push_back(random_sheets);
+			}
+			filter_templates_ = (*tag_it)->getOption<bool>( "filter_templates" , false );
+		}
+
+		// per-residue control
+		if ( (*tag_it)->getName() == "DetailedControls" ) {
+			if ( (*tag_it)->hasOption( "task_operations" ) ) {
+				core::pack::task::TaskFactoryOP task_factory = protocols::rosetta_scripts::parse_task_operations( *tag_it, data );
+				detailed_controls_settings_.push_back(
+					detailedControlsTagSetting("task_operations", task_factory, 0, 0, sampleEnum::unset, sampleEnum::unset));
+			} else {
+				core::Size const start_res = (*tag_it)->getOption<core::Size>( "start_res", 1 );
+				core::Size const stop_res = (*tag_it)->getOption<core::Size>( "stop_res", 0 );
+
+				sampleEnum sample_template(sampleEnum::unset), sample_abinitio(sampleEnum::unset);
+				if ( (*tag_it)->hasOption( "sample_template" ) ) {
+					sample_template = (*tag_it)->getOption<bool>( "sample_template", true ) ? sampleEnum::on : sampleEnum::off;
 				}
-
-				// ddomain options
-				hcut_ = tag->getOption< core::Real >( "domain_hcut" , 0.18);
-				pcut_ = tag->getOption< core::Real >( "domain_pcut" , 0.81);
-				length_ = tag->getOption< core::Size >( "domain_length" , 38);
-
-				// user constraints
-				coord_cst_res_ = tag->getOption<std::string>( "coord_cst_res", "" );
-
-				// if user constraints are defined, make sure coord_csts are defined in at least one stage
-				if ( coord_cst_res_.size() > 0 ) {
-					runtime_assert(
-							stage1_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
-							stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
-							fa_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 );
+				if ( (*tag_it)->hasOption( "sample_abinitio" ) ) {
+					sample_abinitio = (*tag_it)->getOption<bool>( "sample_abinitio", true ) ? sampleEnum::on : sampleEnum::off;
 				}
+				detailed_controls_settings_.push_back(
+					detailedControlsTagSetting("else", nullptr, start_res, stop_res, sample_template, sample_abinitio));
+			} // if tag == DetailedControls
+		} //forach tag
+	}
+}
 
-				// fragments
-				utility::vector1< utility::tag::TagCOP > const branch_tags( tag->getTags() );
-				utility::vector1< utility::tag::TagCOP >::const_iterator tag_it;
-				for ( tag_it = branch_tags.begin(); tag_it != branch_tags.end(); ++tag_it ) {
-					if ( (*tag_it)->getName() == "Fragments" ) {
-						using namespace core::fragment;
-						if ( (*tag_it)->hasOption( "three_mers" ) ) {
-							core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "three_mers" )  );
-							fragments_small_.push_back(frags);
-						} else if ( (*tag_it)->hasOption( "small" ) ) {
-							utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "small" ), ',');
-							for ( core::Size i=1; i<= frag_files.size(); ++i ) {
-								fragments_small_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
-							}
-						}
-						if ( (*tag_it)->hasOption( "nine_mers" ) ) {
-							core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "nine_mers" ) );
-							fragments_big_.push_back(frags);
-						} else if ( (*tag_it)->hasOption( "big" ) ) {
-							utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "big" ), ',');
-							for ( core::Size i=1; i<= frag_files.size(); ++i ) {
-								fragments_big_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
-							}
-						}
-					}
+std::string HybridizeProtocol::get_name() const {
+	return mover_name();
+}
 
-					if ( (*tag_it)->getName() == "Template" ) {
-						std::string const template_fn = (*tag_it)->getOption<std::string>( "pdb" );
-						std::string const cst_fn = (*tag_it)->getOption<std::string>( "cst_file", "AUTO" );  // should this be NONE?
-						auto const weight = (*tag_it)->getOption<core::Real>( "weight", 1.0 );
-						std::string const symm_file = (*tag_it)->getOption<std::string>( "symmdef", "" );
+std::string HybridizeProtocol::mover_name() {
+	return "Hybridize";
+}
 
-						// randomize some chains
-						utility::vector1< char > rand_chains;
-						if ( (*tag_it)->hasOption( "randomize" ) ) {
-							std::string rand_chain_str = (*tag_it)->getOption<std::string>( "randomize", "" );
-							utility::vector1< std::string > rand_chain_strs = utility::string_split( rand_chain_str, ',');
-							for ( core::Size j = 1; j<=rand_chain_strs.size(); ++j ) {
-								if ( rand_chain_strs[j].length() != 0 ) {
-									rand_chains.push_back( rand_chain_strs[j][0] );
-								}
-							}
-						}
-						bool const align_pdb_info = (*tag_it)->getOption<bool>( "auto_align", true );
-						add_template(template_fn, cst_fn, symm_file, weight, rand_chains, align_pdb_info);
-					}
+std::string hybridize_subelement_ct_name( std::string const & name ) {
+	return "Hybridize_subelement_" + name + "Type";
+}
 
-					// strand pairings
-					if ( (*tag_it)->getName() == "Pairings" ) {
-						pairings_file_ = (*tag_it)->getOption< std::string >( "file", "" );
-						if ( (*tag_it)->hasOption("sheets") ) {
-							auto sheets = (*tag_it)->getOption< core::Size >( "sheets" );
-							sheets_.clear();
-							random_sheets_.clear();
-							sheets_.push_back(sheets);
-						} else if ( (*tag_it)->hasOption("random_sheets") ) {
-							auto random_sheets = (*tag_it)->getOption< core::Size >( "random_sheets" );
-							sheets_.clear();
-							random_sheets_.clear();
-							random_sheets_.push_back(random_sheets);
-						}
-						filter_templates_ = (*tag_it)->getOption<bool>( "filter_templates" , false );
-					}
+void HybridizeProtocol::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd )
+{
 
-					// per-residue control
-					if ( (*tag_it)->getName() == "DetailedControls" ) {
-						if ( (*tag_it)->hasOption( "task_operations" ) ) {
-							core::pack::task::TaskFactoryOP task_factory = protocols::rosetta_scripts::parse_task_operations( *tag_it, data );
-							detailed_controls_settings_.push_back(
-									detailedControlsTagSetting("task_operations", task_factory, 0, 0, sampleEnum::unset, sampleEnum::unset));
-						} else {
-							core::Size const start_res = (*tag_it)->getOption<core::Size>( "start_res", 1 );
-							core::Size const stop_res = (*tag_it)->getOption<core::Size>( "stop_res", 0 );
+	using namespace utility::tag;
+	AttributeList attlist;
 
-							sampleEnum sample_template(sampleEnum::unset), sample_abinitio(sampleEnum::unset);
-							if ( (*tag_it)->hasOption( "sample_template" ) ) {
-								sample_template = (*tag_it)->getOption<bool>( "sample_template", true ) ? sampleEnum::on : sampleEnum::off;
-							}
-							if ( (*tag_it)->hasOption( "sample_abinitio" ) ) {
-								sample_abinitio = (*tag_it)->getOption<bool>( "sample_abinitio", true ) ? sampleEnum::on : sampleEnum::off;
-							}
-							detailed_controls_settings_.push_back(
-									detailedControlsTagSetting("else", nullptr, start_res, stop_res, sample_template, sample_abinitio));
-						} // if tag == DetailedControls
-					} //forach tag
-				}
-			}
+	//basic direct attributes
+	attlist
+		+ XMLSchemaAttribute::attribute_w_default( "stage1_increase_cycles", xsct_real, "Increase/decrease sampling in stage 1", "1.0" ) //XRW TODO: should be nonnegative real
+		+ XMLSchemaAttribute::attribute_w_default( "stage2_increase_cycles", xsct_real, "Increase/decrease sampling in stage 2", "1.0" ) //XRW TODO: should be nonnegative real
+		+ XMLSchemaAttribute::attribute_w_default( "stage2_temperature", xsct_real, "kT for the Monte Carlo simulation", "2.0" ) //XRW TODO: should be nonnegative real
+		+ XMLSchemaAttribute::attribute_w_default( "stage2.5_increase_cycles", xsct_real, "Increase/decrease number of minimization steps following stage 2", "1.0" ) //XRW TODO: should be nonnegative real
+		+ XMLSchemaAttribute( "fa_cst_file", xs_string, "constraints file for fullatom stage" )
+		+ XMLSchemaAttribute::attribute_w_default( "batch", xsct_non_negative_integer, "The number of centroid structures to generate per fullatom model. Setting this to 0 will only run centroid modeling.", "1" )
+		+ XMLSchemaAttribute::attribute_w_default( "jump_move", xsct_rosetta_bool, "rigid body moves in stage 1", "false" )
+		+ XMLSchemaAttribute::attribute_w_default( "jump_move_repeat", xsct_non_negative_integer, "cycles in stage 1 that handle rigid body moves", "1" )
+		+ XMLSchemaAttribute::attribute_w_default( "keep_pose_constraint", xsct_rosetta_bool, "If set to true, keep constraints on the incoming pose (useful if constraints are generated in a mover prior to hybridize)", "false" )
+		+ XMLSchemaAttribute::attribute_w_default( "cenrot", xsct_rosetta_bool, "centroid rotamer modeling; necessary for stage2_pack_scorefxn to be useful; probably requires command line option -corrections:score:cenrot", "false" )
+		+ XMLSchemaAttribute( "csts_from_frags", xsct_rosetta_bool, "when set, derives dihedral constraints from input fragments; you need to set 'dihedral_constraint' weight in the stages you want to use this")
+		+ XMLSchemaAttribute( "max_contig_insertion", xsct_non_negative_integer, "Limits the length of 'template recombination' moves. Useful when inputs are full-length (no gaps).")
+		+ XMLSchemaAttribute( "min_after_stage1", xsct_rosetta_bool, "minimize after stage 1 (?)")
+		+ XMLSchemaAttribute( "fragprob_stage2", xsct_real, "controls the ratio of fragment insertions versus template recombination moves, implicit default 0.3")
+		+ XMLSchemaAttribute( "randfragprob_stage2", xsct_real, "controls the number of random fragfile insertions versus 'cutpoint' insertions, implicit default 0.5")
+		//ab initio options
+		+ XMLSchemaAttribute( "stage1_1_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+		+ XMLSchemaAttribute( "stage1_2_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+		+ XMLSchemaAttribute( "stage1_3_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+		+ XMLSchemaAttribute( "stage1_4_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+		+ XMLSchemaAttribute( "stage1_probability", xsct_real, "probability of doing 'fold tree hybridize' for stage one (with rigid body moves(?) instead of 'frag insertion in unaligned regions'")
+		+ XMLSchemaAttribute( "add_hetatm", xsct_rosetta_bool, "If true, use ligands from input template files")
+		+ XMLSchemaAttribute( "hetatm_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated intra-ligand restraints.  Called hetatm_self_cst_weight in documentation.")
+		+ XMLSchemaAttribute( "hetatm_to_protein_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated ligand-protein restraints. Called hetatm_prot_cst_weight in documentation.")
+		+ XMLSchemaAttribute( "realign_domains", xsct_rosetta_bool, "If unset, this will not align the input domains to each other before running the protocol. Unsetting this option requires that input domains be previously aligned to a common reference frame. This option may be useful to unset for building models into density (if all inputs are docking into density).")
+		+ XMLSchemaAttribute( "realign_domains_stage2", xsct_rosetta_bool, "If set, realign domains in between the two centroid stages; default only aligns the initial models.")
+		+ XMLSchemaAttribute( "add_non_init_chunks", xsct_real, "Normally, secondary structure chunks are used from the starting model to set the foldtree. This option will steal chunks from other templates as well (as long as they do not overlap with current chunks); the number is the expected number of chunks (poisson distribution). This option is recommended when starting from an extended chain.")
+		+ XMLSchemaAttribute( "frag_1mer_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+		+ XMLSchemaAttribute( "small_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+		+ XMLSchemaAttribute( "big_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+		+ XMLSchemaAttribute( "chunk_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+		+ XMLSchemaAttribute( "frag_weight_aligned", xsct_real, "Allow fragment insertions in template regions. The default is 0; increasing this will lead to increased model diversity.")
+		+ XMLSchemaAttribute( "auto_frag_insertion_weight", xsct_rosetta_bool, "automatically set fragment insertion weights")
+		+ XMLSchemaAttribute( "max_registry_shift", xsct_non_negative_integer, "Add a random move that shifts the sequence during model-building")
+		+ XMLSchemaAttribute( "repeats", xsct_non_negative_integer, "repeats for relax step")
+		+ XMLSchemaAttribute( "disulf_file", xs_string, "If specified, force the attached disulfide patterning")
+		//stage 2 options
+		+ XMLSchemaAttribute( "no_global_frame", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
+		+ XMLSchemaAttribute( "linmin_only", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
+		+ XMLSchemaAttribute( "cartfrag_overlap", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
+		+ XMLSchemaAttribute( "seqfrags_only", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
+		+ XMLSchemaAttribute( "skip_long_min", xsct_non_negative_integer, "only valid in Cartesian Hybridize; skip a final minimization")
+		//scorefunctions
+		+ XMLSchemaAttribute( "stage1_scorefxn", xs_string, "Scorefunction for stage 1 (looked up from DataMap")
+		+ XMLSchemaAttribute( "stage2_scorefxn", xs_string, "Scorefunction for stage 2 (looked up from DataMap")
+		+ XMLSchemaAttribute( "stage2_min_scorefxn", xs_string, "Scorefunction for stage 2 minimization (looked up from DataMap")
+		+ XMLSchemaAttribute( "stage2_pack_scorefxn", xs_string, "Scorefunction for stage 2 'packing' (looked up from DataMap. Only valid if boolean cenrot is true.")
+		+ XMLSchemaAttribute( "fa_scorefxn", xs_string, "Scorefunction for fullatom stage (looked up from DataMap")
+		//ddomain options (not a typo)
+		+ XMLSchemaAttribute::attribute_w_default( "domain_pcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.18")
+		+ XMLSchemaAttribute::attribute_w_default( "domain_hcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.81")
+		+ XMLSchemaAttribute::attribute_w_default( "domain_length", xsct_non_negative_integer, "Used in DDomainParse.  Aggressively undocumented.", "38");
+	//user constraints
+	core::pose::attributes_for_get_resnum_selector( attlist, xsd, "coord_cst_res");
+	//orphaned docstring: "residues with user-provided CoordinateConstraints; If defined, at least one of the scorefunctions in [stage1_scorefxn, stage2_scorefxn, fa_scorefxn] must have nonzero coordinate_constraint weights"); //XRW TODO maybe
 
-			std::string HybridizeProtocol::get_name() const {
-				return mover_name();
-			}
+	// attributes for Fragments subelement
+	AttributeList fragment_subelement_attributes;
+	fragment_subelement_attributes
+		+ XMLSchemaAttribute( "three_mers", xs_string, "3mers fragments file")
+		+ XMLSchemaAttribute( "small", xs_string, "comma separated vector of small (probably 3mer) fragments files")
+		+ XMLSchemaAttribute( "nine_mers", xs_string, "9mers fragments file")
+		+ XMLSchemaAttribute( "big", xs_string, "comma separated vector of small (probably 3mer) fragments files");
 
-			std::string HybridizeProtocol::mover_name() {
-				return "Hybridize";
-			}
+	// attributes for Template subelement
+	AttributeList template_subelement_attributes;
+	template_subelement_attributes
+		+ XMLSchemaAttribute::required_attribute( "pdb", xs_string, "file path to pdb template")
+		+ XMLSchemaAttribute::attribute_w_default( "cst_file", xs_string, "file path to constraints file associated with this template", "AUTO")
+		+ XMLSchemaAttribute::attribute_w_default( "weight", xsct_real, "Sampling frequency weight for this template", "1.0")
+		+ XMLSchemaAttribute( "symmdef", xs_string, "symmdef file associated with this template (only if using symmetry)")
+		+ XMLSchemaAttribute( "randomize", xs_string, "comma-seprated list of chains to randomize - not documented")
+		+ XMLSchemaAttribute::attribute_w_default( "auto_align", xsct_rosetta_bool, "frustratingly undocumented", "true");
 
-			std::string hybridize_subelement_ct_name( std::string const & name ) {
-				return "Hybridize_subelement_" + name + "Type";
-			}
+	std::string const pairings_warning(" sheets and random_sheets are mutually exclusive.");
+	// attributes for Pairings subelement
+	AttributeList pairings_subelement_attributes;
+	pairings_subelement_attributes
+		+ XMLSchemaAttribute::required_attribute( "file", xs_string, "path to pairings file")
+		+ XMLSchemaAttribute( "sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
+		+ XMLSchemaAttribute( "random_sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
+		+ XMLSchemaAttribute::attribute_w_default( "filter_templates", xsct_rosetta_bool, "remove templates with incorrect pairings", "false");
 
-			void HybridizeProtocol::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd )
-			{
+	// attributes for DetailedControls subelement
+	AttributeList DetailedControls_subelement_attributes;
+	DetailedControls_subelement_attributes
+		+ XMLSchemaAttribute::attribute_w_default( "start_res", xsct_non_negative_integer, "starting residue for a DetailedControl region", "1")
+		+ XMLSchemaAttribute( "stop_res", xsct_non_negative_integer, "ending residue for a DetailedControl region; defaults to the rest of the Pose")
+		+ XMLSchemaAttribute::attribute_w_default( "sample_template", xsct_rosetta_bool, "if false, disallow template hybridization moves", "true")
+		+ XMLSchemaAttribute::attribute_w_default( "sample_abinitio", xsct_rosetta_bool, "if false, disallow fragment insertion moves", "true");
+	rosetta_scripts::attributes_for_parse_task_operations(DetailedControls_subelement_attributes);
 
-				using namespace utility::tag;
-				AttributeList attlist;
+	XMLSchemaSimpleSubelementList subelements;
+	subelements.complex_type_naming_func( & hybridize_subelement_ct_name );
+	subelements.add_simple_subelement( "Fragments", fragment_subelement_attributes, "Instructions for fragments files.  Should occur exactly once.");
+	subelements.add_simple_subelement( "Template", template_subelement_attributes, "Instructions for templates. Must occur at least once, may occur as many times as you wish.");
+	subelements.add_simple_subelement( "Pairings", pairings_subelement_attributes, "Used with FoldTreeHybridize and poorly documented");
+	subelements.add_simple_subelement( "DetailedControls", DetailedControls_subelement_attributes, "Used to prevent regions from being sampled extensively (meaning, don't remodel regions where the model is already correct)");
 
-				//basic direct attributes
-				attlist
-					+ XMLSchemaAttribute::attribute_w_default( "stage1_increase_cycles", xsct_real, "Increase/decrease sampling in stage 1", "1.0" ) //XRW TODO: should be nonnegative real
-					+ XMLSchemaAttribute::attribute_w_default( "stage2_increase_cycles", xsct_real, "Increase/decrease sampling in stage 2", "1.0" ) //XRW TODO: should be nonnegative real
-					+ XMLSchemaAttribute::attribute_w_default( "stage2_temperature", xsct_real, "kT for the Monte Carlo simulation", "2.0" ) //XRW TODO: should be nonnegative real
-					+ XMLSchemaAttribute::attribute_w_default( "stage2.5_increase_cycles", xsct_real, "Increase/decrease number of minimization steps following stage 2", "1.0" ) //XRW TODO: should be nonnegative real
-					+ XMLSchemaAttribute( "fa_cst_file", xs_string, "constraints file for fullatom stage" )
-					+ XMLSchemaAttribute::attribute_w_default( "batch", xsct_non_negative_integer, "The number of centroid structures to generate per fullatom model. Setting this to 0 will only run centroid modeling.", "1" )
-					+ XMLSchemaAttribute::attribute_w_default( "jump_move", xsct_rosetta_bool, "rigid body moves in stage 1", "false" )
-					+ XMLSchemaAttribute::attribute_w_default( "jump_move_repeat", xsct_non_negative_integer, "cycles in stage 1 that handle rigid body moves", "1" )
-					+ XMLSchemaAttribute::attribute_w_default( "keep_pose_constraint", xsct_rosetta_bool, "If set to true, keep constraints on the incoming pose (useful if constraints are generated in a mover prior to hybridize)", "false" )
-					+ XMLSchemaAttribute::attribute_w_default( "cenrot", xsct_rosetta_bool, "centroid rotamer modeling; necessary for stage2_pack_scorefxn to be useful; probably requires command line option -corrections:score:cenrot", "false" )
-					+ XMLSchemaAttribute( "csts_from_frags", xsct_rosetta_bool, "when set, derives dihedral constraints from input fragments; you need to set 'dihedral_constraint' weight in the stages you want to use this")
-					+ XMLSchemaAttribute( "max_contig_insertion", xsct_non_negative_integer, "Limits the length of 'template recombination' moves. Useful when inputs are full-length (no gaps).")
-					+ XMLSchemaAttribute( "min_after_stage1", xsct_rosetta_bool, "minimize after stage 1 (?)")
-					+ XMLSchemaAttribute( "fragprob_stage2", xsct_real, "controls the ratio of fragment insertions versus template recombination moves, implicit default 0.3")
-					+ XMLSchemaAttribute( "randfragprob_stage2", xsct_real, "controls the number of random fragfile insertions versus 'cutpoint' insertions, implicit default 0.5")
-					//ab initio options
-					+ XMLSchemaAttribute( "stage1_1_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-					+ XMLSchemaAttribute( "stage1_2_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-					+ XMLSchemaAttribute( "stage1_3_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-					+ XMLSchemaAttribute( "stage1_4_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-					+ XMLSchemaAttribute( "stage1_probability", xsct_real, "probability of doing 'fold tree hybridize' for stage one (with rigid body moves(?) instead of 'frag insertion in unaligned regions'")
-					+ XMLSchemaAttribute( "add_hetatm", xsct_rosetta_bool, "If true, use ligands from input template files")
-					+ XMLSchemaAttribute( "hetatm_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated intra-ligand restraints.  Called hetatm_self_cst_weight in documentation.")
-					+ XMLSchemaAttribute( "hetatm_to_protein_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated ligand-protein restraints. Called hetatm_prot_cst_weight in documentation.")
-					+ XMLSchemaAttribute( "realign_domains", xsct_rosetta_bool, "If unset, this will not align the input domains to each other before running the protocol. Unsetting this option requires that input domains be previously aligned to a common reference frame. This option may be useful to unset for building models into density (if all inputs are docking into density).")
-					+ XMLSchemaAttribute( "realign_domains_stage2", xsct_rosetta_bool, "If set, realign domains in between the two centroid stages; default only aligns the initial models.")
-					+ XMLSchemaAttribute( "add_non_init_chunks", xsct_real, "Normally, secondary structure chunks are used from the starting model to set the foldtree. This option will steal chunks from other templates as well (as long as they do not overlap with current chunks); the number is the expected number of chunks (poisson distribution). This option is recommended when starting from an extended chain.")
-					+ XMLSchemaAttribute( "frag_1mer_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-					+ XMLSchemaAttribute( "small_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-					+ XMLSchemaAttribute( "big_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-					+ XMLSchemaAttribute( "chunk_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-					+ XMLSchemaAttribute( "frag_weight_aligned", xsct_real, "Allow fragment insertions in template regions. The default is 0; increasing this will lead to increased model diversity.")
-					+ XMLSchemaAttribute( "auto_frag_insertion_weight", xsct_rosetta_bool, "automatically set fragment insertion weights")
-					+ XMLSchemaAttribute( "max_registry_shift", xsct_non_negative_integer, "Add a random move that shifts the sequence during model-building")
-					+ XMLSchemaAttribute( "repeats", xsct_non_negative_integer, "repeats for relax step")
-					+ XMLSchemaAttribute( "disulf_file", xs_string, "If specified, force the attached disulfide patterning")
-					//stage 2 options
-					+ XMLSchemaAttribute( "no_global_frame", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
-					+ XMLSchemaAttribute( "linmin_only", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
-					+ XMLSchemaAttribute( "cartfrag_overlap", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
-					+ XMLSchemaAttribute( "seqfrags_only", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
-					+ XMLSchemaAttribute( "skip_long_min", xsct_non_negative_integer, "only valid in Cartesian Hybridize; skip a final minimization")
-					//scorefunctions
-					+ XMLSchemaAttribute( "stage1_scorefxn", xs_string, "Scorefunction for stage 1 (looked up from DataMap")
-					+ XMLSchemaAttribute( "stage2_scorefxn", xs_string, "Scorefunction for stage 2 (looked up from DataMap")
-					+ XMLSchemaAttribute( "stage2_min_scorefxn", xs_string, "Scorefunction for stage 2 minimization (looked up from DataMap")
-					+ XMLSchemaAttribute( "stage2_pack_scorefxn", xs_string, "Scorefunction for stage 2 'packing' (looked up from DataMap. Only valid if boolean cenrot is true.")
-					+ XMLSchemaAttribute( "fa_scorefxn", xs_string, "Scorefunction for fullatom stage (looked up from DataMap")
-					//ddomain options (not a typo)
-					+ XMLSchemaAttribute::attribute_w_default( "domain_pcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.18")
-					+ XMLSchemaAttribute::attribute_w_default( "domain_hcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.81")
-					+ XMLSchemaAttribute::attribute_w_default( "domain_length", xsct_non_negative_integer, "Used in DDomainParse.  Aggressively undocumented.", "38");
-				//user constraints
-				core::pose::attributes_for_get_resnum_selector( attlist, xsd, "coord_cst_res");
-				//orphaned docstring: "residues with user-provided CoordinateConstraints; If defined, at least one of the scorefunctions in [stage1_scorefxn, stage2_scorefxn, fa_scorefxn] must have nonzero coordinate_constraint weights"); //XRW TODO maybe
+	protocols::moves::xsd_type_definition_w_attributes_and_repeatable_subelements( xsd, mover_name(), "This is the Hybridize mover at the core of comparative modeling (RosettaCM).  Typically its XML is written by a script rather than manually.", attlist, subelements );
+}
 
-				// attributes for Fragments subelement
-				AttributeList fragment_subelement_attributes;
-				fragment_subelement_attributes
-					+ XMLSchemaAttribute( "three_mers", xs_string, "3mers fragments file")
-					+ XMLSchemaAttribute( "small", xs_string, "comma separated vector of small (probably 3mer) fragments files")
-					+ XMLSchemaAttribute( "nine_mers", xs_string, "9mers fragments file")
-					+ XMLSchemaAttribute( "big", xs_string, "comma separated vector of small (probably 3mer) fragments files");
+/// @brief Provide the citation.
+void
+HybridizeProtocol::provide_citation_info(basic::citation_manager::CitationCollectionList & citations ) const {
+	basic::citation_manager::CitationCollectionOP collection(
+		utility::pointer::make_shared< basic::citation_manager::CitationCollection >(
+		mover_name(),
+		basic::citation_manager::CitedModuleType::Mover
+		)
+	);
+	collection->add_citation( basic::citation_manager::CitationManager::get_instance()->get_citation_by_doi("10.1016/j.str.2013.08.005") );
 
-				// attributes for Template subelement
-				AttributeList template_subelement_attributes;
-				template_subelement_attributes
-					+ XMLSchemaAttribute::required_attribute( "pdb", xs_string, "file path to pdb template")
-					+ XMLSchemaAttribute::attribute_w_default( "cst_file", xs_string, "file path to constraints file associated with this template", "AUTO")
-					+ XMLSchemaAttribute::attribute_w_default( "weight", xsct_real, "Sampling frequency weight for this template", "1.0")
-					+ XMLSchemaAttribute( "symmdef", xs_string, "symmdef file associated with this template (only if using symmetry)")
-					+ XMLSchemaAttribute( "randomize", xs_string, "comma-seprated list of chains to randomize - not documented")
-					+ XMLSchemaAttribute::attribute_w_default( "auto_align", xsct_rosetta_bool, "frustratingly undocumented", "true");
+	citations.add( collection );
+}
 
-				std::string const pairings_warning(" sheets and random_sheets are mutually exclusive.");
-				// attributes for Pairings subelement
-				AttributeList pairings_subelement_attributes;
-				pairings_subelement_attributes
-					+ XMLSchemaAttribute::required_attribute( "file", xs_string, "path to pairings file")
-					+ XMLSchemaAttribute( "sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
-					+ XMLSchemaAttribute( "random_sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
-					+ XMLSchemaAttribute::attribute_w_default( "filter_templates", xsct_rosetta_bool, "remove templates with incorrect pairings", "false");
+std::string HybridizeProtocolCreator::keyname() const {
+	return HybridizeProtocol::mover_name();
+}
 
-				// attributes for DetailedControls subelement
-				AttributeList DetailedControls_subelement_attributes;
-				DetailedControls_subelement_attributes
-					+ XMLSchemaAttribute::attribute_w_default( "start_res", xsct_non_negative_integer, "starting residue for a DetailedControl region", "1")
-					+ XMLSchemaAttribute( "stop_res", xsct_non_negative_integer, "ending residue for a DetailedControl region; defaults to the rest of the Pose")
-					+ XMLSchemaAttribute::attribute_w_default( "sample_template", xsct_rosetta_bool, "if false, disallow template hybridization moves", "true")
-					+ XMLSchemaAttribute::attribute_w_default( "sample_abinitio", xsct_rosetta_bool, "if false, disallow fragment insertion moves", "true");
-				rosetta_scripts::attributes_for_parse_task_operations(DetailedControls_subelement_attributes);
+protocols::moves::MoverOP
+HybridizeProtocolCreator::create_mover() const {
+	return utility::pointer::make_shared< HybridizeProtocol >();
+}
 
-				XMLSchemaSimpleSubelementList subelements;
-				subelements.complex_type_naming_func( & hybridize_subelement_ct_name );
-				subelements.add_simple_subelement( "Fragments", fragment_subelement_attributes, "Instructions for fragments files.  Should occur exactly once.");
-				subelements.add_simple_subelement( "Template", template_subelement_attributes, "Instructions for templates. Must occur at least once, may occur as many times as you wish.");
-				subelements.add_simple_subelement( "Pairings", pairings_subelement_attributes, "Used with FoldTreeHybridize and poorly documented");
-				subelements.add_simple_subelement( "DetailedControls", DetailedControls_subelement_attributes, "Used to prevent regions from being sampled extensively (meaning, don't remodel regions where the model is already correct)");
-
-				protocols::moves::xsd_type_definition_w_attributes_and_repeatable_subelements( xsd, mover_name(), "This is the Hybridize mover at the core of comparative modeling (RosettaCM).  Typically its XML is written by a script rather than manually.", attlist, subelements );
-			}
-
-			/// @brief Provide the citation.
-			void
-				HybridizeProtocol::provide_citation_info(basic::citation_manager::CitationCollectionList & citations ) const {
-					basic::citation_manager::CitationCollectionOP collection(
-							utility::pointer::make_shared< basic::citation_manager::CitationCollection >(
-								mover_name(),
-								basic::citation_manager::CitedModuleType::Mover
-								)
-							);
-					collection->add_citation( basic::citation_manager::CitationManager::get_instance()->get_citation_by_doi("10.1016/j.str.2013.08.005") );
-
-					citations.add( collection );
-				}
-
-			std::string HybridizeProtocolCreator::keyname() const {
-				return HybridizeProtocol::mover_name();
-			}
-
-			protocols::moves::MoverOP
-				HybridizeProtocolCreator::create_mover() const {
-					return utility::pointer::make_shared< HybridizeProtocol >();
-				}
-
-			void HybridizeProtocolCreator::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) const
-			{
-				HybridizeProtocol::provide_xml_schema( xsd );
-			}
+void HybridizeProtocolCreator::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) const
+{
+	HybridizeProtocol::provide_xml_schema( xsd );
+}
 
 
-			} // hybridization
-	} // protocols
+} // hybridization
+} // protocols

--- a/source/src/protocols/hybridization/HybridizeProtocol.cc
+++ b/source/src/protocols/hybridization/HybridizeProtocol.cc
@@ -79,6 +79,7 @@
 
 #include <core/conformation/Residue.hh>
 #include <core/conformation/util.hh>
+#include <core/conformation/carbohydrates/util.hh>
 
 #include <core/kinematics/FoldTree.hh>
 #include <core/kinematics/MoveMap.hh>
@@ -155,2102 +156,2139 @@
 static basic::Tracer TR( "protocols.hybridization.HybridizeProtocol" );
 
 namespace protocols {
-namespace hybridization {
+	namespace hybridization {
 
 
-using namespace core;
-using namespace kinematics;
-using namespace sequence;
-using namespace pack;
-using namespace task;
-using namespace operation;
-using namespace scoring;
-using namespace constraints;
-using namespace protocols::loops;
+		using namespace core;
+		using namespace kinematics;
+		using namespace sequence;
+		using namespace pack;
+		using namespace task;
+		using namespace operation;
+		using namespace scoring;
+		using namespace constraints;
+		using namespace protocols::loops;
 
 
-/////////////
-// creator
+		/////////////
+		// creator
 
 
 
 
-/////////////
-// mover
-HybridizeProtocol::HybridizeProtocol()
-{
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
+		/////////////
+		// mover
+		HybridizeProtocol::HybridizeProtocol()
+		{
+			using namespace basic::options;
+			using namespace basic::options::OptionKeys;
 
-	init();
-}
-
-
-// creator with data input
-HybridizeProtocol::HybridizeProtocol(
-	utility::vector1 <core::pose::PoseOP> templates_in,
-	utility::vector1 <core::Real> template_weights_in,
-	core::scoring::ScoreFunctionOP stage1_scorefxn_in,
-	core::scoring::ScoreFunctionOP stage2_scorefxn_in,
-	core::scoring::ScoreFunctionOP fa_scorefxn_in,
-	std::string const & frag3_fn,
-	std::string const & frag9_fn,
-	std::string const & cen_cst_in,
-	std::string const & fa_cst_in
-)
-{
-	if ( templates_in.size() != template_weights_in.size() ) {
-		throw CREATE_EXCEPTION(utility::excn::BadInput, "Error! Input templates and weights are in different sizes!");
-	}
-
-	stage1_probability_     = 1.;
-	stage1_increase_cycles_ = 1.;
-
-	stage1_1_cycles_    = 2000;
-	stage1_2_cycles_    = 2000;
-	stage1_3_cycles_    = 2000;
-	stage1_4_cycles_    = 400;
-
-	stage2_temperature_ = 2.;
-
-	add_hetatm_ = false;
-	realign_domains_ = true;
-	realign_domains_stage2_ = true;
-	add_non_init_chunks_ = 0.;
-	frag_weight_aligned_ = 0.;
-	auto_frag_insertion_weight_ = true;
-	max_registry_shift_ = 0;
-	frag_1mer_insertion_weight_ = 0.;
-	small_frag_insertion_weight_ = 0.;
-	big_frag_insertion_weight_ = 0.5;
-	chunk_insertion_weight_ = 1.;
-	hetatm_self_cst_weight_ = 10.;
-	hetatm_prot_cst_weight_ = 0.;
-	cartfrag_overlap_ = 2;
-	seqfrags_only_ = false;
-	skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
-	keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
-
-	cenrot_ = false;
-
-	csts_from_frags_ = false;  // generate dihedral constraints from fragments
-	max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
-	min_after_stage1_ = false;   // tors min after stage1
-	fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
-	randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
-
-
-	// domain parsing options
-	hcut_ = 0.18;
-	pcut_ = 0.81;
-	length_ = 38;
-
-
-	jump_move_ = false;
-	jump_move_repeat_ = 1;
-
-	stage2_increase_cycles_ = 1.;
-	stage25_increase_cycles_ = 1.;
-	no_global_frame_ = false;
-	linmin_only_ = false;
-
-	batch_relax_ = 1;
-	relax_repeats_ = 5;
-
-	// disulfide file
-	//    if ( option[ in::fix_disulf ].user() ) {
-	//        disulf_file_ = option[ in::fix_disulf ]();
-	//    }
-
-	// read fragments
-	using namespace core::fragment;
-	FragSetOP frags9 = FragmentIO().read_data( frag9_fn );
-	fragments_big_.push_back(frags9);
-
-	FragSetOP frags3 = FragmentIO().read_data( frag3_fn );
-	fragments_small_.push_back(frags3);
-
-	// scorefxns
-	set_stage1_scorefxn(stage1_scorefxn_in);
-	set_stage2_scorefxn(stage2_scorefxn_in);
-	set_fullatom_scorefxn(fa_scorefxn_in);
-
-	cen_cst_in_ = cen_cst_in;
-	fa_cst_in_ = fa_cst_in;
-	for ( core::Size i_template = 1; i_template <= templates_in.size(); ++i_template ) {
-		add_template(templates_in[i_template], "NONE", "", template_weights_in[i_template]);
-		// skip validate_template, for now
-	}
-}
-
-// sets default options
-void
-HybridizeProtocol::init() {
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
-
-	stage1_probability_ = option[cm::hybridize::stage1_probability]();
-	stage1_increase_cycles_ = option[cm::hybridize::stage1_increase_cycles]();
-	stage1_1_cycles_ = option[cm::hybridize::stage1_1_cycles]();
-	stage1_2_cycles_ = option[cm::hybridize::stage1_2_cycles]();
-	stage1_3_cycles_ = option[cm::hybridize::stage1_3_cycles]();
-	stage1_4_cycles_ = option[cm::hybridize::stage1_4_cycles]();
-	stage2_temperature_ = option[cm::hybridize::stage2_temperature]();
-	add_hetatm_ = false;
-	realign_domains_ = option[cm::hybridize::realign_domains]();
-	realign_domains_stage2_ = option[cm::hybridize::realign_domains_stage2]();
-	add_non_init_chunks_ = option[cm::hybridize::add_non_init_chunks]();
-	frag_weight_aligned_ = option[cm::hybridize::frag_weight_aligned]();
-	auto_frag_insertion_weight_ = option[cm::hybridize::auto_frag_insertion_weight]();
-	max_registry_shift_ = option[cm::hybridize::max_registry_shift]();
-	frag_1mer_insertion_weight_ = option[cm::hybridize::frag_1mer_insertion_weight]();
-	small_frag_insertion_weight_ = option[cm::hybridize::small_frag_insertion_weight]();
-	big_frag_insertion_weight_ = option[cm::hybridize::big_frag_insertion_weight]();
-	chunk_insertion_weight_ = 1.;
-	hetatm_self_cst_weight_ = 10.;
-	hetatm_prot_cst_weight_ = 0.;
-	cartfrag_overlap_ = 2;
-	seqfrags_only_ = false;
-	skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
-	keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
-
-	include_loop_ss_chunks_ = option[cm::hybridize::include_loop_ss_chunks]();
-
-	cenrot_ = option[corrections::score::cenrot]();
-
-	csts_from_frags_ = false;  // generate dihedral constraints from fragments
-	max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
-	min_after_stage1_ = false;   // tors min after stage1
-	fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
-	randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
-
-
-	// domain parsing options
-	hcut_ = 0.18;
-	pcut_ = 0.81;
-	length_ = 38;
-
-
-	jump_move_ = false;
-	jump_move_repeat_ = 1;
-
-	stage2_increase_cycles_ = option[cm::hybridize::stage2_increase_cycles]();
-	stage25_increase_cycles_ = option[cm::hybridize::stage2min_increase_cycles]();
-	no_global_frame_ = option[cm::hybridize::no_global_frame]();
-	linmin_only_ = option[cm::hybridize::linmin_only]();
-
-	// default scorefunctions
-	//    stage2 scorefunctions are initialized in CartesianHybridize
-	stage1_scorefxn_ = core::scoring::ScoreFunctionFactory::create_score_function( "score3" );
-	fa_scorefxn_ = core::scoring::get_score_function();
-
-	core::scoring::constraints::add_fa_constraints_from_cmdline_to_scorefxn( *fa_scorefxn_ );
-
-
-	if ( option[ OptionKeys::constraints::cst_fa_file ].user() ) {
-		utility::vector1< std::string > cst_files = option[ OptionKeys::constraints::cst_fa_file ]();
-		auto choice = core::Size( numeric::random::rg().random_range( 1, cst_files.size() ) );
-		fa_cst_fn_ = cst_files[choice];
-		TR.Info << "Fullatom Constraint choice: " << fa_cst_fn_ << std::endl;
-	}
-
-	batch_relax_ = option[ cm::hybridize::relax ]();
-	relax_repeats_ = option[ basic::options::OptionKeys::relax::default_repeats ]();
-
-	// disulfide file
-	if ( option[ in::fix_disulf ].user() ) {
-		disulf_file_ = option[ in::fix_disulf ]();
-	}
-
-	// read fragments
-	if ( option[ in::file::frag9 ].user() ) {
-		using namespace core::fragment;
-		FragSetOP frags = FragmentIO().read_data( option[ in::file::frag9 ]() );
-		fragments_big_.push_back(frags);
-	}
-	if ( option[ in::file::frag3 ].user() ) {
-		using namespace core::fragment;
-		FragSetOP frags = FragmentIO().read_data( option[ in::file::frag3 ]() );
-		fragments_small_.push_back(frags);
-	}
-
-	// native
-	if ( option[ in::file::native ].user() ) {
-		native_needs_load_ = true;
-	} else if ( option[ evaluation::align_rmsd_target ].user() ) {
-		native_needs_load_from_align_rmsd_target_ = true;
-	}
-
-	// strand pairings
-	pairings_file_ = option[jumps::pairing_file]();
-	if ( option[jumps::sheets].user() ) {
-		sheets_ = option[jumps::sheets]();
-	} else {
-		random_sheets_ = option[jumps::random_sheets]();
-	}
-	filter_templates_ = option[jumps::filter_templates]();
-}
-
-void
-HybridizeProtocol::check_and_create_fragments( core::pose::Pose & pose ) {
-	if ( fragments_big_.size() > 0 && fragments_small_.size() > 0 ) return;
-
-	core::Size fragbiglen=9;
-
-	if ( !fragments_big_.size() ) {
-		// number of residues
-		core::Size nres_tgt = pose.size();
-		core::conformation::symmetry::SymmetryInfoCOP symm_info;
-		if ( core::pose::symmetry::is_symmetric(pose) ) {
-			auto & SymmConf (
-				dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-			symm_info = SymmConf.Symmetry_Info();
-			nres_tgt = symm_info->num_independent_residues();
+			init();
 		}
-		if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-		while ( !pose.residue(nres_tgt).is_protein() ) nres_tgt--;
 
-		fragbiglen = std::min( fragbiglen, nres_tgt );
 
-		core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >() );
-
-		// sequence
-		std::string tgt_seq = pose.sequence();
-		std::string tgt_ss(nres_tgt, '0');
-
-		using namespace basic::options;
-		using namespace basic::options::OptionKeys;
-		if ( option[ OptionKeys::in::file::psipred_ss2 ].user() ) {
-			utility::vector1< char > psipred = read_psipred_ss2_file( pose );
-			for ( core::Size j=1; j<=nres_tgt; ++j ) {
-				tgt_ss[j-1] = psipred[j];
+		// creator with data input
+		HybridizeProtocol::HybridizeProtocol(
+				utility::vector1 <core::pose::PoseOP> templates_in,
+				utility::vector1 <core::Real> template_weights_in,
+				core::scoring::ScoreFunctionOP stage1_scorefxn_in,
+				core::scoring::ScoreFunctionOP stage2_scorefxn_in,
+				core::scoring::ScoreFunctionOP fa_scorefxn_in,
+				std::string const & frag3_fn,
+				std::string const & frag9_fn,
+				std::string const & cen_cst_in,
+				std::string const & fa_cst_in
+				)
+		{
+			if ( templates_in.size() != template_weights_in.size() ) {
+				throw CREATE_EXCEPTION(utility::excn::BadInput, "Error! Input templates and weights are in different sizes!");
 			}
-		} else {
-			// templates vote on secstruct
-			for ( core::Size i=1; i<=templates_.size(); ++i ) {
-				for ( core::Size j=1; j<=templates_[i]->size(); ++j ) {
-					if ( !templates_[i]->residue(j).is_protein() ) continue;
-					core::Size tgt_pos = templates_[i]->pdb_info()->number(j);
 
-					runtime_assert( tgt_pos<=nres_tgt );
-					char tgt_ss_j = templates_[i]->secstruct(j);
+			stage1_probability_     = 1.;
+			stage1_increase_cycles_ = 1.;
 
-					if ( tgt_ss[tgt_pos-1] == '0' ) {
-						tgt_ss[tgt_pos-1] = tgt_ss_j;
-					} else if ( tgt_ss[tgt_pos-1] != tgt_ss_j ) {
-						tgt_ss[tgt_pos-1] = 'D'; // templates disagree
-					}
-				}
-			}
-			for ( core::Size j=1; j<=nres_tgt; ++j ) {
-				if ( tgt_ss[j-1] == '0' ) tgt_ss[j-1] = 'D';
+			stage1_1_cycles_    = 2000;
+			stage1_2_cycles_    = 2000;
+			stage1_3_cycles_    = 2000;
+			stage1_4_cycles_    = 400;
+
+			stage2_temperature_ = 2.;
+
+			add_hetatm_ = false;
+			realign_domains_ = true;
+			realign_domains_stage2_ = true;
+			add_non_init_chunks_ = 0.;
+			frag_weight_aligned_ = 0.;
+			auto_frag_insertion_weight_ = true;
+			max_registry_shift_ = 0;
+			frag_1mer_insertion_weight_ = 0.;
+			small_frag_insertion_weight_ = 0.;
+			big_frag_insertion_weight_ = 0.5;
+			chunk_insertion_weight_ = 1.;
+			hetatm_self_cst_weight_ = 10.;
+			hetatm_prot_cst_weight_ = 0.;
+			cartfrag_overlap_ = 2;
+			seqfrags_only_ = false;
+			skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
+			keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+
+			cenrot_ = false;
+
+			csts_from_frags_ = false;  // generate dihedral constraints from fragments
+			max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
+			min_after_stage1_ = false;   // tors min after stage1
+			fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
+			randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+
+
+			// domain parsing options
+			hcut_ = 0.18;
+			pcut_ = 0.81;
+			length_ = 38;
+
+
+			jump_move_ = false;
+			jump_move_repeat_ = 1;
+
+			stage2_increase_cycles_ = 1.;
+			stage25_increase_cycles_ = 1.;
+			no_global_frame_ = false;
+			linmin_only_ = false;
+
+			batch_relax_ = 1;
+			relax_repeats_ = 5;
+
+			// disulfide file
+			//    if ( option[ in::fix_disulf ].user() ) {
+			//        disulf_file_ = option[ in::fix_disulf ]();
+			//    }
+
+			// read fragments
+			using namespace core::fragment;
+			FragSetOP frags9 = FragmentIO().read_data( frag9_fn );
+			fragments_big_.push_back(frags9);
+
+			FragSetOP frags3 = FragmentIO().read_data( frag3_fn );
+			fragments_small_.push_back(frags3);
+
+			// scorefxns
+			set_stage1_scorefxn(stage1_scorefxn_in);
+			set_stage2_scorefxn(stage2_scorefxn_in);
+			set_fullatom_scorefxn(fa_scorefxn_in);
+
+			cen_cst_in_ = cen_cst_in;
+			fa_cst_in_ = fa_cst_in;
+			for ( core::Size i_template = 1; i_template <= templates_in.size(); ++i_template ) {
+				add_template(templates_in[i_template], "NONE", "", template_weights_in[i_template]);
+				// skip validate_template, for now
 			}
 		}
 
-		// pick from vall based on template SS + target sequence
-		for ( core::Size j=1; j<=nres_tgt-fragbiglen+1; ++j ) {
-			core::fragment::FrameOP frame( utility::pointer::make_shared< core::fragment::Frame >(j, fragbiglen) );
-
-			if ( j > residue_sample_abinitio_.size() || residue_sample_abinitio_[j] ) {
-				frame->add_fragment(
-					core::fragment::picking_old::vall::pick_fragments_by_ss_plus_aa(
-					tgt_ss.substr( j-1, fragbiglen ), tgt_seq.substr( j-1, fragbiglen ), 25, true, core::fragment::IndependentBBTorsionSRFD() ) );
-				frags->add( frame );
-			}
-		}
-		fragments_big_.push_back( frags );
-	}
-	if ( !fragments_small_.size() ) {
-		core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >(3) );
-
-		// make them from big fragments
-		core::fragment::chop_fragments( *fragments_big_[1], *frags );
-		fragments_small_.push_back( frags );
-	}
-}
-
-//fpd add fragment-derived constraints
-void
-HybridizeProtocol::add_fragment_csts( core::pose::Pose &pose ) {
-	TR << "Adding fragment constraints" << std::endl;
-
-	core::fragment::FragSetOP frags = fragments_small_[1];
-
-	// stolen from SecondaryStructure.cc
-	if ( frags->global_offset() != 0 ) {
-		TR.Error << "SecondaryStructure computations must be carried out with local coordinates (global offset of fragments must be 0)." << std::endl;
-		TR.Error << "   value of global offset of fragments: " << frags->global_offset() << std::endl;
-		utility_exit_with_message("SecondaryStructure computations not in local coordinates!");
-	}
-
-	// 1 - collect fragment statistics
-	core::Size frag_nres = frags->max_pos();
-	utility::vector1< utility::vector1< core::Real > > phi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
-	utility::vector1< utility::vector1< core::Real > > psi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
-	utility::vector1< int > N( frag_nres, 0 );
-
-	for ( core::fragment::FragID_Iterator it=frags->begin(), eit=frags->end(); it!=eit; ++it ) { //carefully checked that I don't change FrameData
-		core::Size loop_start = 1;
-		core::Size loop_end = it->frame().length();
-		for ( core::Size fpos = loop_start; fpos <= loop_end; ++fpos ) {
-			core::fragment::BBTorsionSRFDCOP res_i =
-				utility::pointer::dynamic_pointer_cast<const core::fragment::BBTorsionSRFD> (it->fragment().get_residue( fpos ) );
-
-			core::Size pos = it->frame().seqpos( fpos );
-			core::Real phi = std::fmod( res_i->torsion(1), 360.0 ); if ( phi<0 ) phi +=360.0;
-			core::Real psi = std::fmod( res_i->torsion(2), 360.0 ); if ( psi<0 ) psi +=360.0;
-
-			auto phibin = (core::Size) std::floor( phi/10.0 ); if ( phibin == 36 ) phibin=0;
-			auto psibin = (core::Size) std::floor( psi/10.0 ); if ( psibin == 36 ) psibin=0;
-
-			phi_distr[pos][phibin+1]+=1.0;
-			psi_distr[pos][psibin+1]+=1.0;
-			N[pos]++;
-		}
-	}
-
-	// smoothing
-	//core::Real smoothing[7] = {0.09, 0.14, 0.175, 0.19, 0.175, 0.14, 0.09};  // very soft
-	core::Real smoothing[7] = {0.01, 0.05, 0.24, 0.40, 0.24, 0.05, 0.01}; // less soft
-	for ( int i=1; i<=(int)frag_nres; ++i ) {
-		utility::vector1< core::Real > phi_i = phi_distr[i];
-		utility::vector1< core::Real > psi_i = psi_distr[i];
-		for ( int j=1; j<=36; ++j ) {
-			phi_distr[i][j] = smoothing[0]*phi_i[1+((j+32)%36)]
-				+ smoothing[1]*phi_i[1+((j+33)%36)]
-				+ smoothing[2]*phi_i[1+((j+34)%36)]
-				+ smoothing[3]*phi_i[1+((j+35)%36)]
-				+ smoothing[4]*phi_i[1+((j+0)%36)]
-				+ smoothing[5]*phi_i[1+((j+1)%36)]
-				+ smoothing[6]*phi_i[1+((j+2)%36)];
-
-			psi_distr[i][j] = smoothing[0]*psi_i[1+((j+32)%36)]
-				+ smoothing[1]*psi_i[1+((j+33)%36)]
-				+ smoothing[2]*psi_i[1+((j+34)%36)]
-				+ smoothing[3]*psi_i[1+((j+35)%36)]
-				+ smoothing[4]*psi_i[1+((j+0)%36)]
-				+ smoothing[5]*psi_i[1+((j+1)%36)]
-				+ smoothing[6]*psi_i[1+((j+2)%36)];
-
-			phi_distr[i][j] /= N[i];
-			psi_distr[i][j] /= N[i];
-		}
-	}
-
-	// convert to energy
-	core::Real mest=0.1;
-	for ( int i=1; i<=(int)frag_nres; ++i ) {
-		for ( int j=1; j<=36; ++j ) {
-			// shift so max is 0
-			phi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*phi_distr[i][j] ) + std::log( mest/36.0 ) ;
-			psi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*psi_distr[i][j] ) + std::log( mest/36.0 ) ;
-		}
-
-		//TR << "phi " << i;
-		//for (int j=1; j<=36; ++j) TR << " " << phi_distr[i][j];
-		//TR << std::endl;
-
-		//TR << "psi " << i;
-		//for (int j=1; j<=36; ++j) TR << " " << psi_distr[i][j];
-		//TR << std::endl;
-	}
-
-	// finally .. add constraints
-	for ( int i=1; i<=(int)frag_nres; ++i ) {
-		using namespace core::scoring::func;
-		using namespace core::scoring::constraints;
-
-		if ( !pose.residue(i).is_protein() ) continue;
-
-		if ( i>1 && pose.residue(i-1).is_protein() ) {
-			FuncOP phi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, phi_distr[i] ) );
-			ConstraintOP phi_cst( utility::pointer::make_shared< DihedralConstraint >(
-				core::id::AtomID(3,i-1),core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i), phi_func  ) );
-			pose.add_constraint( scoring::constraints::ConstraintCOP( phi_cst ) );
-		}
-
-		if ( i<(int)frag_nres && pose.residue(i+1).is_protein() ) {
-			FuncOP psi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, psi_distr[i] ) );
-			ConstraintOP psi_cst( utility::pointer::make_shared< DihedralConstraint >(
-				core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i),core::id::AtomID(1,i+1), psi_func  ) );
-			pose.add_constraint( scoring::constraints::ConstraintCOP( psi_cst ) );
-		}
-	}
-}
-
-void
-HybridizeProtocol::initialize_and_sample_loops(
-	core::pose::Pose &pose,
-	core::pose::PoseOP chosen_templ,
-	protocols::loops::Loops template_contigs,
-	core::scoring::ScoreFunctionOP scorefxn)
-{
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
-
-	// xyz copy starting model
-	for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
-		for ( core::Size j=1; j<=chosen_templ->residue(i).natoms(); ++j ) {
-			core::id::AtomID src(j,i), tgt(j, chosen_templ->pdb_info()->number(i));
-			pose.set_xyz( tgt, chosen_templ->xyz( src ) );
-		}
-	}
-
-	// make loops as inverse of template_contigs
-	TR << "CONTIGS" << std::endl << template_contigs << std::endl;
-	//core::Size ncontigs = template_contigs.size();
-	core::Size nres_tgt = pose.size();
-
-	//symmetry
-	core::conformation::symmetry::SymmetryInfoCOP symm_info;
-	if ( core::pose::symmetry::is_symmetric(pose) ) {
-		auto & SymmConf (
-			dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-		symm_info = SymmConf.Symmetry_Info();
-		nres_tgt = symm_info->num_independent_residues();
-	}
-
-	if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-
-	protocols::loops::LoopsOP loops( utility::pointer::make_shared< protocols::loops::Loops >() );
-	utility::vector1< bool > templ_coverage(nres_tgt, false);
-
-	for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
-		core::Size cres = chosen_templ->pdb_info()->number(i);
-		templ_coverage[cres] = true;
-	}
-
-	// remove 1-3 residue "segments"
-	for ( core::Size i=1; i<=nres_tgt-2; ++i ) {
-		if ( !templ_coverage[i] && templ_coverage[i+1] && !templ_coverage[i+2] ) {
-			templ_coverage[i+1]=false;
-		} else if ( i<=nres_tgt-3 && !templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && !templ_coverage[i+3] ) {
-			templ_coverage[i+1]=false;
-			templ_coverage[i+2]=false;
-		} else if ( i<=nres_tgt-4 &&
-				!templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && templ_coverage[i+3] && !templ_coverage[i+4] ) {
-			templ_coverage[i+1]=false;
-			templ_coverage[i+2]=false;
-			templ_coverage[i+3]=false;
-		}
-	}
-	// make loopfile
-	bool inloop=!templ_coverage[1];
-	core::Size loopstart=1, loopstop;
-	for ( core::Size i=2; i<=nres_tgt; ++i ) {
-		if ( templ_coverage[i] && inloop ) {
-			inloop = false;
-			loopstop = i;
-			if ( loopstop < loopstart + 2 ) {
-				if ( loopstart>1 ) loopstart--;
-				if ( loopstop<nres_tgt ) loopstop++;
-			}
-			loops->add_loop( loopstart,loopstop );
-		} else if ( !templ_coverage[i] && !inloop ) {
-			// start loop
-			inloop = true;
-			loopstart = i-1;
-		}
-	}
-	if ( inloop ) {
-		// end loop
-		loopstop = nres_tgt;
-		while ( loopstop < loopstart + 2 ) { loopstart--; }
-		loops->add_loop( loopstart,loopstop );
-	}
-	TR << "LOOPS" << std::endl << *loops << std::endl;
-
-	// now do insertions
-	if ( loops->size() != 0 ) {
-		// set foldtree + variants
-		loops->auto_choose_cutpoints(pose);
-		core::kinematics::FoldTree f_in=pose.fold_tree(), f_new;
-		protocols::loops::fold_tree_from_loops( pose, *loops, f_new);
-		pose.fold_tree( f_new );
-		protocols::loops::add_cutpoint_variants( pose );
-
-		// set movemap
-		core::kinematics::MoveMapOP mm_loop( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-		for ( auto const & it : *loops ) {
-			for ( core::Size i=it.start(); i<=it.stop(); ++i ) {
-				mm_loop->set_bb(i, true);
-				mm_loop->set_chi(i, true); // chi of loop residues
-			}
-		}
-
-		// setup fragment movers
-		protocols::simple_moves::ClassicFragmentMoverOP frag3mover, frag9mover;
-		core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
-		core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
-		TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
-		TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
-		frag3mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_small, mm_loop );
-		frag3mover->set_check_ss( false ); frag3mover->enable_end_bias_check( false );
-		frag9mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_big, mm_loop );
-		frag9mover->set_check_ss( false ); frag9mover->enable_end_bias_check( false );
-
-		// extend + idealize loops
-		for ( auto const & it : *loops ) {
-			protocols::loops::Loop to_idealize( it );
-			protocols::loops::set_extended_torsions( pose, it );
-		}
-
-		// setup MC
-		scorefxn->set_weight( core::scoring::linear_chainbreak, 0.5 );
-		(*scorefxn)(pose);
-		protocols::moves::MonteCarloOP mc1( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
-
-		auto neffcycles = (core::Size)(1000*option[cm::hybridize::stage1_increase_cycles]());
-		for ( core::Size n=1; n<=neffcycles; ++n ) {
-			frag9mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag9" );
-			frag3mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag3" );
-
-			if ( n%100 == 0 ) {
-				mc1->show_scores();
-				mc1->show_counters();
-			}
-		}
-		mc1->recover_low( pose );
-
-		scorefxn->set_weight( core::scoring::linear_chainbreak, 2.0 );
-		(*scorefxn)(pose);
-		protocols::moves::MonteCarloOP mc2( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
-		for ( core::Size n=1; n<=neffcycles; ++n ) {
-			frag9mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag9" );
-			frag3mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag3" );
-
-			if ( n%100 == 0 ) {
-				mc2->show_scores();
-				mc2->show_counters();
-			}
-		}
-
-		// restore input ft
-		mc2->recover_low( pose );
-		protocols::loops::remove_cutpoint_variants( pose );
-		pose.fold_tree( f_in );
-	}
-}
-
-
-void HybridizeProtocol::add_template(
-	std::string const & template_fn,
-	std::string const & cst_fn,
-	std::string const & symm_file,
-	core::Real const weight,
-	utility::vector1<char> const & randchains,
-	bool const align_pdb_info)
-{
-	core::chemical::ResidueTypeSetCOP const residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
-
-	core::pose::PoseOP template_pose( utility::pointer::make_shared< core::pose::Pose >() );
-	if ( template_fn == "extended" ) {
-		// auto constraints make no sense
-		if ( cst_fn == "AUTO" ) {
-			TR.Error << "Warning!  Turning off auto constraints for extended pose" << std::endl;
-		}
-		add_null_template( template_pose, "NONE", symm_file, weight );
-	} else {
-		core::import_pose::pose_from_file( *template_pose, *residue_set, template_fn , core::import_pose::PDB_file);
-		add_template( template_pose, cst_fn, symm_file, weight, randchains, template_fn, align_pdb_info);
-	}
-}
-
-
-void HybridizeProtocol::add_null_template(
-	core::pose::PoseOP template_pose,
-	std::string cst_fn,
-	std::string symm_file,
-	core::Real weight)
-{
-	template_fns_.push_back("null");
-	templates_.push_back(template_pose);
-	templates_aln_.push_back(template_pose); // shallow copy
-	template_cst_fn_.push_back(cst_fn);
-	symmdef_files_.push_back(symm_file);
-	template_weights_.push_back(weight);
-	template_chunks_.push_back(protocols::loops::Loops());
-	template_contigs_.push_back(protocols::loops::Loops());
-	randomize_chains_.push_back(utility::vector1<char>(0));
-}
-
-void HybridizeProtocol::add_template(
-	core::pose::PoseOP template_pose,
-	std::string const & cst_fn,
-	std::string const & symm_file,
-	core::Real const weight,
-	utility::vector1<char> const & rand_chains,
-	std::string const & filename,
-	bool const align_pdb_info)
-{
-	// add secondary structure information to the template pose
-	core::scoring::dssp::Dssp dssp_obj( *template_pose );
-	dssp_obj.insert_ss_into_pose( *template_pose );
-
-	// find ss chunks in template
-	protocols::loops::Loops contigs = protocols::loops::extract_continuous_chunks(*template_pose);
-	protocols::loops::Loops chunks;
-	if ( include_loop_ss_chunks_ ) {
-		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
-	} else {
-		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
-	}
-
-	// if there are no SS elts in the pose, use contigs
-	if ( chunks.num_loop() == 0 ) chunks = contigs;
-
-	TR.Debug << "Chunks from template\n" << chunks << std::endl;
-	TR.Debug << "Contigs from template\n" << contigs << std::endl;
-
-	template_fns_.push_back(filename);
-	templates_.push_back(template_pose);
-	templates_aln_.push_back(template_pose); // shallow copy
-	template_cst_fn_.push_back(cst_fn);
-	symmdef_files_.push_back(symm_file);
-	template_weights_.push_back(weight);
-	template_chunks_.push_back(chunks);
-	template_contigs_.push_back(contigs);
-	randomize_chains_.push_back(rand_chains);
-	should_align_pdb_infos_.push_back(align_pdb_info);
-
-	non_null_template_indices_.push_back( templates_.size() );
-}
-
-void HybridizeProtocol::update_template(core::Size const template_idx )
-{
-	core::pose::PoseOP const template_pose(templates_[template_idx]);
-
-	// add secondary structure information to the template pose
-	core::scoring::dssp::Dssp dssp_obj( *template_pose );
-	dssp_obj.insert_ss_into_pose( *template_pose );
-
-	// find ss chunks in template
-	protocols::loops::Loops const contigs = protocols::loops::extract_continuous_chunks(*template_pose);
-
-	protocols::loops::Loops chunks;
-	if ( include_loop_ss_chunks_ ) {
-		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
-	} else {
-		chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
-	}
-	if ( chunks.num_loop() == 0 ) chunks = contigs;
-
-	template_chunks_[template_idx] = chunks;
-	template_contigs_[template_idx] = contigs;
-}
-
-
-// validate input templates match input sequence
-// TO DO: if only sequences mismatch try realigning
-void HybridizeProtocol::validate_template(
-	std::string const & filename,
-	std::string const & fasta,
-	core::pose::PoseOP template_pose,
-	bool & align_pdb_info)
-{
-	core::Size nres_fasta = fasta.length(), nres_templ = template_pose->size();
-	core::Size next_ligand = nres_fasta+1; // ligands must be sequentially numbered
-
-	bool requires_alignment = false;
-	for ( core::Size i=1; i<=nres_templ; ++i ) {
-		char templ_aa = template_pose->residue(i).name1();
-		core::Size i_fasta = template_pose->pdb_info()->number(i);
-		bool is_ligand = !template_pose->residue(i).is_protein();
-
-		// ligands
-		if ( i_fasta > nres_fasta || is_ligand ) {
-			if ( !is_ligand ) {
-				TR.Error << "   Residue number " << i_fasta << " is outside of input fasta range." << std::endl;
-				requires_alignment = true;
-				break;
-			} else {
-				template_pose->pdb_info()->number(i,next_ligand);
-			}
-			next_ligand++;
-		} else {
-			char fasta_aa = fasta[i_fasta-1];
-			if ( fasta_aa != templ_aa ) {
-				TR.Error << "Sequence mismatch between input fasta and template " << filename
-					<< " at residue " << i_fasta << std::endl;
-				TR.Error << "   Expected: " << fasta_aa << "   Saw: " << templ_aa << std::endl;
-				if ( !align_pdb_info ) utility_exit_with_message("Issue validating template in HybridizeProtocol.");
-				requires_alignment = true;
-				break;
-			}
-		}
-	}
-	if ( requires_alignment ) {
-		TR.Error << "THE PDB INFO IS NOT IN SYNC WITH THE FASTA. ATTEMPTING TO RESOLVE THE ISSUE AUTOMATICALLY" << std::endl;
-		//this block code shouldn't be needed since hybrid needs asymmetric poses anyway but it doesn't hurt
-		core::pose::Pose pose_for_seq;
-		core::pose::symmetry::extract_asymmetric_unit(*template_pose, pose_for_seq, false);
-
-		core::sequence::SequenceOP full_length_seq( utility::pointer::make_shared< core::sequence::Sequence >( fasta, "target" ));
-		core::sequence::SequenceOP t_pdb_seq( utility::pointer::make_shared< core::sequence::Sequence >( pose_for_seq.sequence(), "pose_seq" ));
-		core::sequence::SWAligner sw_align;
-		core::sequence::ScoringSchemeOP ss(  utility::pointer::make_shared< core::sequence::SimpleScoringScheme >(120, 0, -100, 0));
-		core::sequence::SequenceAlignment fasta2template;
-
-		fasta2template = sw_align.align(full_length_seq, t_pdb_seq, ss);
-
-		TR << fasta2template << std::endl;
-
-		core::id::SequenceMapping sequencemap = fasta2template.sequence_mapping(1,2);
-		sequencemap.reverse();
-		core::Size ndel = 0;
-		core::Size counter = 1;
-		core::Size nres = template_pose->size();
-		for ( core::Size i=1; i<=nres; i++ ) {
-			if ( ! template_pose->residue(counter).is_protein() ) {
-				// will get fixed later
-				counter++;
-				continue;
-			}
-
-			core::Size pdbnumber = template_pose->pdb_info()->number(counter);
-			core::Size fastanumber = sequencemap[i];
-			if ( fastanumber == 0 ) { // extra residues in template
-				template_pose->delete_residue_range_slow( counter,counter );
-				ndel++;
-				continue;
-			}
-			if ( pdbnumber != fastanumber ) {
-				template_pose->pdb_info()->number(counter,fastanumber);
-			}
-			counter++;
-		}
-		if ( ndel > 0 ) {
-			TR.Error << "WARNING! Realignment removed " << ndel << " residues!" << std::endl;
-		}
-	} else {
-		align_pdb_info = false;
-	}
-}
-
-
-core::Size HybridizeProtocol::pick_starting_template( ) {
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
-
-	numeric::random::WeightedSampler weighted_sampler;
-	weighted_sampler.weights(template_weights_);
-	return weighted_sampler.random_sample(numeric::random::rg());
-}
-
-void HybridizeProtocol::domain_parse_templates(core::Size nres) {
-	if ( domains_all_templ_.size() == templates_.size() ) {
-		return;
-	}
-
-	DDomainParse ddom(pcut_,hcut_,length_);
-
-	domains_all_templ_.resize( templates_.size() );
-	for ( core::Size i_template=1; i_template<=templates_.size(); ++i_template ) {
-		if ( templates_[i_template]->size() < 3 ) {
-			continue;  // ???
-		}
-
-		domains_all_templ_[i_template] = ddom.split( *templates_[i_template] );
-
-		// convert domain numbering to target pose numbering
-		protocols::loops::Loops all_domains;
-		for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
-			for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
-				core::Size seqpos_start_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].start());
-
-				if ( seqpos_start_pose > nres ) continue; // sometimes dna can do this
-
-				domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
-
-				core::Size seqpos_stop_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].stop());
-				domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
-
-				all_domains.add_loop( seqpos_start_pose, seqpos_stop_pose );
-			}
-		}
-
-		// extend to cover full-length seq
-		// assumes no overlap in domain defs!
-		all_domains.sequential_order();
-		if ( all_domains.num_loop() == 0 ) continue;
-
-		std::map<core::Size,core::Size> remap_endpoints;
-		remap_endpoints [ all_domains[1].start() ] = 1;
-		remap_endpoints [ all_domains[all_domains.num_loop()].stop() ] = nres;
-		for ( core::Size iloops=2; iloops<=all_domains.size(); ++iloops ) {
-			core::Size start_i = (all_domains[iloops-1].stop() + all_domains[iloops].start() + 1)/2;
-			remap_endpoints [ all_domains[iloops-1].stop() ] = start_i-1;
-			remap_endpoints [ all_domains[iloops].start() ] = start_i;
-		}
-
-		for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
-			for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
-				core::Size seqpos_start_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].start() ];
-				domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
-
-				core::Size seqpos_stop_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].stop() ];
-				domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
-			}
-		}
-
-		TR << "Found " << domains_all_templ_[i_template].size() << " domains using template " << template_fns_[i_template] << std::endl;
-		for ( core::Size i=1; i<=domains_all_templ_[i_template].size(); ++i ) {
-			TR << "domain " << i << ": " << domains_all_templ_[i_template][i] << std::endl;
-		}
-	}
-}
-
-void
-HybridizeProtocol::setup_templates_and_sampling_options( core::pose::Pose const & pose ) {
-	std::string const & pose_sequence(pose.sequence());
-	if ( coord_cst_res_.size() ) {
-		user_csts_ = core::pose::get_resnum_list_ordered( coord_cst_res_, pose );
-	}
-	for ( core::Size i=1; i<=template_fns_.size(); ++i ) {
-		bool align_pdb_info = should_align_pdb_infos_[i];
-		validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
-
-		if ( align_pdb_info ) {
-			align_pdb_info = false;
-			validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
-			update_template(i);
-		}
-	}
-
-	core::Size const nres_nonvirt = get_num_residues_nonvirt(pose);
-	if ( detailed_controls_settings_.size() ) {
-		residue_sample_template_.resize(nres_nonvirt, true);
-		residue_sample_abinitio_.resize(nres_nonvirt, true);
-	}
-	for ( auto const & detailed_control_settings : detailed_controls_settings_ ) {
-		if ( detailed_control_settings.type_ == "task_operations" ) {
-			core::pack::task::PackerTaskOP task = detailed_control_settings.taskFactOP_->create_task_and_apply_taskoperations( pose );
-			for ( core::Size ires = 1; ires <= nres_nonvirt; ++ires ) {
-				if ( !task->residue_task( ires ).being_packed() ) {
-					residue_sample_template_[ires] = false;
-					residue_sample_abinitio_[ires] = false;
-				}
-			}
-		} else {
-			core::Size const stop_res(detailed_control_settings.stop_res_ == 0 ? nres_nonvirt : detailed_control_settings.stop_res_);
-			if ( detailed_control_settings.sample_template_ != sampleEnum::unset ) {
-				for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
-					residue_sample_template_[ires] = (detailed_control_settings.sample_template_ == sampleEnum::off ? false : true);
-				}
-			}
-			if ( detailed_control_settings.sample_abinitio_ != sampleEnum::unset ) {
-				for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
-					residue_sample_abinitio_[ires] = (detailed_control_settings.sample_abinitio_ == sampleEnum::off ? false : true);
-				}
-			}
-		}
-	}
-}
-
-void HybridizeProtocol::apply( core::pose::Pose & pose )
-{
-	using namespace protocols::moves;
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
-	using namespace core::pose::datacache;
-	using namespace core::io::silent;
-	using namespace ObjexxFCL::format;
-
-	if ( native_ == nullptr ) {
-		if ( native_needs_load_ ) {
-			native_ = utility::pointer::make_shared< core::pose::Pose >();
-			if ( option[in::file::fullatom]() ) {
-				core::import_pose::pose_from_file( *native_, option[ in::file::native ]() , core::import_pose::PDB_file);
-			} else {
-				core::chemical::ResidueTypeSetCOP residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
-				core::import_pose::pose_from_file( *native_, *residue_set, option[ in::file::native ]()  , core::import_pose::PDB_file);
-			}
-			native_needs_load_ = false;
-		} else if ( native_needs_load_from_align_rmsd_target_ ) {
-			native_ = utility::pointer::make_shared< core::pose::Pose >();
-			utility::vector1< std::string > const & align_rmsd_target( option[ evaluation::align_rmsd_target ]() );
-			core::import_pose::pose_from_file( *native_, align_rmsd_target[1] , core::import_pose::PDB_file); // just use the first one for now
-			native_needs_load_from_align_rmsd_target_ = false;
-		}
-	}
-
-	setup_templates_and_sampling_options(pose);
-
-	// number of residues in asu without VRTs
-	core::Size nres_tgt = pose.size();
-	core::Size nres_protein_tgt = pose.size();
-	core::conformation::symmetry::SymmetryInfoCOP symm_info;
-	if ( core::pose::symmetry::is_symmetric(pose) ) {
-		auto & SymmConf (
-			dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
-		symm_info = SymmConf.Symmetry_Info();
-		nres_tgt = symm_info->num_independent_residues();
-		nres_protein_tgt = symm_info->num_independent_residues();
-	}
-	if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
-	while ( !pose.residue(nres_protein_tgt).is_protein() ) nres_protein_tgt--;
-
-	//save necessary constraint in pose
-	core::scoring::constraints::ConstraintSetOP save_pose_constraint_set( utility::pointer::make_shared< core::scoring::constraints::ConstraintSet >() ) ;
-	if ( keep_pose_constraint_ ) {
-		save_pose_constraint_set = pose.constraint_set()->clone();
-		core::scoring::constraints::remove_nonbb_constraints(pose);
-	}
-
-	if ( pose.is_fullatom() ) {
-		protocols::moves::MoverOP tocen( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::CENTROID ) );
-		tocen->apply(pose);
-	}
-
-	// make fragments if we don't have them at this point
-	check_and_create_fragments( pose );
-
-	// domain parse templates if we do not have domain definitions
-	domain_parse_templates(nres_tgt);
-
-	// select random fragment sets if >2 are provided
-	core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
-	core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
-	TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
-	TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
-
-	// starting structure pool (for batch relax)
-	std::vector < SilentStructOP > post_centroid_structs;
-	bool need_more_samples = true;
-
-	// main centroid generation loop
-	core::Real gdtmm = 0.0;
-	if ( stage2_scorefxn_ == nullptr ) {
-		utility_exit_with_message("Stage 2 Scorefxn must be set!!!");
-	}
-
-	while ( need_more_samples ) {
-		need_more_samples = false;
-
-		// pick starting template
-		core::Size initial_template_index = pick_starting_template();
-		TR << "Using initial template: " << I(4,initial_template_index) << " " << template_fns_[initial_template_index] << std::endl;
-
-		// ensure
-		//    1)that no CONTIGS cross multiple CHAINS
-		//    2)that every input CHAIN has a chunk in it
-		// if not, add the corresponding contig as a chunk
-		utility::vector1< int > cuts = pose.fold_tree().cutpoints();
-		protocols::loops::Loops const &contigs_old = template_contigs_[initial_template_index];
-		protocols::loops::Loops contigs_new;
-		for ( core::Size j=1; j<=contigs_old.num_loop(); ++j ) {
-			protocols::loops::Loop contig_j = contigs_old[j];
-
-			for ( core::Size i=1; i<=cuts.size(); ++i ) {
-				int nextcut = cuts[i];
-				if ( nextcut > (int)nres_protein_tgt ) break;
-
-				core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
-				core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
-
-				if ( (int)start <= nextcut && (int)stop > nextcut ) {
-					// find template res corresponding to cut
-					for ( core::Size k=contig_j.start(); k<=contig_j.stop(); ++k ) {
-						if ( templates_[initial_template_index]->pdb_info()->number(k) == nextcut ) {
-							// ensure contig >= 3 res
-							if ( k > contig_j.start()+1 ) {
-								contigs_new.push_back( protocols::loops::Loop(contig_j.start(), k) );
-							}
-							TR << "Split contig ("<<contig_j.start()<<","<<contig_j.stop()<< ") at " << k << " [pdbnum: "<<start<<"/"<<stop<<"/" << nextcut << "]" << std::endl;
-							contig_j.set_start( k+1 );
-						}
-					}
-
-				}
-			}
-			// ensure contig >= 3 res
-			if ( contig_j.stop() > contig_j.start()+1 ) {
-				contigs_new.push_back( contig_j );
-			}
-		}
-		template_contigs_[initial_template_index] = contigs_new;
-
-		protocols::loops::Loops &chunks = template_chunks_[initial_template_index];
-		for ( core::Size i=0; i<=cuts.size(); ++i ) {
-			int prevcut = (i==0) ? 1 : cuts[i];
-			int nextcut = (i==cuts.size()) ? nres_protein_tgt : cuts[i+1];
-			if ( nextcut > (int)nres_protein_tgt ) break;
-			bool haschunk = false;
-			for ( core::Size j=1; j<=chunks.num_loop() && !haschunk; ++j ) {
-				protocols::loops::Loop const &chunk_j = chunks[j];
-				core::Size start = templates_[initial_template_index]->pdb_info()->number(chunk_j.start());
-				core::Size stop  = templates_[initial_template_index]->pdb_info()->number(chunk_j.stop());
-				if ( (int)start > prevcut && (int)stop <= nextcut ) haschunk=true;
-			}
-
-			if ( ! haschunk ) {
-				TR << "Segment ("<<prevcut<<","<<nextcut<<") has no chunks!  Adding contigs!" << std::endl;
-				bool hascontig=false;
-				for ( core::Size j=1; j<=contigs_new.num_loop(); ++j ) {
-					protocols::loops::Loop const &contig_j = contigs_new[j];
-					core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
-					core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
-					if ( (int)start > prevcut && (int)stop <= nextcut ) {
-						hascontig = true;
-						chunks.push_back( contig_j );
-					}
-				}
-				if ( !hascontig ) {
-					TR << "Warning!  No contigs found for segment!" << std::endl;
-					TR << "If you are not using the 'randomize=X' option there is likely something wrong with your input and models will not be reasonable!" << std::endl;
-				}
-			}
-		}
-
-		// (0) randomize chains
-		if ( randomize_chains_[initial_template_index].size() > 0 ) {
-			runtime_assert ( templates_[initial_template_index]->pdb_info() );
-			numeric::xyzVector< core::Real > comFixed(0,0,0), comMoving(0,0,0);
-			core::Real nFixed=0, nMoving=0;
-
-			TR << "Randomize >" << randomize_chains_[initial_template_index].size() << "<" << std::endl;
-			for ( core::Size q=1; q<=randomize_chains_[initial_template_index].size(); ++q ) {
-				TR << "Randomize >" << randomize_chains_[initial_template_index][q] << "<" << std::endl;
-			}
-
-			for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
-				char chain = templates_[initial_template_index]->pdb_info()->chain(i);
-				if ( std::find(
-						randomize_chains_[initial_template_index].begin(),
-						randomize_chains_[initial_template_index].end(),
-						chain) != randomize_chains_[initial_template_index].end()
-						) {
-					comMoving += templates_[initial_template_index]->residue(i).xyz(2);
-					nMoving++;
-				} else {
-					comFixed += templates_[initial_template_index]->residue(i).xyz(2);
-					nFixed++;
-				}
-			}
-
-			// sanity check
-			if ( nMoving == 0 ) {
-				utility_exit_with_message("Randomize chain enabled but chain(s) not found!");
-			}
-
-			comMoving /= nMoving;
-			comFixed /= nFixed;
-
-			// randomize orientation
-			numeric::xyzMatrix< core::Real > R = protocols::geometry::random_reorientation_matrix( 360, 360 );
-
-			// randomize offset
-			numeric::xyzVector< core::Real > T = numeric::random::random_point_on_unit_sphere< core::Real >( numeric::random::rg() );
-
-			// perturb & slide into contact
-			bool done=false, compacting=false;
-			core::Real DIST = 100.0;
-			core::scoring::ScoreFunction sf_vdw;
-			core::Real vdw_score = -1.0, step_size = -2.0, min_step_size = 0.25;
-			sf_vdw.set_weight( core::scoring::vdw, 1.0 );
-			core::pose::Pose template_orig = *(templates_[initial_template_index]);
-			while ( !done && DIST > 0 ) {
-				utility::vector1< id::AtomID > atm_ids;
-				utility::vector1< numeric::xyzVector< core::Real> > atm_xyzs;
-
-				for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
-					core::conformation::Residue const & rsd_i = template_orig.residue(i);
-					char chain = templates_[initial_template_index]->pdb_info()->chain(i);
-					if ( std::find(
-							randomize_chains_[initial_template_index].begin(),
-							randomize_chains_[initial_template_index].end(),
-							chain) != randomize_chains_[initial_template_index].end()
-							) {
-						for ( core::Size j = 1; j <= rsd_i.natoms(); ++j ) {
-							id::AtomID id( j,i );
-							atm_ids.push_back( id );
-							numeric::xyzVector< core::Real > new_ij = R*(rsd_i.xyz(j) - comMoving) + comFixed + DIST * T;
-							atm_xyzs.push_back( new_ij );
-						}
-					}
-				}
-				templates_[initial_template_index]->batch_set_xyz( atm_ids, atm_xyzs );
-				core::Real score_d = sf_vdw( *(templates_[initial_template_index]) );
-				if ( vdw_score < 0 ) vdw_score = score_d;
-
-				if ( !compacting && score_d > vdw_score + 2.0 ) {
-					compacting = true;
-					step_size = min_step_size;
-				} else if ( compacting  && vdw_score <= score_d + 2.0 ) {
-					done = true;
+		// sets default options
+		void
+			HybridizeProtocol::init() {
+				using namespace basic::options;
+				using namespace basic::options::OptionKeys;
+
+				stage1_probability_ = option[cm::hybridize::stage1_probability]();
+				stage1_increase_cycles_ = option[cm::hybridize::stage1_increase_cycles]();
+				stage1_1_cycles_ = option[cm::hybridize::stage1_1_cycles]();
+				stage1_2_cycles_ = option[cm::hybridize::stage1_2_cycles]();
+				stage1_3_cycles_ = option[cm::hybridize::stage1_3_cycles]();
+				stage1_4_cycles_ = option[cm::hybridize::stage1_4_cycles]();
+				stage2_temperature_ = option[cm::hybridize::stage2_temperature]();
+				add_hetatm_ = false;
+				realign_domains_ = option[cm::hybridize::realign_domains]();
+				realign_domains_stage2_ = option[cm::hybridize::realign_domains_stage2]();
+				add_non_init_chunks_ = option[cm::hybridize::add_non_init_chunks]();
+				frag_weight_aligned_ = option[cm::hybridize::frag_weight_aligned]();
+				auto_frag_insertion_weight_ = option[cm::hybridize::auto_frag_insertion_weight]();
+				max_registry_shift_ = option[cm::hybridize::max_registry_shift]();
+				frag_1mer_insertion_weight_ = option[cm::hybridize::frag_1mer_insertion_weight]();
+				small_frag_insertion_weight_ = option[cm::hybridize::small_frag_insertion_weight]();
+				big_frag_insertion_weight_ = option[cm::hybridize::big_frag_insertion_weight]();
+				chunk_insertion_weight_ = 1.;
+				hetatm_self_cst_weight_ = 10.;
+				hetatm_prot_cst_weight_ = 0.;
+				cartfrag_overlap_ = 2;
+				seqfrags_only_ = false;
+				skip_long_min_ = true;   //fpd  this is no longer necessary and seems to hurt model accuracy
+				keep_pose_constraint_ = false;   //fpd PLEASE INITIALIZE NEW VARIABLES
+
+				include_loop_ss_chunks_ = option[cm::hybridize::include_loop_ss_chunks]();
+
+				cenrot_ = option[corrections::score::cenrot]();
+
+				csts_from_frags_ = false;  // generate dihedral constraints from fragments
+				max_contig_insertion_ = 0;  // don't insert contigs larger than this size (0 ==> don't limit)
+				min_after_stage1_ = false;   // tors min after stage1
+				fragprob_stage2_ = 0.3;  // ratio of fragment vs. template moves
+				randfragprob_stage2_ = 0.5; // given a fragmove, how often is it applied to a random position (as opposed to a chainbreak position)
+
+
+				// domain parsing options
+				hcut_ = 0.18;
+				pcut_ = 0.81;
+				length_ = 38;
+
+
+				jump_move_ = false;
+				jump_move_repeat_ = 1;
+
+				stage2_increase_cycles_ = option[cm::hybridize::stage2_increase_cycles]();
+				stage25_increase_cycles_ = option[cm::hybridize::stage2min_increase_cycles]();
+				no_global_frame_ = option[cm::hybridize::no_global_frame]();
+				linmin_only_ = option[cm::hybridize::linmin_only]();
+
+				// default scorefunctions
+				//    stage2 scorefunctions are initialized in CartesianHybridize
+				stage1_scorefxn_ = core::scoring::ScoreFunctionFactory::create_score_function( "score3" );
+				fa_scorefxn_ = core::scoring::get_score_function();
+
+				core::scoring::constraints::add_fa_constraints_from_cmdline_to_scorefxn( *fa_scorefxn_ );
+
+
+				if ( option[ OptionKeys::constraints::cst_fa_file ].user() ) {
+					utility::vector1< std::string > cst_files = option[ OptionKeys::constraints::cst_fa_file ]();
+					auto choice = core::Size( numeric::random::rg().random_range( 1, cst_files.size() ) );
+					fa_cst_fn_ = cst_files[choice];
+					TR.Info << "Fullatom Constraint choice: " << fa_cst_fn_ << std::endl;
 				}
 
-				TR << "D=" << DIST << " score=" << score_d << std::endl;
+				batch_relax_ = option[ cm::hybridize::relax ]();
+				relax_repeats_ = option[ basic::options::OptionKeys::relax::default_repeats ]();
 
-				DIST += step_size;
-			}
-		}
-
-		// (1) steal hetatms from template
-		utility::vector1< std::pair< core::Size,core::Size > > hetatms;
-		if ( add_hetatm_ ) {
-			for ( core::Size ires=1; ires <= templates_[initial_template_index]->size(); ++ires ) {
-				if ( templates_[initial_template_index]->pdb_info()->number(ires) > (int)nres_tgt ) {
-					TR.Debug << "Insert hetero residue: " << templates_[initial_template_index]->residue(ires).name3() << std::endl;
-					if ( templates_[initial_template_index]->residue(ires).is_polymer()
-							&& !templates_[initial_template_index]->residue(ires).is_lower_terminus()
-							&& !pose.residue(pose.size()).is_upper_terminus() ) {
-						pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires));
-					} else {
-						pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
-					}
-					hetatms.push_back( std::make_pair( ires, pose.size() ) );
+				// disulfide file
+				if ( option[ in::fix_disulf ].user() ) {
+					disulf_file_ = option[ in::fix_disulf ]();
 				}
-			}
-			pose.conformation().chains_from_termini();
-		}
 
-		// (2) realign structures per-domain
-		if ( realign_domains_ ) {
-			//
-			if ( std::find( non_null_template_indices_.begin(), non_null_template_indices_.end(), initial_template_index )
-					!= non_null_template_indices_.end() ) {
-				align_templates_by_domain(templates_[initial_template_index], domains_all_templ_[initial_template_index]);
-			} else {
-				if ( non_null_template_indices_.size() == 0 ) {
-					TR << "No non-extended templates.  Skipping alignment." << std::endl;
-				} else {
-					TR << "Cannot align to extended template! Choosing a random template instead." << std::endl;
-					core::Size aln_target = numeric::random::random_range(1, non_null_template_indices_.size() );
-					align_templates_by_domain(templates_[aln_target], domains_all_templ_[aln_target]);
+				// read fragments
+				if ( option[ in::file::frag9 ].user() ) {
+					using namespace core::fragment;
+					FragSetOP frags = FragmentIO().read_data( option[ in::file::frag9 ]() );
+					fragments_big_.push_back(frags);
 				}
-			}
-		}
-
-		// (3) apply symmetry
-		std::string symmdef_file = symmdef_files_[initial_template_index];
-		if ( !symmdef_file.empty() && symmdef_file != "NULL" ) {
-			protocols::symmetry::SetupForSymmetryMover makeSymm( symmdef_file );
-			makeSymm.apply(pose);
-
-			//fpd   to get the right rotamer set we need to do this
-			basic::options::option[basic::options::OptionKeys::symmetry::symmetry_definition].value( "dummy" );
-
-			// xyz copy hetatms (properly handle cases where scoring subunit is not the first)
-			if ( add_hetatm_ ) {
-				for ( core::Size ihet=1; ihet <= hetatms.size(); ++ihet ) {
-					core::conformation::Residue const &res_in = templates_[initial_template_index]->residue(hetatms[ihet].first);
-					for ( core::Size iatm=1; iatm<=res_in.natoms(); ++iatm ) {
-						core::id::AtomID tgt(iatm,hetatms[ihet].second);
-						pose.set_xyz( tgt, res_in.xyz( iatm ) );
-					}
+				if ( option[ in::file::frag3 ].user() ) {
+					using namespace core::fragment;
+					FragSetOP frags = FragmentIO().read_data( option[ in::file::frag3 ]() );
+					fragments_small_.push_back(frags);
 				}
-			}
-		}
 
-		// (4) add a virtual if we have a map or coord csts
-		//     keep after symm
-		//     should we check if a map is loaded (or density scoring is on) instead??
-		if ( option[ OptionKeys::edensity::mapfile ].user() || user_csts_.size() > 0 ) {
-			MoverOP dens( utility::pointer::make_shared< protocols::electron_density::SetupForDensityScoringMover >() );
-			dens->apply( pose );
-		}
-
-		// (5) initialize template history
-		//     keep after symm
-		TemplateHistoryOP history( utility::pointer::make_shared< TemplateHistory >(pose) );
-		history->setall( initial_template_index );
-		pose.data().set( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY, history );
-
-		// (6) allowed movement
-		utility::vector1<bool> allowed_to_move;
-		allowed_to_move.resize(pose.size(),true);
-		for ( int i=1; i<=(int)residue_sample_template_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_template_[i];
-		for ( int i=1; i<=(int)residue_sample_abinitio_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_abinitio_[i];
-
-		// STAGE 1
-		//fpd constraints are handled a little bit weird
-		//  * foldtree hybridize sets chainbreak variants then applies constraints (so c-beta csts are treated properly)
-		//  * after chainbreak variants are removed, csts are removed and reapplied in this function
-		//  * finally after switch to fullatom CSTs are reapplied again (optionally using a different CST file)
-		// If "AUTO" is specified for cen_csts automatic centroid csts are generated
-		// If "AUTO" is specified for fa_csts automatic fa csts are generated
-		// If "NONE" is specified for fa_csts, cen csts are used (AUTO or otherwise)
-		// An empty string is treated as equivalent to "NONE"
-
-		// fold tree hybridize
-		if ( numeric::random::rg().uniform() < stage1_probability_ ) {
-
-			for ( core::Size repeatstage1=0; repeatstage1 < jump_move_repeat_; ++repeatstage1 ) {
-
-				std::string cst_fn = template_cst_fn_[initial_template_index];
-
-				FoldTreeHybridizeOP ft_hybridize(
-					utility::pointer::make_shared< FoldTreeHybridize >(
-					initial_template_index, templates_aln_, template_weights_,
-					template_chunks_, frags_small, frags_big) ) ;
-
-				ft_hybridize->set_constraint_file( cst_fn );
-				ft_hybridize->set_constraint( cen_cst_in_ );
-				ft_hybridize->set_scorefunction( stage1_scorefxn_ );
-
-				// options
-				ft_hybridize->set_increase_cycles( stage1_increase_cycles_ );
-				ft_hybridize->set_stage1_1_cycles( stage1_1_cycles_ );
-				ft_hybridize->set_stage1_2_cycles( stage1_2_cycles_ );
-				ft_hybridize->set_stage1_3_cycles( stage1_3_cycles_ );
-				ft_hybridize->set_stage1_4_cycles( stage1_4_cycles_ );
-				ft_hybridize->set_add_non_init_chunks( add_non_init_chunks_ );
-				ft_hybridize->set_add_hetatm( add_hetatm_, hetatm_self_cst_weight_, hetatm_prot_cst_weight_ );
-				ft_hybridize->set_frag_1mer_insertion_weight( frag_1mer_insertion_weight_ );
-				ft_hybridize->set_small_frag_insertion_weight( small_frag_insertion_weight_ );
-				ft_hybridize->set_big_frag_insertion_weight( big_frag_insertion_weight_ );
-				ft_hybridize->set_chunk_insertion_weight( chunk_insertion_weight_ );
-				ft_hybridize->set_frag_weight_aligned( frag_weight_aligned_ );
-				ft_hybridize->set_auto_frag_insertion_weight( auto_frag_insertion_weight_ );
-				ft_hybridize->set_max_registry_shift( max_registry_shift_ );
+				// native
+				if ( option[ in::file::native ].user() ) {
+					native_needs_load_ = true;
+				} else if ( option[ evaluation::align_rmsd_target ].user() ) {
+					native_needs_load_from_align_rmsd_target_ = true;
+				}
 
 				// strand pairings
-				ft_hybridize->set_pairings_file( pairings_file_ );
-				ft_hybridize->set_sheets( sheets_ );
-				ft_hybridize->set_random_sheets( random_sheets_ );
-				ft_hybridize->set_filter_templates( filter_templates_ );
-
-				// allowed movement
-				ft_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
-				ft_hybridize->set_minimize_at_end( min_after_stage1_ );
-				ft_hybridize->set_minimize_sf( stage2_scorefxn_ );
-
-				// max insertion
-				ft_hybridize->set_max_insertion( max_contig_insertion_ );
-
-				// other cst stuff
-				ft_hybridize->set_user_csts( user_csts_ );
-
-				// finally run stage 1
-				ft_hybridize->apply(pose);
-
-				// get strand pairings if they exist for constraints in later stages
-				strand_pairs_ = ft_hybridize->get_strand_pairs();
-
-				//jump perturbation and minimization
-				//fpd!  these docking moves should be incorporated as part of stage 1!
-				if ( jump_move_ ) {
-					do_intrastage_docking( pose );
-				}
-			} //end of repeatstage1
-
-		} else {
-			// just do frag insertion in unaligned regions
-			core::pose::PoseOP chosen_templ = templates_aln_[initial_template_index];
-			protocols::loops::Loops chosen_contigs = template_contigs_[initial_template_index];
-			initialize_and_sample_loops(pose, chosen_templ, chosen_contigs, stage1_scorefxn_);
-		}
-
-		// realign domains to the output of stage 1
-		if ( jump_move_ || realign_domains_stage2_ ) {
-			TR << "Realigning template domains to stage1 pose." << std::endl;
-			core::pose::PoseOP stage1pose( utility::pointer::make_shared< core::pose::Pose >( pose ) );
-			align_templates_by_domain(stage1pose); // don't use stored domains; recompute parse from model
-		}
-
-		//write gdtmm to output
-		if ( native_ && native_->size() ) {
-			gdtmm = get_gdtmm(*native_, pose, aln_);
-			core::pose::setPoseExtraScore( pose, "GDTMM_after_stage1", gdtmm);
-			TR << "GDTMM_after_stage1" << F(8,3,gdtmm) << std::endl;
-		}
-
-		// STAGE 2
-		// apply constraints
-		if ( stage2_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
-			std::string cst_fn = template_cst_fn_[initial_template_index];
-			if ( !keep_pose_constraint_ ) {
-				if ( ! cen_cst_in_.empty() ) {
-					setup_constraints(pose, cen_cst_in_);
+				pairings_file_ = option[jumps::pairing_file]();
+				if ( option[jumps::sheets].user() ) {
+					sheets_ = option[jumps::sheets]();
 				} else {
-					setup_centroid_constraints( pose, templates_aln_, template_weights_, cst_fn );
+					random_sheets_ = option[jumps::random_sheets]();
 				}
+				filter_templates_ = option[jumps::filter_templates]();
 			}
-			if ( add_hetatm_ ) {
-				add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
-			}
-			if ( strand_pairs_.size() ) {
-				add_strand_pairs_cst(pose, strand_pairs_);
-			}
-		}
 
-		// add torsion constraints derived from fragments
-		if ( csts_from_frags_ ) {
-			if ( stage2_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
-				add_fragment_csts( pose );
-			} else {
-				TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
-			}
-		}
+		void
+			HybridizeProtocol::check_and_create_fragments( core::pose::Pose & pose ) {
+				if ( fragments_big_.size() > 0 && fragments_small_.size() > 0 ) return;
 
-		if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
-			if ( user_csts_.size() > 0 ) {
-				setup_user_coordinate_constraints(pose,user_csts_);
-			}
-		}
+				core::Size fragbiglen=9;
 
-		if ( !option[cm::hybridize::skip_stage2]() ) {
-			core::scoring::ScoreFunctionOP stage2_scorefxn_clone = stage2_scorefxn_->clone();
-
-			core::scoring::methods::EnergyMethodOptions lowres_options(stage2_scorefxn_clone->energy_method_options());
-			lowres_options.set_cartesian_bonded_linear(true);
-			stage2_scorefxn_clone->set_energy_method_options(lowres_options);
-
-			CartesianHybridizeOP cart_hybridize(
-				utility::pointer::make_shared< CartesianHybridize >( templates_aln_, template_weights_, template_chunks_,template_contigs_, frags_big ) );
-
-			// default scorefunctions (cenrot-compatable)
-			if ( stage2_scorefxn_!=nullptr ) cart_hybridize->set_scorefunction( stage2_scorefxn_ );
-			if ( stage2pack_scorefxn_!=nullptr ) cart_hybridize->set_pack_scorefunction( stage2pack_scorefxn_ );
-			if ( stage2min_scorefxn_!=nullptr ) cart_hybridize->set_min_scorefunction( stage2min_scorefxn_ );
-
-			// set options
-			cart_hybridize->set_increase_cycles( stage2_increase_cycles_ );
-			cart_hybridize->set_no_global_frame( no_global_frame_ );
-			cart_hybridize->set_linmin_only( linmin_only_ );
-			cart_hybridize->set_seqfrags_only( seqfrags_only_ );
-			cart_hybridize->set_cartfrag_overlap( cartfrag_overlap_ );
-			cart_hybridize->set_skip_long_min( skip_long_min_ );
-			cart_hybridize->set_cenrot( cenrot_ );
-			cart_hybridize->set_fragment_probs(fragprob_stage2_, randfragprob_stage2_);
-
-			// max insertion
-			cart_hybridize->set_max_insertion( max_contig_insertion_ );
-
-			// per-residue controls
-			cart_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
-
-			// finally run stage 2
-			cart_hybridize->apply(pose);
-		}
-
-		//write gdtmm to output
-		if ( native_ && native_->size() ) {
-			gdtmm = get_gdtmm(*native_, pose, aln_);
-			core::pose::setPoseExtraScore( pose, "GDTMM_after_stage2", gdtmm);
-			TR << "GDTMM_after_stage2" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
-		}
-		// get fragment history
-		runtime_assert( pose.data().has( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
-		history = utility::pointer::static_pointer_cast< TemplateHistory >( pose.data().get_ptr( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
-
-		TR << "History :";
-		for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4,i); }
-		TR << std::endl;
-		TR << "History :";
-		for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4, history->get(i)); }
-		TR << std::endl;
-
-		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-		mm->set_bb  ( true );
-		mm->set_chi ( true );
-		mm->set_jump( true );
-
-		//fpd -- in positions where no fragment insertions are allowed, also allow no minimization
-		if ( residue_sample_template_.size() > 0 && residue_sample_abinitio_.size() > 0 ) {
-			for ( int i=1; i<=(int)nres_tgt; ++i ) {
-				if ( !residue_sample_template_[i] && !residue_sample_abinitio_[i] ) {
-					TR.Trace << "locking residue " << i << std::endl;
-					mm->set_bb  ( i, false );
-					mm->set_chi ( i, false );
-				}
-			}
-		}
-
-		if ( core::pose::symmetry::is_symmetric(pose) ) {
-			core::pose::symmetry::make_symmetric_movemap( pose, *mm );
-		}
-
-		// stage "2.5" .. minimize with centroid energy + full-strength cart bonded
-		if ( !option[cm::hybridize::skip_stage2]() ) {
-			core::optimization::MinimizerOptions options_lbfgs( "lbfgs_armijo_nonmonotone", 0.01, true, false, false );
-			core::optimization::CartesianMinimizer minimizer;
-			auto n_min_cycles =(core::Size) (200.*stage25_increase_cycles_);
-			options_lbfgs.max_iter(n_min_cycles);
-			(*stage2_scorefxn_)(pose); minimizer.run( pose, *mm, *stage2_scorefxn_, options_lbfgs );
-		}
-
-		// STAGE 3: RELAX
-		if ( batch_relax_ > 0 ) {
-			// set disulfides before going to FA
-			if ( disulf_file_.length() > 0 ) {
-				// delete current disulfides
-				for ( int i=1; i<=(int)pose.size(); ++i ) {
-					if ( !pose.residue(i).is_protein() ) continue;
-					if ( pose.residue(i).type().is_disulfide_bonded() ) {
-						core::conformation::change_cys_state( i, "CYS", pose.conformation() );
+				if ( !fragments_big_.size() ) {
+					// number of residues
+					core::Size nres_tgt = pose.size();
+					core::conformation::symmetry::SymmetryInfoCOP symm_info;
+					if ( core::pose::symmetry::is_symmetric(pose) ) {
+						auto & SymmConf (
+								dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+						symm_info = SymmConf.Symmetry_Info();
+						nres_tgt = symm_info->num_independent_residues();
 					}
-				}
+					if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+					while ( !pose.residue(nres_tgt).is_protein() ) nres_tgt--;
 
-				// manually add new ones
-				TR << " add disulfide: " << std::endl;
-				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].value(disulf_file_);
-				core::pose::initialize_disulfide_bonds(pose);
-				// must reset this since initialize_disulfide_bonds is used in pose io
-				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].deactivate();
-				basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].to_default(); // reset to the default value
-			} else {
-				pose.conformation().detect_disulfides();
-			}
+					fragbiglen = std::min( fragbiglen, nres_tgt );
 
-			protocols::moves::MoverOP tofa( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::FA_STANDARD ) );
-			tofa->apply(pose);
+					core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >() );
 
-			// apply fa constraints
-			std::string cst_fn = template_cst_fn_[initial_template_index];
-			if ( fa_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
-				if ( !keep_pose_constraint_ ) {
-					if ( ! fa_cst_in_.empty() ) {
-						setup_constraints(pose, fa_cst_in_);
+					// sequence
+					std::string tgt_seq = pose.sequence();
+					std::string tgt_ss(nres_tgt, '0');
+
+					using namespace basic::options;
+					using namespace basic::options::OptionKeys;
+					if ( option[ OptionKeys::in::file::psipred_ss2 ].user() ) {
+						utility::vector1< char > psipred = read_psipred_ss2_file( pose );
+						for ( core::Size j=1; j<=nres_tgt; ++j ) {
+							tgt_ss[j-1] = psipred[j];
+						}
 					} else {
-						setup_fullatom_constraints( pose, templates_aln_, template_weights_, cst_fn, fa_cst_fn_ );
+						// templates vote on secstruct
+						for ( core::Size i=1; i<=templates_.size(); ++i ) {
+							for ( core::Size j=1; j<=templates_[i]->size(); ++j ) {
+								if ( !templates_[i]->residue(j).is_protein() ) continue;
+								core::Size tgt_pos = templates_[i]->pdb_info()->number(j);
+
+								runtime_assert( tgt_pos<=nres_tgt );
+								char tgt_ss_j = templates_[i]->secstruct(j);
+
+								if ( tgt_ss[tgt_pos-1] == '0' ) {
+									tgt_ss[tgt_pos-1] = tgt_ss_j;
+								} else if ( tgt_ss[tgt_pos-1] != tgt_ss_j ) {
+									tgt_ss[tgt_pos-1] = 'D'; // templates disagree
+								}
+							}
+						}
+						for ( core::Size j=1; j<=nres_tgt; ++j ) {
+							if ( tgt_ss[j-1] == '0' ) tgt_ss[j-1] = 'D';
+						}
 					}
-				} else {
-					pose.constraint_set(save_pose_constraint_set);
+
+					// pick from vall based on template SS + target sequence
+					for ( core::Size j=1; j<=nres_tgt-fragbiglen+1; ++j ) {
+						core::fragment::FrameOP frame( utility::pointer::make_shared< core::fragment::Frame >(j, fragbiglen) );
+
+						if ( j > residue_sample_abinitio_.size() || residue_sample_abinitio_[j] ) {
+							frame->add_fragment(
+									core::fragment::picking_old::vall::pick_fragments_by_ss_plus_aa(
+										tgt_ss.substr( j-1, fragbiglen ), tgt_seq.substr( j-1, fragbiglen ), 25, true, core::fragment::IndependentBBTorsionSRFD() ) );
+							frags->add( frame );
+						}
+					}
+					fragments_big_.push_back( frags );
 				}
+				if ( !fragments_small_.size() ) {
+					core::fragment::FragSetOP frags( utility::pointer::make_shared< core::fragment::ConstantLengthFragSet >(3) );
+
+					// make them from big fragments
+					core::fragment::chop_fragments( *fragments_big_[1], *frags );
+					fragments_small_.push_back( frags );
+				}
+			}
+
+		//fpd add fragment-derived constraints
+		void
+			HybridizeProtocol::add_fragment_csts( core::pose::Pose &pose ) {
+				TR << "Adding fragment constraints" << std::endl;
+
+				core::fragment::FragSetOP frags = fragments_small_[1];
+
+				// stolen from SecondaryStructure.cc
+				if ( frags->global_offset() != 0 ) {
+					TR.Error << "SecondaryStructure computations must be carried out with local coordinates (global offset of fragments must be 0)." << std::endl;
+					TR.Error << "   value of global offset of fragments: " << frags->global_offset() << std::endl;
+					utility_exit_with_message("SecondaryStructure computations not in local coordinates!");
+				}
+
+				// 1 - collect fragment statistics
+				core::Size frag_nres = frags->max_pos();
+				utility::vector1< utility::vector1< core::Real > > phi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
+				utility::vector1< utility::vector1< core::Real > > psi_distr( frag_nres, utility::vector1< core::Real >(36,0.0) );
+				utility::vector1< int > N( frag_nres, 0 );
+
+				for ( core::fragment::FragID_Iterator it=frags->begin(), eit=frags->end(); it!=eit; ++it ) { //carefully checked that I don't change FrameData
+					core::Size loop_start = 1;
+					core::Size loop_end = it->frame().length();
+					for ( core::Size fpos = loop_start; fpos <= loop_end; ++fpos ) {
+						core::fragment::BBTorsionSRFDCOP res_i =
+							utility::pointer::dynamic_pointer_cast<const core::fragment::BBTorsionSRFD> (it->fragment().get_residue( fpos ) );
+
+						core::Size pos = it->frame().seqpos( fpos );
+						core::Real phi = std::fmod( res_i->torsion(1), 360.0 ); if ( phi<0 ) phi +=360.0;
+						core::Real psi = std::fmod( res_i->torsion(2), 360.0 ); if ( psi<0 ) psi +=360.0;
+
+						auto phibin = (core::Size) std::floor( phi/10.0 ); if ( phibin == 36 ) phibin=0;
+						auto psibin = (core::Size) std::floor( psi/10.0 ); if ( psibin == 36 ) psibin=0;
+
+						phi_distr[pos][phibin+1]+=1.0;
+						psi_distr[pos][psibin+1]+=1.0;
+						N[pos]++;
+					}
+				}
+
+				// smoothing
+				//core::Real smoothing[7] = {0.09, 0.14, 0.175, 0.19, 0.175, 0.14, 0.09};  // very soft
+				core::Real smoothing[7] = {0.01, 0.05, 0.24, 0.40, 0.24, 0.05, 0.01}; // less soft
+				for ( int i=1; i<=(int)frag_nres; ++i ) {
+					utility::vector1< core::Real > phi_i = phi_distr[i];
+					utility::vector1< core::Real > psi_i = psi_distr[i];
+					for ( int j=1; j<=36; ++j ) {
+						phi_distr[i][j] = smoothing[0]*phi_i[1+((j+32)%36)]
+							+ smoothing[1]*phi_i[1+((j+33)%36)]
+							+ smoothing[2]*phi_i[1+((j+34)%36)]
+							+ smoothing[3]*phi_i[1+((j+35)%36)]
+							+ smoothing[4]*phi_i[1+((j+0)%36)]
+							+ smoothing[5]*phi_i[1+((j+1)%36)]
+							+ smoothing[6]*phi_i[1+((j+2)%36)];
+
+						psi_distr[i][j] = smoothing[0]*psi_i[1+((j+32)%36)]
+							+ smoothing[1]*psi_i[1+((j+33)%36)]
+							+ smoothing[2]*psi_i[1+((j+34)%36)]
+							+ smoothing[3]*psi_i[1+((j+35)%36)]
+							+ smoothing[4]*psi_i[1+((j+0)%36)]
+							+ smoothing[5]*psi_i[1+((j+1)%36)]
+							+ smoothing[6]*psi_i[1+((j+2)%36)];
+
+						phi_distr[i][j] /= N[i];
+						psi_distr[i][j] /= N[i];
+					}
+				}
+
+				// convert to energy
+				core::Real mest=0.1;
+				for ( int i=1; i<=(int)frag_nres; ++i ) {
+					for ( int j=1; j<=36; ++j ) {
+						// shift so max is 0
+						phi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*phi_distr[i][j] ) + std::log( mest/36.0 ) ;
+						psi_distr[i][j] = -std::log( mest/36.0 + (1-mest)*psi_distr[i][j] ) + std::log( mest/36.0 ) ;
+					}
+
+					//TR << "phi " << i;
+					//for (int j=1; j<=36; ++j) TR << " " << phi_distr[i][j];
+					//TR << std::endl;
+
+					//TR << "psi " << i;
+					//for (int j=1; j<=36; ++j) TR << " " << psi_distr[i][j];
+					//TR << std::endl;
+				}
+
+				// finally .. add constraints
+				for ( int i=1; i<=(int)frag_nres; ++i ) {
+					using namespace core::scoring::func;
+					using namespace core::scoring::constraints;
+
+					if ( !pose.residue(i).is_protein() ) continue;
+
+					if ( i>1 && pose.residue(i-1).is_protein() ) {
+						FuncOP phi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, phi_distr[i] ) );
+						ConstraintOP phi_cst( utility::pointer::make_shared< DihedralConstraint >(
+									core::id::AtomID(3,i-1),core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i), phi_func  ) );
+						pose.add_constraint( scoring::constraints::ConstraintCOP( phi_cst ) );
+					}
+
+					if ( i<(int)frag_nres && pose.residue(i+1).is_protein() ) {
+						FuncOP psi_func( utility::pointer::make_shared< CircularSplineFunc >( 1.0, psi_distr[i] ) );
+						ConstraintOP psi_cst( utility::pointer::make_shared< DihedralConstraint >(
+									core::id::AtomID(1,i),core::id::AtomID(2,i),core::id::AtomID(3,i),core::id::AtomID(1,i+1), psi_func  ) );
+						pose.add_constraint( scoring::constraints::ConstraintCOP( psi_cst ) );
+					}
+				}
+			}
+
+		void
+			HybridizeProtocol::initialize_and_sample_loops(
+					core::pose::Pose &pose,
+					core::pose::PoseOP chosen_templ,
+					protocols::loops::Loops template_contigs,
+					core::scoring::ScoreFunctionOP scorefxn)
+			{
+				using namespace basic::options;
+				using namespace basic::options::OptionKeys;
+
+				// xyz copy starting model
+				for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
+					for ( core::Size j=1; j<=chosen_templ->residue(i).natoms(); ++j ) {
+						core::id::AtomID src(j,i), tgt(j, chosen_templ->pdb_info()->number(i));
+						pose.set_xyz( tgt, chosen_templ->xyz( src ) );
+					}
+				}
+
+				// make loops as inverse of template_contigs
+				TR << "CONTIGS" << std::endl << template_contigs << std::endl;
+				//core::Size ncontigs = template_contigs.size();
+				core::Size nres_tgt = pose.size();
+
+				//symmetry
+				core::conformation::symmetry::SymmetryInfoCOP symm_info;
+				if ( core::pose::symmetry::is_symmetric(pose) ) {
+					auto & SymmConf (
+							dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+					symm_info = SymmConf.Symmetry_Info();
+					nres_tgt = symm_info->num_independent_residues();
+				}
+
+				if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+
+				protocols::loops::LoopsOP loops( utility::pointer::make_shared< protocols::loops::Loops >() );
+				utility::vector1< bool > templ_coverage(nres_tgt, false);
+
+				for ( core::Size i=1; i<=chosen_templ->size(); ++i ) {
+					core::Size cres = chosen_templ->pdb_info()->number(i);
+					templ_coverage[cres] = true;
+				}
+
+				// remove 1-3 residue "segments"
+				for ( core::Size i=1; i<=nres_tgt-2; ++i ) {
+					if ( !templ_coverage[i] && templ_coverage[i+1] && !templ_coverage[i+2] ) {
+						templ_coverage[i+1]=false;
+					} else if ( i<=nres_tgt-3 && !templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && !templ_coverage[i+3] ) {
+						templ_coverage[i+1]=false;
+						templ_coverage[i+2]=false;
+					} else if ( i<=nres_tgt-4 &&
+							!templ_coverage[i] && templ_coverage[i+1] && templ_coverage[i+2] && templ_coverage[i+3] && !templ_coverage[i+4] ) {
+						templ_coverage[i+1]=false;
+						templ_coverage[i+2]=false;
+						templ_coverage[i+3]=false;
+					}
+				}
+				// make loopfile
+				bool inloop=!templ_coverage[1];
+				core::Size loopstart=1, loopstop;
+				for ( core::Size i=2; i<=nres_tgt; ++i ) {
+					if ( templ_coverage[i] && inloop ) {
+						inloop = false;
+						loopstop = i;
+						if ( loopstop < loopstart + 2 ) {
+							if ( loopstart>1 ) loopstart--;
+							if ( loopstop<nres_tgt ) loopstop++;
+						}
+						loops->add_loop( loopstart,loopstop );
+					} else if ( !templ_coverage[i] && !inloop ) {
+						// start loop
+						inloop = true;
+						loopstart = i-1;
+					}
+				}
+				if ( inloop ) {
+					// end loop
+					loopstop = nres_tgt;
+					while ( loopstop < loopstart + 2 ) { loopstart--; }
+					loops->add_loop( loopstart,loopstop );
+				}
+				TR << "LOOPS" << std::endl << *loops << std::endl;
+
+				// now do insertions
+				if ( loops->size() != 0 ) {
+					// set foldtree + variants
+					loops->auto_choose_cutpoints(pose);
+					core::kinematics::FoldTree f_in=pose.fold_tree(), f_new;
+					protocols::loops::fold_tree_from_loops( pose, *loops, f_new);
+					pose.fold_tree( f_new );
+					protocols::loops::add_cutpoint_variants( pose );
+
+					// set movemap
+					core::kinematics::MoveMapOP mm_loop( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+					for ( auto const & it : *loops ) {
+						for ( core::Size i=it.start(); i<=it.stop(); ++i ) {
+							mm_loop->set_bb(i, true);
+							mm_loop->set_chi(i, true); // chi of loop residues
+						}
+					}
+
+					// setup fragment movers
+					protocols::simple_moves::ClassicFragmentMoverOP frag3mover, frag9mover;
+					core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
+					core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
+					TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
+					TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
+					frag3mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_small, mm_loop );
+					frag3mover->set_check_ss( false ); frag3mover->enable_end_bias_check( false );
+					frag9mover = utility::pointer::make_shared< protocols::simple_moves::ClassicFragmentMover >( frags_big, mm_loop );
+					frag9mover->set_check_ss( false ); frag9mover->enable_end_bias_check( false );
+
+					// extend + idealize loops
+					for ( auto const & it : *loops ) {
+						protocols::loops::Loop to_idealize( it );
+						protocols::loops::set_extended_torsions( pose, it );
+					}
+
+					// setup MC
+					scorefxn->set_weight( core::scoring::linear_chainbreak, 0.5 );
+					(*scorefxn)(pose);
+					protocols::moves::MonteCarloOP mc1( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
+
+					auto neffcycles = (core::Size)(1000*option[cm::hybridize::stage1_increase_cycles]());
+					for ( core::Size n=1; n<=neffcycles; ++n ) {
+						frag9mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag9" );
+						frag3mover->apply( pose ); (*scorefxn)(pose); mc1->boltzmann( pose , "frag3" );
+
+						if ( n%100 == 0 ) {
+							mc1->show_scores();
+							mc1->show_counters();
+						}
+					}
+					mc1->recover_low( pose );
+
+					scorefxn->set_weight( core::scoring::linear_chainbreak, 2.0 );
+					(*scorefxn)(pose);
+					protocols::moves::MonteCarloOP mc2( utility::pointer::make_shared< protocols::moves::MonteCarlo >( pose, *scorefxn, 2.0 ) );
+					for ( core::Size n=1; n<=neffcycles; ++n ) {
+						frag9mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag9" );
+						frag3mover->apply( pose ); (*scorefxn)(pose); mc2->boltzmann( pose , "frag3" );
+
+						if ( n%100 == 0 ) {
+							mc2->show_scores();
+							mc2->show_counters();
+						}
+					}
+
+					// restore input ft
+					mc2->recover_low( pose );
+					protocols::loops::remove_cutpoint_variants( pose );
+					pose.fold_tree( f_in );
+				}
+			}
+
+
+		void HybridizeProtocol::add_template(
+				std::string const & template_fn,
+				std::string const & cst_fn,
+				std::string const & symm_file,
+				core::Real const weight,
+				utility::vector1<char> const & randchains,
+				bool const align_pdb_info)
+		{
+			core::chemical::ResidueTypeSetCOP const residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
+
+			core::pose::PoseOP template_pose( utility::pointer::make_shared< core::pose::Pose >() );
+			if ( template_fn == "extended" ) {
+				// auto constraints make no sense
+				if ( cst_fn == "AUTO" ) {
+					TR.Error << "Warning!  Turning off auto constraints for extended pose" << std::endl;
+				}
+				add_null_template( template_pose, "NONE", symm_file, weight );
+			} else {
+				core::import_pose::pose_from_file( *template_pose, *residue_set, template_fn , core::import_pose::PDB_file);
+				add_template( template_pose, cst_fn, symm_file, weight, randchains, template_fn, align_pdb_info);
+			}
+		}
+
+
+		void HybridizeProtocol::add_null_template(
+				core::pose::PoseOP template_pose,
+				std::string cst_fn,
+				std::string symm_file,
+				core::Real weight)
+		{
+			template_fns_.push_back("null");
+			templates_.push_back(template_pose);
+			templates_aln_.push_back(template_pose); // shallow copy
+			template_cst_fn_.push_back(cst_fn);
+			symmdef_files_.push_back(symm_file);
+			template_weights_.push_back(weight);
+			template_chunks_.push_back(protocols::loops::Loops());
+			template_contigs_.push_back(protocols::loops::Loops());
+			randomize_chains_.push_back(utility::vector1<char>(0));
+		}
+
+		void HybridizeProtocol::add_template(
+				core::pose::PoseOP template_pose,
+				std::string const & cst_fn,
+				std::string const & symm_file,
+				core::Real const weight,
+				utility::vector1<char> const & rand_chains,
+				std::string const & filename,
+				bool const align_pdb_info)
+		{
+			// add secondary structure information to the template pose
+			core::scoring::dssp::Dssp dssp_obj( *template_pose );
+			dssp_obj.insert_ss_into_pose( *template_pose );
+
+			// find ss chunks in template
+			protocols::loops::Loops contigs = protocols::loops::extract_continuous_chunks(*template_pose);
+			protocols::loops::Loops chunks;
+			if ( include_loop_ss_chunks_ ) {
+				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
+			} else {
+				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
+			}
+
+			// if there are no SS elts in the pose, use contigs
+			if ( chunks.num_loop() == 0 ) chunks = contigs;
+
+			TR.Debug << "Chunks from template\n" << chunks << std::endl;
+			TR.Debug << "Contigs from template\n" << contigs << std::endl;
+
+			template_fns_.push_back(filename);
+			templates_.push_back(template_pose);
+			templates_aln_.push_back(template_pose); // shallow copy
+			template_cst_fn_.push_back(cst_fn);
+			symmdef_files_.push_back(symm_file);
+			template_weights_.push_back(weight);
+			template_chunks_.push_back(chunks);
+			template_contigs_.push_back(contigs);
+			randomize_chains_.push_back(rand_chains);
+			should_align_pdb_infos_.push_back(align_pdb_info);
+
+			non_null_template_indices_.push_back( templates_.size() );
+		}
+
+		void HybridizeProtocol::update_template(core::Size const template_idx )
+		{
+			core::pose::PoseOP const template_pose(templates_[template_idx]);
+
+			// add secondary structure information to the template pose
+			core::scoring::dssp::Dssp dssp_obj( *template_pose );
+			dssp_obj.insert_ss_into_pose( *template_pose );
+
+			// find ss chunks in template
+			protocols::loops::Loops const contigs = protocols::loops::extract_continuous_chunks(*template_pose);
+
+			protocols::loops::Loops chunks;
+			if ( include_loop_ss_chunks_ ) {
+				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HEL", 3, 6, 3, 3, 4);
+			} else {
+				chunks = protocols::loops::extract_secondary_structure_chunks(*template_pose, "HE", 3, 6, 3, 3, 4);
+			}
+			if ( chunks.num_loop() == 0 ) chunks = contigs;
+
+			template_chunks_[template_idx] = chunks;
+			template_contigs_[template_idx] = contigs;
+		}
+
+
+		// validate input templates match input sequence
+		// TO DO: if only sequences mismatch try realigning
+		void HybridizeProtocol::validate_template(
+				std::string const & filename,
+				std::string const & fasta,
+				core::pose::PoseOP template_pose,
+				bool & align_pdb_info)
+		{
+			core::Size nres_fasta = fasta.length(), nres_templ = template_pose->size();
+			core::Size next_ligand = nres_fasta+1; // ligands must be sequentially numbered
+
+			bool requires_alignment = false;
+			for ( core::Size i=1; i<=nres_templ; ++i ) {
+				char templ_aa = template_pose->residue(i).name1();
+				core::Size i_fasta = template_pose->pdb_info()->number(i);
+				bool is_ligand = !template_pose->residue(i).is_protein();
+
+				// ligands
+				if ( i_fasta > nres_fasta || is_ligand ) {
+					if ( !is_ligand ) {
+						TR.Error << "   Residue number " << i_fasta << " is outside of input fasta range." << std::endl;
+						requires_alignment = true;
+						break;
+					} else {
+						template_pose->pdb_info()->number(i,next_ligand);
+					}
+					next_ligand++;
+				} else {
+					char fasta_aa = fasta[i_fasta-1];
+					if ( fasta_aa != templ_aa ) {
+						TR.Error << "Sequence mismatch between input fasta and template " << filename
+							<< " at residue " << i_fasta << std::endl;
+						TR.Error << "   Expected: " << fasta_aa << "   Saw: " << templ_aa << std::endl;
+						if ( !align_pdb_info ) utility_exit_with_message("Issue validating template in HybridizeProtocol.");
+						requires_alignment = true;
+						break;
+					}
+				}
+			}
+			if ( requires_alignment ) {
+				TR.Error << "THE PDB INFO IS NOT IN SYNC WITH THE FASTA. ATTEMPTING TO RESOLVE THE ISSUE AUTOMATICALLY" << std::endl;
+				//this block code shouldn't be needed since hybrid needs asymmetric poses anyway but it doesn't hurt
+				core::pose::Pose pose_for_seq;
+				core::pose::symmetry::extract_asymmetric_unit(*template_pose, pose_for_seq, false);
+
+				core::sequence::SequenceOP full_length_seq( utility::pointer::make_shared< core::sequence::Sequence >( fasta, "target" ));
+				core::sequence::SequenceOP t_pdb_seq( utility::pointer::make_shared< core::sequence::Sequence >( pose_for_seq.sequence(), "pose_seq" ));
+				core::sequence::SWAligner sw_align;
+				core::sequence::ScoringSchemeOP ss(  utility::pointer::make_shared< core::sequence::SimpleScoringScheme >(120, 0, -100, 0));
+				core::sequence::SequenceAlignment fasta2template;
+
+				fasta2template = sw_align.align(full_length_seq, t_pdb_seq, ss);
+
+				TR << fasta2template << std::endl;
+
+				core::id::SequenceMapping sequencemap = fasta2template.sequence_mapping(1,2);
+				sequencemap.reverse();
+				core::Size ndel = 0;
+				core::Size counter = 1;
+				core::Size nres = template_pose->size();
+				for ( core::Size i=1; i<=nres; i++ ) {
+					if ( ! template_pose->residue(counter).is_protein() ) {
+						// will get fixed later
+						counter++;
+						continue;
+					}
+
+					core::Size pdbnumber = template_pose->pdb_info()->number(counter);
+					core::Size fastanumber = sequencemap[i];
+					if ( fastanumber == 0 ) { // extra residues in template
+						template_pose->delete_residue_range_slow( counter,counter );
+						ndel++;
+						continue;
+					}
+					if ( pdbnumber != fastanumber ) {
+						template_pose->pdb_info()->number(counter,fastanumber);
+					}
+					counter++;
+				}
+				if ( ndel > 0 ) {
+					TR.Error << "WARNING! Realignment removed " << ndel << " residues!" << std::endl;
+				}
+			} else {
+				align_pdb_info = false;
+			}
+		}
+
+
+		core::Size HybridizeProtocol::pick_starting_template( ) {
+			using namespace basic::options;
+			using namespace basic::options::OptionKeys;
+
+			numeric::random::WeightedSampler weighted_sampler;
+			weighted_sampler.weights(template_weights_);
+			return weighted_sampler.random_sample(numeric::random::rg());
+		}
+
+		void HybridizeProtocol::domain_parse_templates(core::Size nres) {
+			if ( domains_all_templ_.size() == templates_.size() ) {
+				return;
+			}
+
+			DDomainParse ddom(pcut_,hcut_,length_);
+
+			domains_all_templ_.resize( templates_.size() );
+			for ( core::Size i_template=1; i_template<=templates_.size(); ++i_template ) {
+				if ( templates_[i_template]->size() < 3 ) {
+					continue;  // ???
+				}
+
+				domains_all_templ_[i_template] = ddom.split( *templates_[i_template] );
+
+				// convert domain numbering to target pose numbering
+				protocols::loops::Loops all_domains;
+				for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
+					for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
+						core::Size seqpos_start_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].start());
+
+						if ( seqpos_start_pose > nres ) continue; // sometimes dna can do this
+
+						domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
+
+						core::Size seqpos_stop_pose = templates_[i_template]->pdb_info()->number(domains_all_templ_[i_template][iloops][iloop].stop());
+						domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
+
+						all_domains.add_loop( seqpos_start_pose, seqpos_stop_pose );
+					}
+				}
+
+				// extend to cover full-length seq
+				// assumes no overlap in domain defs!
+				all_domains.sequential_order();
+				if ( all_domains.num_loop() == 0 ) continue;
+
+				std::map<core::Size,core::Size> remap_endpoints;
+				remap_endpoints [ all_domains[1].start() ] = 1;
+				remap_endpoints [ all_domains[all_domains.num_loop()].stop() ] = nres;
+				for ( core::Size iloops=2; iloops<=all_domains.size(); ++iloops ) {
+					core::Size start_i = (all_domains[iloops-1].stop() + all_domains[iloops].start() + 1)/2;
+					remap_endpoints [ all_domains[iloops-1].stop() ] = start_i-1;
+					remap_endpoints [ all_domains[iloops].start() ] = start_i;
+				}
+
+				for ( core::Size iloops=1; iloops<=domains_all_templ_[i_template].size(); ++iloops ) {
+					for ( core::Size iloop=1; iloop<=domains_all_templ_[i_template][iloops].num_loop(); ++iloop ) {
+						core::Size seqpos_start_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].start() ];
+						domains_all_templ_[i_template][iloops][iloop].set_start( seqpos_start_pose );
+
+						core::Size seqpos_stop_pose = remap_endpoints[ domains_all_templ_[i_template][iloops][iloop].stop() ];
+						domains_all_templ_[i_template][iloops][iloop].set_stop( seqpos_stop_pose );
+					}
+				}
+
+				TR << "Found " << domains_all_templ_[i_template].size() << " domains using template " << template_fns_[i_template] << std::endl;
+				for ( core::Size i=1; i<=domains_all_templ_[i_template].size(); ++i ) {
+					TR << "domain " << i << ": " << domains_all_templ_[i_template][i] << std::endl;
+				}
+			}
+		}
+
+		void
+			HybridizeProtocol::setup_templates_and_sampling_options( core::pose::Pose const & pose ) {
+				std::string const & pose_sequence(pose.sequence());
+				if ( coord_cst_res_.size() ) {
+					user_csts_ = core::pose::get_resnum_list_ordered( coord_cst_res_, pose );
+				}
+				for ( core::Size i=1; i<=template_fns_.size(); ++i ) {
+					bool align_pdb_info = should_align_pdb_infos_[i];
+					validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
+
+					if ( align_pdb_info ) {
+						align_pdb_info = false;
+						validate_template( template_fns_[i], pose_sequence, templates_[i], align_pdb_info );
+						update_template(i);
+					}
+				}
+
+				core::Size const nres_nonvirt = get_num_residues_nonvirt(pose);
+				if ( detailed_controls_settings_.size() ) {
+					residue_sample_template_.resize(nres_nonvirt, true);
+					residue_sample_abinitio_.resize(nres_nonvirt, true);
+				}
+				for ( auto const & detailed_control_settings : detailed_controls_settings_ ) {
+					if ( detailed_control_settings.type_ == "task_operations" ) {
+						core::pack::task::PackerTaskOP task = detailed_control_settings.taskFactOP_->create_task_and_apply_taskoperations( pose );
+						for ( core::Size ires = 1; ires <= nres_nonvirt; ++ires ) {
+							if ( !task->residue_task( ires ).being_packed() ) {
+								residue_sample_template_[ires] = false;
+								residue_sample_abinitio_[ires] = false;
+							}
+						}
+					} else {
+						core::Size const stop_res(detailed_control_settings.stop_res_ == 0 ? nres_nonvirt : detailed_control_settings.stop_res_);
+						if ( detailed_control_settings.sample_template_ != sampleEnum::unset ) {
+							for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
+								residue_sample_template_[ires] = (detailed_control_settings.sample_template_ == sampleEnum::off ? false : true);
+							}
+						}
+						if ( detailed_control_settings.sample_abinitio_ != sampleEnum::unset ) {
+							for ( core::Size ires=detailed_control_settings.start_res_; ires<=stop_res; ++ires ) {
+								residue_sample_abinitio_[ires] = (detailed_control_settings.sample_abinitio_ == sampleEnum::off ? false : true);
+							}
+						}
+					}
+				}
+			}
+
+		void HybridizeProtocol::apply( core::pose::Pose & pose )
+		{
+			using namespace protocols::moves;
+			using namespace basic::options;
+			using namespace basic::options::OptionKeys;
+			using namespace core::pose::datacache;
+			using namespace core::io::silent;
+			using namespace ObjexxFCL::format;
+
+			if ( native_ == nullptr ) {
+				if ( native_needs_load_ ) {
+					native_ = utility::pointer::make_shared< core::pose::Pose >();
+					if ( option[in::file::fullatom]() ) {
+						core::import_pose::pose_from_file( *native_, option[ in::file::native ]() , core::import_pose::PDB_file);
+					} else {
+						core::chemical::ResidueTypeSetCOP residue_set = core::chemical::ChemicalManager::get_instance()->residue_type_set( "centroid" );
+						core::import_pose::pose_from_file( *native_, *residue_set, option[ in::file::native ]()  , core::import_pose::PDB_file);
+					}
+					native_needs_load_ = false;
+				} else if ( native_needs_load_from_align_rmsd_target_ ) {
+					native_ = utility::pointer::make_shared< core::pose::Pose >();
+					utility::vector1< std::string > const & align_rmsd_target( option[ evaluation::align_rmsd_target ]() );
+					core::import_pose::pose_from_file( *native_, align_rmsd_target[1] , core::import_pose::PDB_file); // just use the first one for now
+					native_needs_load_from_align_rmsd_target_ = false;
+				}
+			}
+
+			setup_templates_and_sampling_options(pose);
+
+			// number of residues in asu without VRTs
+			core::Size nres_tgt = pose.size();
+			core::Size nres_protein_tgt = pose.size();
+			core::conformation::symmetry::SymmetryInfoCOP symm_info;
+			if ( core::pose::symmetry::is_symmetric(pose) ) {
+				auto & SymmConf (
+						dynamic_cast<core::conformation::symmetry::SymmetricConformation &> ( pose.conformation()) );
+				symm_info = SymmConf.Symmetry_Info();
+				nres_tgt = symm_info->num_independent_residues();
+				nres_protein_tgt = symm_info->num_independent_residues();
+			}
+			if ( pose.residue(nres_tgt).aa() == core::chemical::aa_vrt ) nres_tgt--;
+			while ( !pose.residue(nres_protein_tgt).is_protein() ) nres_protein_tgt--;
+
+			//save necessary constraint in pose
+			core::scoring::constraints::ConstraintSetOP save_pose_constraint_set( utility::pointer::make_shared< core::scoring::constraints::ConstraintSet >() ) ;
+			if ( keep_pose_constraint_ ) {
+				save_pose_constraint_set = pose.constraint_set()->clone();
+				core::scoring::constraints::remove_nonbb_constraints(pose);
+			}
+
+			if ( pose.is_fullatom() ) {
+				protocols::moves::MoverOP tocen( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::CENTROID ) );
+				tocen->apply(pose);
+			}
+
+			// make fragments if we don't have them at this point
+			check_and_create_fragments( pose );
+
+			// domain parse templates if we do not have domain definitions
+			domain_parse_templates(nres_tgt);
+
+			// select random fragment sets if >2 are provided
+			core::fragment::FragSetOP frags_small = fragments_small_[numeric::random::rg().random_range(1,fragments_small_.size())];
+			core::fragment::FragSetOP frags_big = fragments_big_[numeric::random::rg().random_range(1,fragments_big_.size())];
+			TR.Info << "FRAGMENTS small max length: " << frags_small->max_frag_length() << std::endl;
+			TR.Info << "FRAGMENTS big max length: " << frags_big->max_frag_length() << std::endl;
+
+			// starting structure pool (for batch relax)
+			std::vector < SilentStructOP > post_centroid_structs;
+			bool need_more_samples = true;
+
+			// main centroid generation loop
+			core::Real gdtmm = 0.0;
+			if ( stage2_scorefxn_ == nullptr ) {
+				utility_exit_with_message("Stage 2 Scorefxn must be set!!!");
+			}
+
+			while ( need_more_samples ) {
+				need_more_samples = false;
+
+				// pick starting template
+				core::Size initial_template_index = pick_starting_template();
+				TR << "Using initial template: " << I(4,initial_template_index) << " " << template_fns_[initial_template_index] << std::endl;
+
+				// ensure
+				//    1)that no CONTIGS cross multiple CHAINS
+				//    2)that every input CHAIN has a chunk in it
+				// if not, add the corresponding contig as a chunk
+				utility::vector1< int > cuts = pose.fold_tree().cutpoints();
+				protocols::loops::Loops const &contigs_old = template_contigs_[initial_template_index];
+				protocols::loops::Loops contigs_new;
+				for ( core::Size j=1; j<=contigs_old.num_loop(); ++j ) {
+					protocols::loops::Loop contig_j = contigs_old[j];
+
+					for ( core::Size i=1; i<=cuts.size(); ++i ) {
+						int nextcut = cuts[i];
+						if ( nextcut > (int)nres_protein_tgt ) break;
+
+						core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
+						core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
+
+						if ( (int)start <= nextcut && (int)stop > nextcut ) {
+							// find template res corresponding to cut
+							for ( core::Size k=contig_j.start(); k<=contig_j.stop(); ++k ) {
+								if ( templates_[initial_template_index]->pdb_info()->number(k) == nextcut ) {
+									// ensure contig >= 3 res
+									if ( k > contig_j.start()+1 ) {
+										contigs_new.push_back( protocols::loops::Loop(contig_j.start(), k) );
+									}
+									TR << "Split contig ("<<contig_j.start()<<","<<contig_j.stop()<< ") at " << k << " [pdbnum: "<<start<<"/"<<stop<<"/" << nextcut << "]" << std::endl;
+									contig_j.set_start( k+1 );
+								}
+							}
+
+						}
+					}
+					// ensure contig >= 3 res
+					if ( contig_j.stop() > contig_j.start()+1 ) {
+						contigs_new.push_back( contig_j );
+					}
+				}
+				template_contigs_[initial_template_index] = contigs_new;
+
+				protocols::loops::Loops &chunks = template_chunks_[initial_template_index];
+				for ( core::Size i=0; i<=cuts.size(); ++i ) {
+					int prevcut = (i==0) ? 1 : cuts[i];
+					int nextcut = (i==cuts.size()) ? nres_protein_tgt : cuts[i+1];
+					if ( nextcut > (int)nres_protein_tgt ) break;
+					bool haschunk = false;
+					for ( core::Size j=1; j<=chunks.num_loop() && !haschunk; ++j ) {
+						protocols::loops::Loop const &chunk_j = chunks[j];
+						core::Size start = templates_[initial_template_index]->pdb_info()->number(chunk_j.start());
+						core::Size stop  = templates_[initial_template_index]->pdb_info()->number(chunk_j.stop());
+						if ( (int)start > prevcut && (int)stop <= nextcut ) haschunk=true;
+					}
+
+					if ( ! haschunk ) {
+						TR << "Segment ("<<prevcut<<","<<nextcut<<") has no chunks!  Adding contigs!" << std::endl;
+						bool hascontig=false;
+						for ( core::Size j=1; j<=contigs_new.num_loop(); ++j ) {
+							protocols::loops::Loop const &contig_j = contigs_new[j];
+							core::Size start = templates_[initial_template_index]->pdb_info()->number(contig_j.start());
+							core::Size stop  = templates_[initial_template_index]->pdb_info()->number(contig_j.stop());
+							if ( (int)start > prevcut && (int)stop <= nextcut ) {
+								hascontig = true;
+								chunks.push_back( contig_j );
+							}
+						}
+						if ( !hascontig ) {
+							TR << "Warning!  No contigs found for segment!" << std::endl;
+							TR << "If you are not using the 'randomize=X' option there is likely something wrong with your input and models will not be reasonable!" << std::endl;
+						}
+					}
+				}
+
+				// (0) randomize chains
+				if ( randomize_chains_[initial_template_index].size() > 0 ) {
+					runtime_assert ( templates_[initial_template_index]->pdb_info() );
+					numeric::xyzVector< core::Real > comFixed(0,0,0), comMoving(0,0,0);
+					core::Real nFixed=0, nMoving=0;
+
+					TR << "Randomize >" << randomize_chains_[initial_template_index].size() << "<" << std::endl;
+					for ( core::Size q=1; q<=randomize_chains_[initial_template_index].size(); ++q ) {
+						TR << "Randomize >" << randomize_chains_[initial_template_index][q] << "<" << std::endl;
+					}
+
+					for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
+						char chain = templates_[initial_template_index]->pdb_info()->chain(i);
+						if ( std::find(
+									randomize_chains_[initial_template_index].begin(),
+									randomize_chains_[initial_template_index].end(),
+									chain) != randomize_chains_[initial_template_index].end()
+							 ) {
+							comMoving += templates_[initial_template_index]->residue(i).xyz(2);
+							nMoving++;
+						} else {
+							comFixed += templates_[initial_template_index]->residue(i).xyz(2);
+							nFixed++;
+						}
+					}
+
+					// sanity check
+					if ( nMoving == 0 ) {
+						utility_exit_with_message("Randomize chain enabled but chain(s) not found!");
+					}
+
+					comMoving /= nMoving;
+					comFixed /= nFixed;
+
+					// randomize orientation
+					numeric::xyzMatrix< core::Real > R = protocols::geometry::random_reorientation_matrix( 360, 360 );
+
+					// randomize offset
+					numeric::xyzVector< core::Real > T = numeric::random::random_point_on_unit_sphere< core::Real >( numeric::random::rg() );
+
+					// perturb & slide into contact
+					bool done=false, compacting=false;
+					core::Real DIST = 100.0;
+					core::scoring::ScoreFunction sf_vdw;
+					core::Real vdw_score = -1.0, step_size = -2.0, min_step_size = 0.25;
+					sf_vdw.set_weight( core::scoring::vdw, 1.0 );
+					core::pose::Pose template_orig = *(templates_[initial_template_index]);
+					while ( !done && DIST > 0 ) {
+						utility::vector1< id::AtomID > atm_ids;
+						utility::vector1< numeric::xyzVector< core::Real> > atm_xyzs;
+
+						for ( core::Size i=1; i<=templates_[initial_template_index]->size(); ++i ) {
+							core::conformation::Residue const & rsd_i = template_orig.residue(i);
+							char chain = templates_[initial_template_index]->pdb_info()->chain(i);
+							if ( std::find(
+										randomize_chains_[initial_template_index].begin(),
+										randomize_chains_[initial_template_index].end(),
+										chain) != randomize_chains_[initial_template_index].end()
+								 ) {
+								for ( core::Size j = 1; j <= rsd_i.natoms(); ++j ) {
+									id::AtomID id( j,i );
+									atm_ids.push_back( id );
+									numeric::xyzVector< core::Real > new_ij = R*(rsd_i.xyz(j) - comMoving) + comFixed + DIST * T;
+									atm_xyzs.push_back( new_ij );
+								}
+							}
+						}
+						templates_[initial_template_index]->batch_set_xyz( atm_ids, atm_xyzs );
+						core::Real score_d = sf_vdw( *(templates_[initial_template_index]) );
+						if ( vdw_score < 0 ) vdw_score = score_d;
+
+						if ( !compacting && score_d > vdw_score + 2.0 ) {
+							compacting = true;
+							step_size = min_step_size;
+						} else if ( compacting  && vdw_score <= score_d + 2.0 ) {
+							done = true;
+						}
+
+						TR << "D=" << DIST << " score=" << score_d << std::endl;
+
+						DIST += step_size;
+					}
+				}
+
+				// (1) steal hetatms from template
+				utility::vector1< std::pair< core::Size,core::Size > > hetatms;
 				if ( add_hetatm_ ) {
-					add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
+					for ( core::Size ires=1; ires <= templates_[initial_template_index]->size(); ++ires ) {
+						if ( templates_[initial_template_index]->pdb_info()->number(ires) > (int)nres_tgt ) {
+							TR.Debug << "Insert hetero residue: " << templates_[initial_template_index]->residue(ires).name3() << std::endl;
+							if(templates_[initial_template_index]->residue(ires).is_carbohydrate()){
+								if (!templates_[initial_template_index]->residue(ires).is_lower_terminus()){
+									core::Size offset = pose.size() + 1 - ires;
+									core::Size parent_res_seqpos( conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue( templates_[initial_template_index]->residue(ires) ) );
+									int self_lower=0;
+									int parent_upper=0;
+									//self_lower = templates_[initial_template_index]->residue(ires).lower_connect_id();
+									//parent_upper = templates_[initial_template_index]->residue(parent_res_seqpos).connect_atom( templates_[initial_template_index]->residue(ires) );
+									for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
+										TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+										if (templates_[initial_template_index]->residue(ires).connect_map( i ).resid() == parent_res_seqpos){
+											//self_lower = templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
+											self_lower = i;
+											parent_upper=templates_[initial_template_index]->residue(ires).connect_map( i ).connid();
+											//parent_upper=templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i);
+										}
+									}
+									parent_res_seqpos += offset;
+									TR.Debug <<"  appending by bond "<<pose.size()+1<<" lower "<<self_lower<<" anchor "<<parent_res_seqpos<<" parent upper "<<parent_upper<<std::endl;
+									pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires), false, self_lower, parent_res_seqpos, parent_upper, false, false);
+								} else {
+									TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
+									for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
+										TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+									}
+									pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
+
+								}
+							}
+							else if ( templates_[initial_template_index]->residue(ires).is_polymer()
+									&& !templates_[initial_template_index]->residue(ires).is_lower_terminus()
+									&& !pose.residue(pose.size()).is_upper_terminus() ) {
+								TR.Debug <<"  appending by bond "<<ires<<std::endl;
+								pose.append_residue_by_bond(templates_[initial_template_index]->residue(ires));
+								for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
+									TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+								}
+							} else {
+								TR.Debug <<"  appending by jump "<<ires<<" is Polymer "<<templates_[initial_template_index]->residue(ires).is_polymer()<<" is Lower "<<templates_[initial_template_index]->residue(ires).is_lower_terminus()<<" is Upper "<<pose.residue(pose.size()).is_upper_terminus()<<std::endl;
+								pose.append_residue_by_jump(templates_[initial_template_index]->residue(ires), 1);
+								for (core::Size i(1);i <= templates_[initial_template_index]->residue(ires).connect_map_size(); ++i){
+									TR.Debug<<"     "<<i<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_partner(i)<<" "<<templates_[initial_template_index]->residue(ires).residue_connection_conn_id(i)<<std::endl;
+								}
+							}
+							hetatms.push_back( std::make_pair( ires, pose.size() ) );
+						}
+					}
+					pose.conformation().chains_from_termini();
 				}
-				if ( strand_pairs_.size() ) {
-					add_strand_pairs_cst(pose, strand_pairs_);
-				}
-			}
 
-			// add torsion constraints derived from fragments
-			if ( csts_from_frags_ ) {
-				if ( fa_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
-					add_fragment_csts( pose );
-				} else {
-					TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
-				}
-			}
-
-			if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
-				// note that CSTs are updated based on stage 1 movement
-				//   this may or may not be desirable
-				if ( user_csts_.size() > 0 ) {
-					setup_user_coordinate_constraints(pose,user_csts_);
-				}
-			}
-
-			if ( batch_relax_ == 1 ) {
-				// standard relax
-				// do relax _without_ ramping down coordinate constraints
-				TR << " batch_relax 1 : " << std::endl;
-				protocols::relax::FastRelax relax_prot( fa_scorefxn_, relax_repeats_ ,"NO CST RAMPING" );
-				relax_prot.min_type("lbfgs_armijo_nonmonotone");
-				relax_prot.apply(pose);
-			} else {
-				// batch relax
-				// add stucture to queue
-				SilentFileOptions opts;
-				SilentStructOP new_struct = SilentStructFactory::get_instance()->get_silent_struct("binary",opts);
-				new_struct->fill_struct( pose );
-				new_struct->energies_from_pose( pose );
-				post_centroid_structs.push_back( new_struct );
-
-				if ( post_centroid_structs.size() == batch_relax_ ) {
-					protocols::relax::FastRelax relax_prot( fa_scorefxn_ );
-					relax_prot.min_type("lbfgs_armijo_nonmonotone");
-					relax_prot.set_force_nonideal(true);
-					relax_prot.set_script_to_batchrelax_default( relax_repeats_ );
-
-					// need to use a packer task factory to handle poses with different disulfide patterning
-					core::pack::task::TaskFactoryOP tf( utility::pointer::make_shared< core::pack::task::TaskFactory >() );
-					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::InitializeFromCommandline >() );
-					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::IncludeCurrent >() );
-					tf->push_back( utility::pointer::make_shared< core::pack::task::operation::RestrictToRepacking >() );
-					relax_prot.set_task_factory( tf );
-
-					// notice! this assumes all poses in a set have the same constraints!
-					relax_prot.batch_apply(post_centroid_structs, pose.constraint_set()->clone());
-
-					// reinflate pose
-					post_centroid_structs[0]->fill_pose( pose );
-				} else {
-					protocols::moves::MoverOP tocen( new protocols::simple_moves::SwitchResidueTypeSetMover( core::chemical::CENTROID ) );
-					tocen->apply(pose);
-					need_more_samples = true;
-				}
-			}
-		} else {
-			// no fullatom sampling
-			(*stage2_scorefxn_)(pose);
-		}
-	}
-	if ( native_ && native_->size() ) {
-		gdtmm = get_gdtmm(*native_, pose, aln_);
-		core::pose::setPoseExtraScore( pose, "GDTMM_final", gdtmm);
-		TR << "GDTMM_final" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
-	}
-}
-
-
-void
-HybridizeProtocol::align_templates_by_domain(core::pose::PoseOP & ref_pose, utility::vector1 <Loops> domains)
-{
-	// get domain parse if not specified
-	core::pose::PoseOP working_pose;
-	if ( core::pose::symmetry::is_symmetric(*ref_pose) ) {
-		working_pose = utility::pointer::make_shared< core::pose::Pose >();
-		core::pose::symmetry::extract_asymmetric_unit(*ref_pose, *working_pose);
-	} else {
-		working_pose = ref_pose;
-	}
-
-	if ( domains.size() == 0 ) {
-		DDomainParse ddom(pcut_,hcut_,length_);
-		utility::vector1 <Loops> domains = ddom.split( *working_pose );
-	}
-
-	// clone original poses -> copies for alignment
-	templates_aln_.clear();
-	for ( core::Size i_pose=1; i_pose <= templates_.size(); ++i_pose ) {
-		templates_aln_.push_back(
-			utility::pointer::make_shared< core::pose::Pose >( *templates_[i_pose] ) );
-	}
-
-	for ( core::Size i_pose=1; i_pose <= templates_aln_.size(); ++i_pose ) {
-		if ( templates_aln_[i_pose] == ref_pose ) continue; // compare pointers
-		align_by_domain(*templates_aln_[i_pose], *working_pose, domains);
-		//std::string out_fn = template_fns_[i_pose] + "_realigned.pdb";
-		//poses[i_pose]->dump_pdb(out_fn);
-	}
-}
-
-
-void
-HybridizeProtocol::align_by_domain(core::pose::Pose & pose, core::pose::Pose const & ref_pose, utility::vector1 <Loops> domains) {
-	// ASSUME:
-	//    domains cover the full pose (no gaps)
-	utility::vector1< core::Real > aln_cutoffs;
-	aln_cutoffs.push_back(6);
-	aln_cutoffs.push_back(4);
-	aln_cutoffs.push_back(3);
-	aln_cutoffs.push_back(2);
-	aln_cutoffs.push_back(1.5);
-	aln_cutoffs.push_back(1);
-	core::Real min_coverage = 0.2;
-
-	// find corresepondance of ligands to nearest residues (in moving pose)
-	core::Size last_protein_residue=pose.size();
-	while ( last_protein_residue>0 && !pose.residue_type(last_protein_residue).is_protein() ) last_protein_residue--;
-
-	if ( last_protein_residue == 0 ) return;
-
-	std::map< core::Size, core::Size > ligres_map;
-	for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
-		core::Real mindist = 999.0;
-		core::Size minj = 1;
-		for ( core::Size j=1; j<=last_protein_residue; ++j ) {
-			core::Real dist_ij = (pose.residue(i).xyz(1) - pose.residue(j).xyz(1)).length(); // hacky (using atom 1 only)
-			if ( dist_ij < mindist ) {
-				mindist = dist_ij;
-				minj = (pose.pdb_info()) ? pose.pdb_info()->number(j) : j;
-			}
-		}
-		ligres_map[i] = minj;
-	}
-
-
-	for ( core::Size i_domain = 1; i_domain <= domains.size() ; ++i_domain ) {
-		core::id::AtomID_Map< core::id::AtomID > atom_map;
-		core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
-
-		// find all residues in moving pose corresponding to this domain
-		std::list <core::Size> residue_list;
-		core::Size n_mapped_residues=0;
-		for ( core::Size ires=1; ires<=pose.size(); ++ires ) {
-			if ( !pose.residue_type(ires).is_protein() ) continue;
-			int pose_res = (pose.pdb_info()) ? pose.pdb_info()->number(ires) : ires;
-			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-				if ( pose_res < (int)domains[i_domain][iloop].start() || pose_res > (int)domains[i_domain][iloop].stop() ) continue;
-				residue_list.push_back(ires);
-			}
-		}
-
-		// find all residues in reference pose corresponding to this domain
-		std::list <core::Size> ref_residue_list;
-		for ( core::Size jres=1; jres<=ref_pose.size(); ++jres ) {
-			if ( !ref_pose.residue_type(jres).is_protein() ) continue;
-			int ref_pose_res = (ref_pose.pdb_info()) ? ref_pose.pdb_info()->number(jres) : jres;
-			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-				if ( ref_pose_res < (int)domains[i_domain][iloop].start() || ref_pose_res > (int)domains[i_domain][iloop].stop() ) continue;
-				ref_residue_list.push_back(jres);
-			}
-		}
-
-		// get tmalign sequence mapping
-		TMalign tm_align;
-		std::string seq_pose, seq_ref, aligned;
-		int reval = tm_align.apply(pose, ref_pose, residue_list, ref_residue_list);
-		if ( reval != 0 ) continue;  // TO DO: remove this domain
-
-		tm_align.alignment2AtomMap(pose, ref_pose, residue_list, ref_residue_list, n_mapped_residues, atom_map);
-		tm_align.alignment2strings(seq_pose, seq_ref, aligned);
-
-		using namespace ObjexxFCL::format;
-		core::Size norm_length = residue_list.size() < ref_residue_list.size() ? residue_list.size():ref_residue_list.size();
-		TR << "Align domain with TMscore of " << F(8,3,tm_align.TMscore(norm_length)) << std::endl;
-		TR << seq_pose << std::endl;
-		TR << aligned << std::endl;
-		TR << seq_ref << std::endl;
-
-		if ( n_mapped_residues < 6 ) continue;  // TO DO: remove this domain
-
-		// add in ligand residues
-		for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
-			core::Size res_controlling_i = ligres_map[i];
-			for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
-				if ( res_controlling_i < domains[i_domain][iloop].start() || res_controlling_i > domains[i_domain][iloop].stop() ) continue;
-				residue_list.push_back(i);
-			}
-		}
-
-		partial_align(pose, ref_pose, atom_map, residue_list, true, aln_cutoffs, min_coverage); // iterate_convergence = true
-	}
-}
-
-
-void
-HybridizeProtocol::do_intrastage_docking(core::pose::Pose & pose) {
-	// call docking or symm docking
-	if ( core::pose::symmetry::is_symmetric(pose) ) {
-		/////
-		/////  SYMM LOGIC
-		protocols::symmetric_docking::SymDockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::symmetric_docking::SymDockingLowRes >(stage1_scorefxn_) );
-		docking_lowres_mover->apply(pose);
-
-		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap>() );
-		mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( true );
-		core::pose::symmetry::make_symmetric_movemap( pose, *mm );
-
-		protocols::minimization_packing::MinMoverOP min_mover(
-			utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
-		min_mover->apply(pose);
-	} else {
-		/////
-		/////  ASYMM LOGIC
-		core::Size const rb_move_jump = 1; // use the first jump as the one between partners <<<< fpd: MAKE THIS A PARSIBLE OPTION
-		protocols::docking::DockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::docking::DockingLowRes >( stage1_scorefxn_, rb_move_jump ) );
-		docking_lowres_mover->apply(pose);
-
-		core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
-		mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( rb_move_jump, true );
-		protocols::minimization_packing::MinMoverOP min_mover( utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
-		min_mover->apply(pose);
-	}
-}
-
-protocols::moves::MoverOP HybridizeProtocol::clone() const { return utility::pointer::make_shared< HybridizeProtocol >( *this ); }
-protocols::moves::MoverOP HybridizeProtocol::fresh_instance() const { return utility::pointer::make_shared< HybridizeProtocol >(); }
-
-
-void
-HybridizeProtocol::parse_my_tag(
-	utility::tag::TagCOP tag,
-	basic::datacache::DataMap & data
-)
-{
-	// basic options
-	stage1_increase_cycles_ = tag->getOption< core::Real >( "stage1_increase_cycles", 1. );
-	stage2_increase_cycles_ = tag->getOption< core::Real >( "stage2_increase_cycles", 1. );
-	stage2_temperature_ = tag->getOption< core::Real >( "stage2_temperature", 2. );
-	stage25_increase_cycles_ = tag->getOption< core::Real >( "stage2.5_increase_cycles", 1. );
-	fa_cst_fn_ = tag->getOption< std::string >( "fa_cst_file", "" );
-	batch_relax_ = tag->getOption< core::Size >( "batch" , 1 );
-	jump_move_= tag->getOption< bool >( "jump_move" , false );
-	jump_move_repeat_= tag->getOption< core::Size >( "jump_move_repeat" , 1 );
-	keep_pose_constraint_= tag->getOption< bool >( "keep_pose_constraint" , false );
-	cenrot_= tag->getOption< bool >( "cenrot" , false );
-
-	//if( tag->hasOption( "task_operations" ) ){
-	//FPD   remove this option, it was used as a residue selector and not as options controlling packing
-	//      the 'DetailedControls' tag should replace one part of this, and a separate mover should generate interface constraints
-
-	// force starting template
-	//FPD   removed this option; it is redundant with weights! (set weight to 0 for templates we do not start with)
-
-
-	if ( tag->hasOption( "csts_from_frags" ) ) {
-		csts_from_frags_ = tag->getOption< bool >( "csts_from_frags" );
-	}
-	if ( tag->hasOption( "max_contig_insertion" ) ) {
-		max_contig_insertion_ = tag->getOption< int >( "max_contig_insertion" );
-	}
-
-	if ( tag->hasOption( "min_after_stage1" ) ) {
-		min_after_stage1_ = tag->getOption< bool >( "min_after_stage1" );
-	}
-	if ( tag->hasOption( "fragprob_stage2" ) ) {
-		fragprob_stage2_ = tag->getOption< core::Real >( "fragprob_stage2" );
-	}
-	if ( tag->hasOption( "randfragprob_stage2" ) ) {
-		randfragprob_stage2_ = tag->getOption< core::Real >( "randfragprob_stage2" );
-	}
-
-
-	// tons of ab initio options
-	if ( tag->hasOption( "stage1_1_cycles" ) ) {
-		stage1_1_cycles_ = tag->getOption< core::Size >( "stage1_1_cycles" );
-	}
-	if ( tag->hasOption( "stage1_2_cycles" ) ) {
-		stage1_2_cycles_ = tag->getOption< core::Size >( "stage1_2_cycles" );
-	}
-	if ( tag->hasOption( "stage1_3_cycles" ) ) {
-		stage1_3_cycles_ = tag->getOption< core::Size >( "stage1_3_cycles" );
-	}
-	if ( tag->hasOption( "stage1_4_cycles" ) ) {
-		stage1_4_cycles_ = tag->getOption< core::Size >( "stage1_4_cycles" );
-	}
-	if ( tag->hasOption( "stage1_probability" ) ) {
-		stage1_probability_ = tag->getOption< core::Real >( "stage1_probability" );
-	}
-	if ( tag->hasOption( "add_hetatm" ) ) {
-		add_hetatm_ = tag->getOption< bool >( "add_hetatm" );
-	}
-	if ( tag->hasOption( "hetatm_cst_weight" ) ) {
-		hetatm_self_cst_weight_ = tag->getOption< core::Real >( "hetatm_cst_weight" );
-	}
-	if ( tag->hasOption( "hetatm_to_protein_cst_weight" ) ) {
-		hetatm_prot_cst_weight_ = tag->getOption< core::Real >( "hetatm_to_protein_cst_weight" );
-	}
-	if ( tag->hasOption( "realign_domains" ) ) {
-		realign_domains_ = tag->getOption< bool >( "realign_domains" );
-	}
-	if ( tag->hasOption( "realign_domains_stage2" ) ) {
-		realign_domains_stage2_ = tag->getOption< bool >( "realign_domains_stage2" );
-	}
-	if ( tag->hasOption( "add_non_init_chunks" ) ) {
-		add_non_init_chunks_ = tag->getOption< core::Real >( "add_non_init_chunks" );
-	}
-	if ( tag->hasOption( "frag_1mer_insertion_weight" ) ) {
-		frag_1mer_insertion_weight_ = tag->getOption< core::Real >( "frag_1mer_insertion_weight" );
-	}
-	if ( tag->hasOption( "small_frag_insertion_weight" ) ) {
-		small_frag_insertion_weight_ = tag->getOption< core::Real >( "small_frag_insertion_weight" );
-	}
-	if ( tag->hasOption( "big_frag_insertion_weight" ) ) {
-		big_frag_insertion_weight_ = tag->getOption< core::Real >( "big_frag_insertion_weight" );
-	}
-	if ( tag->hasOption( "chunk_insertion_weight" ) ) {
-		chunk_insertion_weight_ = tag->getOption< core::Real >( "chunk_insertion_weight" );
-	}
-	if ( tag->hasOption( "frag_weight_aligned" ) ) {
-		frag_weight_aligned_ = tag->getOption< core::Real >( "frag_weight_aligned" );
-	}
-	if ( tag->hasOption( "auto_frag_insertion_weight" ) ) {
-		auto_frag_insertion_weight_ = tag->getOption< bool >( "auto_frag_insertion_weight" );
-	}
-	if ( tag->hasOption( "max_registry_shift" ) ) {
-		max_registry_shift_ = tag->getOption< core::Size >( "max_registry_shift" );
-	}
-	if ( tag->hasOption( "repeats" ) ) {
-		relax_repeats_ = tag->getOption< core::Size >( "repeats" );
-	}
-	if ( tag->hasOption( "disulf_file" ) ) {
-		disulf_file_ = tag->getOption< std::string >( "disulf_file" );
-	}
-
-	// stage 2-specific options
-	if ( tag->hasOption( "no_global_frame" ) ) {
-		no_global_frame_ = tag->getOption< bool >( "no_global_frame" );
-	}
-	if ( tag->hasOption( "linmin_only" ) ) {
-		linmin_only_ = tag->getOption< bool >( "linmin_only" );
-	}
-	if ( tag->hasOption( "cartfrag_overlap" ) ) {
-		cartfrag_overlap_ = tag->getOption< core::Size >( "cartfrag_overlap" );
-	}
-	if ( tag->hasOption( "seqfrags_only" ) ) {
-		seqfrags_only_ = tag->getOption< core::Size >( "seqfrags_only" );
-	}
-	if ( tag->hasOption( "skip_long_min" ) ) {
-		skip_long_min_ = tag->getOption< core::Size >( "skip_long_min" );
-	}
-
-
-	// scorefxns
-	if ( tag->hasOption( "stage1_scorefxn" ) ) {
-		std::string const scorefxn_name( tag->getOption<std::string>( "stage1_scorefxn" ) );
-		stage1_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-	}
-	if ( tag->hasOption( "stage2_scorefxn" ) ) {
-		std::string const scorefxn_name( tag->getOption<std::string>( "stage2_scorefxn" ) );
-		stage2_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-	}
-	if ( tag->hasOption( "stage2_min_scorefxn" ) ) {
-		std::string const scorefxn_name( tag->getOption<std::string>( "stage2_min_scorefxn" ) );
-		stage2min_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-	}
-	if ( tag->hasOption( "stage2_pack_scorefxn" ) ) {
-		if ( !cenrot_ ) {
-			TR << "Warning! Ignoring stage2_pack_scorefxn declaration since cenrot is not set." << std::endl;
-		} else {
-			std::string const scorefxn_name( tag->getOption<std::string>( "stage2_pack_scorefxn" ) );
-			stage2pack_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-		}
-	}
-	if ( tag->hasOption( "fa_scorefxn" ) ) {
-		std::string const scorefxn_name( tag->getOption<std::string>( "fa_scorefxn" ) );
-		fa_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
-	}
-
-	// ddomain options
-	hcut_ = tag->getOption< core::Real >( "domain_hcut" , 0.18);
-	pcut_ = tag->getOption< core::Real >( "domain_pcut" , 0.81);
-	length_ = tag->getOption< core::Size >( "domain_length" , 38);
-
-	// user constraints
-	coord_cst_res_ = tag->getOption<std::string>( "coord_cst_res", "" );
-
-	// if user constraints are defined, make sure coord_csts are defined in at least one stage
-	if ( coord_cst_res_.size() > 0 ) {
-		runtime_assert(
-			stage1_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
-			stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
-			fa_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 );
-	}
-
-	// fragments
-	utility::vector1< utility::tag::TagCOP > const branch_tags( tag->getTags() );
-	utility::vector1< utility::tag::TagCOP >::const_iterator tag_it;
-	for ( tag_it = branch_tags.begin(); tag_it != branch_tags.end(); ++tag_it ) {
-		if ( (*tag_it)->getName() == "Fragments" ) {
-			using namespace core::fragment;
-			if ( (*tag_it)->hasOption( "three_mers" ) ) {
-				core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "three_mers" )  );
-				fragments_small_.push_back(frags);
-			} else if ( (*tag_it)->hasOption( "small" ) ) {
-				utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "small" ), ',');
-				for ( core::Size i=1; i<= frag_files.size(); ++i ) {
-					fragments_small_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
-				}
-			}
-			if ( (*tag_it)->hasOption( "nine_mers" ) ) {
-				core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "nine_mers" ) );
-				fragments_big_.push_back(frags);
-			} else if ( (*tag_it)->hasOption( "big" ) ) {
-				utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "big" ), ',');
-				for ( core::Size i=1; i<= frag_files.size(); ++i ) {
-					fragments_big_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
-				}
-			}
-		}
-
-		if ( (*tag_it)->getName() == "Template" ) {
-			std::string const template_fn = (*tag_it)->getOption<std::string>( "pdb" );
-			std::string const cst_fn = (*tag_it)->getOption<std::string>( "cst_file", "AUTO" );  // should this be NONE?
-			auto const weight = (*tag_it)->getOption<core::Real>( "weight", 1.0 );
-			std::string const symm_file = (*tag_it)->getOption<std::string>( "symmdef", "" );
-
-			// randomize some chains
-			utility::vector1< char > rand_chains;
-			if ( (*tag_it)->hasOption( "randomize" ) ) {
-				std::string rand_chain_str = (*tag_it)->getOption<std::string>( "randomize", "" );
-				utility::vector1< std::string > rand_chain_strs = utility::string_split( rand_chain_str, ',');
-				for ( core::Size j = 1; j<=rand_chain_strs.size(); ++j ) {
-					if ( rand_chain_strs[j].length() != 0 ) {
-						rand_chains.push_back( rand_chain_strs[j][0] );
+				// (2) realign structures per-domain
+				if ( realign_domains_ ) {
+					//
+					if ( std::find( non_null_template_indices_.begin(), non_null_template_indices_.end(), initial_template_index )
+							!= non_null_template_indices_.end() ) {
+						align_templates_by_domain(templates_[initial_template_index], domains_all_templ_[initial_template_index]);
+					} else {
+						if ( non_null_template_indices_.size() == 0 ) {
+							TR << "No non-extended templates.  Skipping alignment." << std::endl;
+						} else {
+							TR << "Cannot align to extended template! Choosing a random template instead." << std::endl;
+							core::Size aln_target = numeric::random::random_range(1, non_null_template_indices_.size() );
+							align_templates_by_domain(templates_[aln_target], domains_all_templ_[aln_target]);
+						}
 					}
 				}
+
+				// (3) apply symmetry
+				std::string symmdef_file = symmdef_files_[initial_template_index];
+				if ( !symmdef_file.empty() && symmdef_file != "NULL" ) {
+					protocols::symmetry::SetupForSymmetryMover makeSymm( symmdef_file );
+					makeSymm.apply(pose);
+
+					//fpd   to get the right rotamer set we need to do this
+					basic::options::option[basic::options::OptionKeys::symmetry::symmetry_definition].value( "dummy" );
+
+					// xyz copy hetatms (properly handle cases where scoring subunit is not the first)
+					if ( add_hetatm_ ) {
+						for ( core::Size ihet=1; ihet <= hetatms.size(); ++ihet ) {
+							core::conformation::Residue const &res_in = templates_[initial_template_index]->residue(hetatms[ihet].first);
+							for ( core::Size iatm=1; iatm<=res_in.natoms(); ++iatm ) {
+								core::id::AtomID tgt(iatm,hetatms[ihet].second);
+								pose.set_xyz( tgt, res_in.xyz( iatm ) );
+							}
+						}
+					}
+				}
+
+				// (4) add a virtual if we have a map or coord csts
+				//     keep after symm
+				//     should we check if a map is loaded (or density scoring is on) instead??
+				if ( option[ OptionKeys::edensity::mapfile ].user() || user_csts_.size() > 0 ) {
+					MoverOP dens( utility::pointer::make_shared< protocols::electron_density::SetupForDensityScoringMover >() );
+					dens->apply( pose );
+				}
+
+				// (5) initialize template history
+				//     keep after symm
+				TemplateHistoryOP history( utility::pointer::make_shared< TemplateHistory >(pose) );
+				history->setall( initial_template_index );
+				pose.data().set( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY, history );
+
+				// (6) allowed movement
+				utility::vector1<bool> allowed_to_move;
+				allowed_to_move.resize(pose.size(),true);
+				for ( int i=1; i<=(int)residue_sample_template_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_template_[i];
+				for ( int i=1; i<=(int)residue_sample_abinitio_.size(); ++i ) allowed_to_move[i] = allowed_to_move[i] && residue_sample_abinitio_[i];
+
+				// STAGE 1
+				//fpd constraints are handled a little bit weird
+				//  * foldtree hybridize sets chainbreak variants then applies constraints (so c-beta csts are treated properly)
+				//  * after chainbreak variants are removed, csts are removed and reapplied in this function
+				//  * finally after switch to fullatom CSTs are reapplied again (optionally using a different CST file)
+				// If "AUTO" is specified for cen_csts automatic centroid csts are generated
+				// If "AUTO" is specified for fa_csts automatic fa csts are generated
+				// If "NONE" is specified for fa_csts, cen csts are used (AUTO or otherwise)
+				// An empty string is treated as equivalent to "NONE"
+
+				// fold tree hybridize
+				if ( numeric::random::rg().uniform() < stage1_probability_ ) {
+
+					for ( core::Size repeatstage1=0; repeatstage1 < jump_move_repeat_; ++repeatstage1 ) {
+
+						std::string cst_fn = template_cst_fn_[initial_template_index];
+
+						FoldTreeHybridizeOP ft_hybridize(
+								utility::pointer::make_shared< FoldTreeHybridize >(
+									initial_template_index, templates_aln_, template_weights_,
+									template_chunks_, frags_small, frags_big) ) ;
+
+						ft_hybridize->set_constraint_file( cst_fn );
+						ft_hybridize->set_constraint( cen_cst_in_ );
+						ft_hybridize->set_scorefunction( stage1_scorefxn_ );
+
+						// options
+						ft_hybridize->set_increase_cycles( stage1_increase_cycles_ );
+						ft_hybridize->set_stage1_1_cycles( stage1_1_cycles_ );
+						ft_hybridize->set_stage1_2_cycles( stage1_2_cycles_ );
+						ft_hybridize->set_stage1_3_cycles( stage1_3_cycles_ );
+						ft_hybridize->set_stage1_4_cycles( stage1_4_cycles_ );
+						ft_hybridize->set_add_non_init_chunks( add_non_init_chunks_ );
+						ft_hybridize->set_add_hetatm( add_hetatm_, hetatm_self_cst_weight_, hetatm_prot_cst_weight_ );
+						ft_hybridize->set_frag_1mer_insertion_weight( frag_1mer_insertion_weight_ );
+						ft_hybridize->set_small_frag_insertion_weight( small_frag_insertion_weight_ );
+						ft_hybridize->set_big_frag_insertion_weight( big_frag_insertion_weight_ );
+						ft_hybridize->set_chunk_insertion_weight( chunk_insertion_weight_ );
+						ft_hybridize->set_frag_weight_aligned( frag_weight_aligned_ );
+						ft_hybridize->set_auto_frag_insertion_weight( auto_frag_insertion_weight_ );
+						ft_hybridize->set_max_registry_shift( max_registry_shift_ );
+
+						// strand pairings
+						ft_hybridize->set_pairings_file( pairings_file_ );
+						ft_hybridize->set_sheets( sheets_ );
+						ft_hybridize->set_random_sheets( random_sheets_ );
+						ft_hybridize->set_filter_templates( filter_templates_ );
+
+						// allowed movement
+						ft_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
+						ft_hybridize->set_minimize_at_end( min_after_stage1_ );
+						ft_hybridize->set_minimize_sf( stage2_scorefxn_ );
+
+						// max insertion
+						ft_hybridize->set_max_insertion( max_contig_insertion_ );
+
+						// other cst stuff
+						ft_hybridize->set_user_csts( user_csts_ );
+
+						// finally run stage 1
+						ft_hybridize->apply(pose);
+
+						// get strand pairings if they exist for constraints in later stages
+						strand_pairs_ = ft_hybridize->get_strand_pairs();
+
+						//jump perturbation and minimization
+						//fpd!  these docking moves should be incorporated as part of stage 1!
+						if ( jump_move_ ) {
+							do_intrastage_docking( pose );
+						}
+					} //end of repeatstage1
+
+				} else {
+					// just do frag insertion in unaligned regions
+					core::pose::PoseOP chosen_templ = templates_aln_[initial_template_index];
+					protocols::loops::Loops chosen_contigs = template_contigs_[initial_template_index];
+					initialize_and_sample_loops(pose, chosen_templ, chosen_contigs, stage1_scorefxn_);
+				}
+
+				// realign domains to the output of stage 1
+				if ( jump_move_ || realign_domains_stage2_ ) {
+					TR << "Realigning template domains to stage1 pose." << std::endl;
+					core::pose::PoseOP stage1pose( utility::pointer::make_shared< core::pose::Pose >( pose ) );
+					align_templates_by_domain(stage1pose); // don't use stored domains; recompute parse from model
+				}
+
+				//write gdtmm to output
+				if ( native_ && native_->size() ) {
+					gdtmm = get_gdtmm(*native_, pose, aln_);
+					core::pose::setPoseExtraScore( pose, "GDTMM_after_stage1", gdtmm);
+					TR << "GDTMM_after_stage1" << F(8,3,gdtmm) << std::endl;
+				}
+
+				// STAGE 2
+				// apply constraints
+				if ( stage2_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
+					std::string cst_fn = template_cst_fn_[initial_template_index];
+					if ( !keep_pose_constraint_ ) {
+						if ( ! cen_cst_in_.empty() ) {
+							setup_constraints(pose, cen_cst_in_);
+						} else {
+							setup_centroid_constraints( pose, templates_aln_, template_weights_, cst_fn );
+						}
+					}
+					if ( add_hetatm_ ) {
+						add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
+					}
+					if ( strand_pairs_.size() ) {
+						add_strand_pairs_cst(pose, strand_pairs_);
+					}
+				}
+
+				// add torsion constraints derived from fragments
+				if ( csts_from_frags_ ) {
+					if ( stage2_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
+						add_fragment_csts( pose );
+					} else {
+						TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
+					}
+				}
+
+				if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
+					if ( user_csts_.size() > 0 ) {
+						setup_user_coordinate_constraints(pose,user_csts_);
+					}
+				}
+
+				if ( !option[cm::hybridize::skip_stage2]() ) {
+					core::scoring::ScoreFunctionOP stage2_scorefxn_clone = stage2_scorefxn_->clone();
+
+					core::scoring::methods::EnergyMethodOptions lowres_options(stage2_scorefxn_clone->energy_method_options());
+					lowres_options.set_cartesian_bonded_linear(true);
+					stage2_scorefxn_clone->set_energy_method_options(lowres_options);
+
+					CartesianHybridizeOP cart_hybridize(
+							utility::pointer::make_shared< CartesianHybridize >( templates_aln_, template_weights_, template_chunks_,template_contigs_, frags_big ) );
+
+					// default scorefunctions (cenrot-compatable)
+					if ( stage2_scorefxn_!=nullptr ) cart_hybridize->set_scorefunction( stage2_scorefxn_ );
+					if ( stage2pack_scorefxn_!=nullptr ) cart_hybridize->set_pack_scorefunction( stage2pack_scorefxn_ );
+					if ( stage2min_scorefxn_!=nullptr ) cart_hybridize->set_min_scorefunction( stage2min_scorefxn_ );
+
+					// set options
+					cart_hybridize->set_increase_cycles( stage2_increase_cycles_ );
+					cart_hybridize->set_no_global_frame( no_global_frame_ );
+					cart_hybridize->set_linmin_only( linmin_only_ );
+					cart_hybridize->set_seqfrags_only( seqfrags_only_ );
+					cart_hybridize->set_cartfrag_overlap( cartfrag_overlap_ );
+					cart_hybridize->set_skip_long_min( skip_long_min_ );
+					cart_hybridize->set_cenrot( cenrot_ );
+					cart_hybridize->set_fragment_probs(fragprob_stage2_, randfragprob_stage2_);
+
+					// max insertion
+					cart_hybridize->set_max_insertion( max_contig_insertion_ );
+
+					// per-residue controls
+					cart_hybridize->set_per_residue_controls( residue_sample_template_, residue_sample_abinitio_ );
+
+					// finally run stage 2
+					cart_hybridize->apply(pose);
+				}
+
+				//write gdtmm to output
+				if ( native_ && native_->size() ) {
+					gdtmm = get_gdtmm(*native_, pose, aln_);
+					core::pose::setPoseExtraScore( pose, "GDTMM_after_stage2", gdtmm);
+					TR << "GDTMM_after_stage2" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
+				}
+				// get fragment history
+				runtime_assert( pose.data().has( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
+				history = utility::pointer::static_pointer_cast< TemplateHistory >( pose.data().get_ptr( CacheableDataType::TEMPLATE_HYBRIDIZATION_HISTORY ) );
+
+				TR << "History :";
+				for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4,i); }
+				TR << std::endl;
+				TR << "History :";
+				for ( core::Size i=1; i<= history->size(); ++i ) { TR << I(4, history->get(i)); }
+				TR << std::endl;
+
+				core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+				mm->set_bb  ( true );
+				mm->set_chi ( true );
+				mm->set_jump( true );
+
+				//fpd -- in positions where no fragment insertions are allowed, also allow no minimization
+				if ( residue_sample_template_.size() > 0 && residue_sample_abinitio_.size() > 0 ) {
+					for ( int i=1; i<=(int)nres_tgt; ++i ) {
+						if ( !residue_sample_template_[i] && !residue_sample_abinitio_[i] ) {
+							TR.Trace << "locking residue " << i << std::endl;
+							mm->set_bb  ( i, false );
+							mm->set_chi ( i, false );
+						}
+					}
+				}
+
+				if ( core::pose::symmetry::is_symmetric(pose) ) {
+					core::pose::symmetry::make_symmetric_movemap( pose, *mm );
+				}
+
+				// stage "2.5" .. minimize with centroid energy + full-strength cart bonded
+				if ( !option[cm::hybridize::skip_stage2]() ) {
+					core::optimization::MinimizerOptions options_lbfgs( "lbfgs_armijo_nonmonotone", 0.01, true, false, false );
+					core::optimization::CartesianMinimizer minimizer;
+					auto n_min_cycles =(core::Size) (200.*stage25_increase_cycles_);
+					options_lbfgs.max_iter(n_min_cycles);
+					(*stage2_scorefxn_)(pose); minimizer.run( pose, *mm, *stage2_scorefxn_, options_lbfgs );
+				}
+
+				// STAGE 3: RELAX
+				if ( batch_relax_ > 0 ) {
+					// set disulfides before going to FA
+					if ( disulf_file_.length() > 0 ) {
+						// delete current disulfides
+						for ( int i=1; i<=(int)pose.size(); ++i ) {
+							if ( !pose.residue(i).is_protein() ) continue;
+							if ( pose.residue(i).type().is_disulfide_bonded() ) {
+								core::conformation::change_cys_state( i, "CYS", pose.conformation() );
+							}
+						}
+
+						// manually add new ones
+						TR << " add disulfide: " << std::endl;
+						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].value(disulf_file_);
+						core::pose::initialize_disulfide_bonds(pose);
+						// must reset this since initialize_disulfide_bonds is used in pose io
+						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].deactivate();
+						basic::options::option[ basic::options::OptionKeys::in::fix_disulf ].to_default(); // reset to the default value
+					} else {
+						pose.conformation().detect_disulfides();
+					}
+
+					protocols::moves::MoverOP tofa( utility::pointer::make_shared< protocols::simple_moves::SwitchResidueTypeSetMover >( core::chemical::FA_STANDARD ) );
+					tofa->apply(pose);
+
+					// apply fa constraints
+					std::string cst_fn = template_cst_fn_[initial_template_index];
+					if ( fa_scorefxn_->get_weight( core::scoring::atom_pair_constraint ) != 0 ) {
+						if ( !keep_pose_constraint_ ) {
+							if ( ! fa_cst_in_.empty() ) {
+								setup_constraints(pose, fa_cst_in_);
+							} else {
+								setup_fullatom_constraints( pose, templates_aln_, template_weights_, cst_fn, fa_cst_fn_ );
+							}
+						} else {
+							pose.constraint_set(save_pose_constraint_set);
+						}
+						if ( add_hetatm_ ) {
+							add_non_protein_cst(pose, *templates_aln_[initial_template_index], hetatm_self_cst_weight_, hetatm_prot_cst_weight_);
+						}
+						if ( strand_pairs_.size() ) {
+							add_strand_pairs_cst(pose, strand_pairs_);
+						}
+					}
+
+					// add torsion constraints derived from fragments
+					if ( csts_from_frags_ ) {
+						if ( fa_scorefxn_->get_weight( core::scoring::dihedral_constraint ) != 0 ) {
+							add_fragment_csts( pose );
+						} else {
+							TR << "Warning! csts_from_frags is on but dihedral_constraint weight=0.  Ignoring!" << std::endl;
+						}
+					}
+
+					if ( stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) != 0 ) {
+						// note that CSTs are updated based on stage 1 movement
+						//   this may or may not be desirable
+						if ( user_csts_.size() > 0 ) {
+							setup_user_coordinate_constraints(pose,user_csts_);
+						}
+					}
+
+					if ( batch_relax_ == 1 ) {
+						// standard relax
+						// do relax _without_ ramping down coordinate constraints
+						TR << " batch_relax 1 : " << std::endl;
+						protocols::relax::FastRelax relax_prot( fa_scorefxn_, relax_repeats_ ,"NO CST RAMPING" );
+						relax_prot.min_type("lbfgs_armijo_nonmonotone");
+						relax_prot.apply(pose);
+					} else {
+						// batch relax
+						// add stucture to queue
+						SilentFileOptions opts;
+						SilentStructOP new_struct = SilentStructFactory::get_instance()->get_silent_struct("binary",opts);
+						new_struct->fill_struct( pose );
+						new_struct->energies_from_pose( pose );
+						post_centroid_structs.push_back( new_struct );
+
+						if ( post_centroid_structs.size() == batch_relax_ ) {
+							protocols::relax::FastRelax relax_prot( fa_scorefxn_ );
+							relax_prot.min_type("lbfgs_armijo_nonmonotone");
+							relax_prot.set_force_nonideal(true);
+							relax_prot.set_script_to_batchrelax_default( relax_repeats_ );
+
+							// need to use a packer task factory to handle poses with different disulfide patterning
+							core::pack::task::TaskFactoryOP tf( utility::pointer::make_shared< core::pack::task::TaskFactory >() );
+							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::InitializeFromCommandline >() );
+							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::IncludeCurrent >() );
+							tf->push_back( utility::pointer::make_shared< core::pack::task::operation::RestrictToRepacking >() );
+							relax_prot.set_task_factory( tf );
+
+							// notice! this assumes all poses in a set have the same constraints!
+							relax_prot.batch_apply(post_centroid_structs, pose.constraint_set()->clone());
+
+							// reinflate pose
+							post_centroid_structs[0]->fill_pose( pose );
+						} else {
+							protocols::moves::MoverOP tocen( new protocols::simple_moves::SwitchResidueTypeSetMover( core::chemical::CENTROID ) );
+							tocen->apply(pose);
+							need_more_samples = true;
+						}
+					}
+				} else {
+					// no fullatom sampling
+					(*stage2_scorefxn_)(pose);
+				}
 			}
-			bool const align_pdb_info = (*tag_it)->getOption<bool>( "auto_align", true );
-			add_template(template_fn, cst_fn, symm_file, weight, rand_chains, align_pdb_info);
+			if ( native_ && native_->size() ) {
+				gdtmm = get_gdtmm(*native_, pose, aln_);
+				core::pose::setPoseExtraScore( pose, "GDTMM_final", gdtmm);
+				TR << "GDTMM_final" << ObjexxFCL::format::F(8,3,gdtmm) << std::endl;
+			}
 		}
 
-		// strand pairings
-		if ( (*tag_it)->getName() == "Pairings" ) {
-			pairings_file_ = (*tag_it)->getOption< std::string >( "file", "" );
-			if ( (*tag_it)->hasOption("sheets") ) {
-				auto sheets = (*tag_it)->getOption< core::Size >( "sheets" );
-				sheets_.clear();
-				random_sheets_.clear();
-				sheets_.push_back(sheets);
-			} else if ( (*tag_it)->hasOption("random_sheets") ) {
-				auto random_sheets = (*tag_it)->getOption< core::Size >( "random_sheets" );
-				sheets_.clear();
-				random_sheets_.clear();
-				random_sheets_.push_back(random_sheets);
+
+		void
+			HybridizeProtocol::align_templates_by_domain(core::pose::PoseOP & ref_pose, utility::vector1 <Loops> domains)
+			{
+				// get domain parse if not specified
+				core::pose::PoseOP working_pose;
+				if ( core::pose::symmetry::is_symmetric(*ref_pose) ) {
+					working_pose = utility::pointer::make_shared< core::pose::Pose >();
+					core::pose::symmetry::extract_asymmetric_unit(*ref_pose, *working_pose);
+				} else {
+					working_pose = ref_pose;
+				}
+
+				if ( domains.size() == 0 ) {
+					DDomainParse ddom(pcut_,hcut_,length_);
+					utility::vector1 <Loops> domains = ddom.split( *working_pose );
+				}
+
+				// clone original poses -> copies for alignment
+				templates_aln_.clear();
+				for ( core::Size i_pose=1; i_pose <= templates_.size(); ++i_pose ) {
+					templates_aln_.push_back(
+							utility::pointer::make_shared< core::pose::Pose >( *templates_[i_pose] ) );
+				}
+
+				for ( core::Size i_pose=1; i_pose <= templates_aln_.size(); ++i_pose ) {
+					if ( templates_aln_[i_pose] == ref_pose ) continue; // compare pointers
+					align_by_domain(*templates_aln_[i_pose], *working_pose, domains);
+					//std::string out_fn = template_fns_[i_pose] + "_realigned.pdb";
+					//poses[i_pose]->dump_pdb(out_fn);
+				}
 			}
-			filter_templates_ = (*tag_it)->getOption<bool>( "filter_templates" , false );
-		}
 
-		// per-residue control
-		if ( (*tag_it)->getName() == "DetailedControls" ) {
-			if ( (*tag_it)->hasOption( "task_operations" ) ) {
-				core::pack::task::TaskFactoryOP task_factory = protocols::rosetta_scripts::parse_task_operations( *tag_it, data );
-				detailed_controls_settings_.push_back(
-					detailedControlsTagSetting("task_operations", task_factory, 0, 0, sampleEnum::unset, sampleEnum::unset));
-			} else {
-				core::Size const start_res = (*tag_it)->getOption<core::Size>( "start_res", 1 );
-				core::Size const stop_res = (*tag_it)->getOption<core::Size>( "stop_res", 0 );
 
-				sampleEnum sample_template(sampleEnum::unset), sample_abinitio(sampleEnum::unset);
-				if ( (*tag_it)->hasOption( "sample_template" ) ) {
-					sample_template = (*tag_it)->getOption<bool>( "sample_template", true ) ? sampleEnum::on : sampleEnum::off;
+		void
+			HybridizeProtocol::align_by_domain(core::pose::Pose & pose, core::pose::Pose const & ref_pose, utility::vector1 <Loops> domains) {
+				// ASSUME:
+				//    domains cover the full pose (no gaps)
+				utility::vector1< core::Real > aln_cutoffs;
+				aln_cutoffs.push_back(6);
+				aln_cutoffs.push_back(4);
+				aln_cutoffs.push_back(3);
+				aln_cutoffs.push_back(2);
+				aln_cutoffs.push_back(1.5);
+				aln_cutoffs.push_back(1);
+				core::Real min_coverage = 0.2;
+
+				// find corresepondance of ligands to nearest residues (in moving pose)
+				core::Size last_protein_residue=pose.size();
+				while ( last_protein_residue>0 && !pose.residue_type(last_protein_residue).is_protein() ) last_protein_residue--;
+
+				if ( last_protein_residue == 0 ) return;
+
+				std::map< core::Size, core::Size > ligres_map;
+				for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
+					core::Real mindist = 999.0;
+					core::Size minj = 1;
+					for ( core::Size j=1; j<=last_protein_residue; ++j ) {
+						core::Real dist_ij = (pose.residue(i).xyz(1) - pose.residue(j).xyz(1)).length(); // hacky (using atom 1 only)
+						if ( dist_ij < mindist ) {
+							mindist = dist_ij;
+							minj = (pose.pdb_info()) ? pose.pdb_info()->number(j) : j;
+						}
+					}
+					ligres_map[i] = minj;
 				}
-				if ( (*tag_it)->hasOption( "sample_abinitio" ) ) {
-					sample_abinitio = (*tag_it)->getOption<bool>( "sample_abinitio", true ) ? sampleEnum::on : sampleEnum::off;
+
+
+				for ( core::Size i_domain = 1; i_domain <= domains.size() ; ++i_domain ) {
+					core::id::AtomID_Map< core::id::AtomID > atom_map;
+					core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
+
+					// find all residues in moving pose corresponding to this domain
+					std::list <core::Size> residue_list;
+					core::Size n_mapped_residues=0;
+					for ( core::Size ires=1; ires<=pose.size(); ++ires ) {
+						if ( !pose.residue_type(ires).is_protein() ) continue;
+						int pose_res = (pose.pdb_info()) ? pose.pdb_info()->number(ires) : ires;
+						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+							if ( pose_res < (int)domains[i_domain][iloop].start() || pose_res > (int)domains[i_domain][iloop].stop() ) continue;
+							residue_list.push_back(ires);
+						}
+					}
+
+					// find all residues in reference pose corresponding to this domain
+					std::list <core::Size> ref_residue_list;
+					for ( core::Size jres=1; jres<=ref_pose.size(); ++jres ) {
+						if ( !ref_pose.residue_type(jres).is_protein() ) continue;
+						int ref_pose_res = (ref_pose.pdb_info()) ? ref_pose.pdb_info()->number(jres) : jres;
+						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+							if ( ref_pose_res < (int)domains[i_domain][iloop].start() || ref_pose_res > (int)domains[i_domain][iloop].stop() ) continue;
+							ref_residue_list.push_back(jres);
+						}
+					}
+
+					// get tmalign sequence mapping
+					TMalign tm_align;
+					std::string seq_pose, seq_ref, aligned;
+					int reval = tm_align.apply(pose, ref_pose, residue_list, ref_residue_list);
+					if ( reval != 0 ) continue;  // TO DO: remove this domain
+
+					tm_align.alignment2AtomMap(pose, ref_pose, residue_list, ref_residue_list, n_mapped_residues, atom_map);
+					tm_align.alignment2strings(seq_pose, seq_ref, aligned);
+
+					using namespace ObjexxFCL::format;
+					core::Size norm_length = residue_list.size() < ref_residue_list.size() ? residue_list.size():ref_residue_list.size();
+					TR << "Align domain with TMscore of " << F(8,3,tm_align.TMscore(norm_length)) << std::endl;
+					TR << seq_pose << std::endl;
+					TR << aligned << std::endl;
+					TR << seq_ref << std::endl;
+
+					if ( n_mapped_residues < 6 ) continue;  // TO DO: remove this domain
+
+					// add in ligand residues
+					for ( core::Size i=last_protein_residue+1; i<=pose.size(); ++i ) {
+						core::Size res_controlling_i = ligres_map[i];
+						for ( core::Size iloop=1; iloop<=domains[i_domain].num_loop(); ++iloop ) {
+							if ( res_controlling_i < domains[i_domain][iloop].start() || res_controlling_i > domains[i_domain][iloop].stop() ) continue;
+							residue_list.push_back(i);
+						}
+					}
+
+					partial_align(pose, ref_pose, atom_map, residue_list, true, aln_cutoffs, min_coverage); // iterate_convergence = true
 				}
-				detailed_controls_settings_.push_back(
-					detailedControlsTagSetting("else", nullptr, start_res, stop_res, sample_template, sample_abinitio));
-			} // if tag == DetailedControls
-		} //forach tag
-	}
-}
-
-std::string HybridizeProtocol::get_name() const {
-	return mover_name();
-}
-
-std::string HybridizeProtocol::mover_name() {
-	return "Hybridize";
-}
-
-std::string hybridize_subelement_ct_name( std::string const & name ) {
-	return "Hybridize_subelement_" + name + "Type";
-}
-
-void HybridizeProtocol::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd )
-{
-
-	using namespace utility::tag;
-	AttributeList attlist;
-
-	//basic direct attributes
-	attlist
-		+ XMLSchemaAttribute::attribute_w_default( "stage1_increase_cycles", xsct_real, "Increase/decrease sampling in stage 1", "1.0" ) //XRW TODO: should be nonnegative real
-		+ XMLSchemaAttribute::attribute_w_default( "stage2_increase_cycles", xsct_real, "Increase/decrease sampling in stage 2", "1.0" ) //XRW TODO: should be nonnegative real
-		+ XMLSchemaAttribute::attribute_w_default( "stage2_temperature", xsct_real, "kT for the Monte Carlo simulation", "2.0" ) //XRW TODO: should be nonnegative real
-		+ XMLSchemaAttribute::attribute_w_default( "stage2.5_increase_cycles", xsct_real, "Increase/decrease number of minimization steps following stage 2", "1.0" ) //XRW TODO: should be nonnegative real
-		+ XMLSchemaAttribute( "fa_cst_file", xs_string, "constraints file for fullatom stage" )
-		+ XMLSchemaAttribute::attribute_w_default( "batch", xsct_non_negative_integer, "The number of centroid structures to generate per fullatom model. Setting this to 0 will only run centroid modeling.", "1" )
-		+ XMLSchemaAttribute::attribute_w_default( "jump_move", xsct_rosetta_bool, "rigid body moves in stage 1", "false" )
-		+ XMLSchemaAttribute::attribute_w_default( "jump_move_repeat", xsct_non_negative_integer, "cycles in stage 1 that handle rigid body moves", "1" )
-		+ XMLSchemaAttribute::attribute_w_default( "keep_pose_constraint", xsct_rosetta_bool, "If set to true, keep constraints on the incoming pose (useful if constraints are generated in a mover prior to hybridize)", "false" )
-		+ XMLSchemaAttribute::attribute_w_default( "cenrot", xsct_rosetta_bool, "centroid rotamer modeling; necessary for stage2_pack_scorefxn to be useful; probably requires command line option -corrections:score:cenrot", "false" )
-		+ XMLSchemaAttribute( "csts_from_frags", xsct_rosetta_bool, "when set, derives dihedral constraints from input fragments; you need to set 'dihedral_constraint' weight in the stages you want to use this")
-		+ XMLSchemaAttribute( "max_contig_insertion", xsct_non_negative_integer, "Limits the length of 'template recombination' moves. Useful when inputs are full-length (no gaps).")
-		+ XMLSchemaAttribute( "min_after_stage1", xsct_rosetta_bool, "minimize after stage 1 (?)")
-		+ XMLSchemaAttribute( "fragprob_stage2", xsct_real, "controls the ratio of fragment insertions versus template recombination moves, implicit default 0.3")
-		+ XMLSchemaAttribute( "randfragprob_stage2", xsct_real, "controls the number of random fragfile insertions versus 'cutpoint' insertions, implicit default 0.5")
-		//ab initio options
-		+ XMLSchemaAttribute( "stage1_1_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-		+ XMLSchemaAttribute( "stage1_2_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-		+ XMLSchemaAttribute( "stage1_3_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-		+ XMLSchemaAttribute( "stage1_4_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
-		+ XMLSchemaAttribute( "stage1_probability", xsct_real, "probability of doing 'fold tree hybridize' for stage one (with rigid body moves(?) instead of 'frag insertion in unaligned regions'")
-		+ XMLSchemaAttribute( "add_hetatm", xsct_rosetta_bool, "If true, use ligands from input template files")
-		+ XMLSchemaAttribute( "hetatm_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated intra-ligand restraints.  Called hetatm_self_cst_weight in documentation.")
-		+ XMLSchemaAttribute( "hetatm_to_protein_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated ligand-protein restraints. Called hetatm_prot_cst_weight in documentation.")
-		+ XMLSchemaAttribute( "realign_domains", xsct_rosetta_bool, "If unset, this will not align the input domains to each other before running the protocol. Unsetting this option requires that input domains be previously aligned to a common reference frame. This option may be useful to unset for building models into density (if all inputs are docking into density).")
-		+ XMLSchemaAttribute( "realign_domains_stage2", xsct_rosetta_bool, "If set, realign domains in between the two centroid stages; default only aligns the initial models.")
-		+ XMLSchemaAttribute( "add_non_init_chunks", xsct_real, "Normally, secondary structure chunks are used from the starting model to set the foldtree. This option will steal chunks from other templates as well (as long as they do not overlap with current chunks); the number is the expected number of chunks (poisson distribution). This option is recommended when starting from an extended chain.")
-		+ XMLSchemaAttribute( "frag_1mer_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-		+ XMLSchemaAttribute( "small_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-		+ XMLSchemaAttribute( "big_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-		+ XMLSchemaAttribute( "chunk_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
-		+ XMLSchemaAttribute( "frag_weight_aligned", xsct_real, "Allow fragment insertions in template regions. The default is 0; increasing this will lead to increased model diversity.")
-		+ XMLSchemaAttribute( "auto_frag_insertion_weight", xsct_rosetta_bool, "automatically set fragment insertion weights")
-		+ XMLSchemaAttribute( "max_registry_shift", xsct_non_negative_integer, "Add a random move that shifts the sequence during model-building")
-		+ XMLSchemaAttribute( "repeats", xsct_non_negative_integer, "repeats for relax step")
-		+ XMLSchemaAttribute( "disulf_file", xs_string, "If specified, force the attached disulfide patterning")
-		//stage 2 options
-		+ XMLSchemaAttribute( "no_global_frame", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
-		+ XMLSchemaAttribute( "linmin_only", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
-		+ XMLSchemaAttribute( "cartfrag_overlap", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
-		+ XMLSchemaAttribute( "seqfrags_only", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
-		+ XMLSchemaAttribute( "skip_long_min", xsct_non_negative_integer, "only valid in Cartesian Hybridize; skip a final minimization")
-		//scorefunctions
-		+ XMLSchemaAttribute( "stage1_scorefxn", xs_string, "Scorefunction for stage 1 (looked up from DataMap")
-		+ XMLSchemaAttribute( "stage2_scorefxn", xs_string, "Scorefunction for stage 2 (looked up from DataMap")
-		+ XMLSchemaAttribute( "stage2_min_scorefxn", xs_string, "Scorefunction for stage 2 minimization (looked up from DataMap")
-		+ XMLSchemaAttribute( "stage2_pack_scorefxn", xs_string, "Scorefunction for stage 2 'packing' (looked up from DataMap. Only valid if boolean cenrot is true.")
-		+ XMLSchemaAttribute( "fa_scorefxn", xs_string, "Scorefunction for fullatom stage (looked up from DataMap")
-		//ddomain options (not a typo)
-		+ XMLSchemaAttribute::attribute_w_default( "domain_pcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.18")
-		+ XMLSchemaAttribute::attribute_w_default( "domain_hcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.81")
-		+ XMLSchemaAttribute::attribute_w_default( "domain_length", xsct_non_negative_integer, "Used in DDomainParse.  Aggressively undocumented.", "38");
-	//user constraints
-	core::pose::attributes_for_get_resnum_selector( attlist, xsd, "coord_cst_res");
-	//orphaned docstring: "residues with user-provided CoordinateConstraints; If defined, at least one of the scorefunctions in [stage1_scorefxn, stage2_scorefxn, fa_scorefxn] must have nonzero coordinate_constraint weights"); //XRW TODO maybe
-
-	// attributes for Fragments subelement
-	AttributeList fragment_subelement_attributes;
-	fragment_subelement_attributes
-		+ XMLSchemaAttribute( "three_mers", xs_string, "3mers fragments file")
-		+ XMLSchemaAttribute( "small", xs_string, "comma separated vector of small (probably 3mer) fragments files")
-		+ XMLSchemaAttribute( "nine_mers", xs_string, "9mers fragments file")
-		+ XMLSchemaAttribute( "big", xs_string, "comma separated vector of small (probably 3mer) fragments files");
-
-	// attributes for Template subelement
-	AttributeList template_subelement_attributes;
-	template_subelement_attributes
-		+ XMLSchemaAttribute::required_attribute( "pdb", xs_string, "file path to pdb template")
-		+ XMLSchemaAttribute::attribute_w_default( "cst_file", xs_string, "file path to constraints file associated with this template", "AUTO")
-		+ XMLSchemaAttribute::attribute_w_default( "weight", xsct_real, "Sampling frequency weight for this template", "1.0")
-		+ XMLSchemaAttribute( "symmdef", xs_string, "symmdef file associated with this template (only if using symmetry)")
-		+ XMLSchemaAttribute( "randomize", xs_string, "comma-seprated list of chains to randomize - not documented")
-		+ XMLSchemaAttribute::attribute_w_default( "auto_align", xsct_rosetta_bool, "frustratingly undocumented", "true");
-
-	std::string const pairings_warning(" sheets and random_sheets are mutually exclusive.");
-	// attributes for Pairings subelement
-	AttributeList pairings_subelement_attributes;
-	pairings_subelement_attributes
-		+ XMLSchemaAttribute::required_attribute( "file", xs_string, "path to pairings file")
-		+ XMLSchemaAttribute( "sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
-		+ XMLSchemaAttribute( "random_sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
-		+ XMLSchemaAttribute::attribute_w_default( "filter_templates", xsct_rosetta_bool, "remove templates with incorrect pairings", "false");
-
-	// attributes for DetailedControls subelement
-	AttributeList DetailedControls_subelement_attributes;
-	DetailedControls_subelement_attributes
-		+ XMLSchemaAttribute::attribute_w_default( "start_res", xsct_non_negative_integer, "starting residue for a DetailedControl region", "1")
-		+ XMLSchemaAttribute( "stop_res", xsct_non_negative_integer, "ending residue for a DetailedControl region; defaults to the rest of the Pose")
-		+ XMLSchemaAttribute::attribute_w_default( "sample_template", xsct_rosetta_bool, "if false, disallow template hybridization moves", "true")
-		+ XMLSchemaAttribute::attribute_w_default( "sample_abinitio", xsct_rosetta_bool, "if false, disallow fragment insertion moves", "true");
-	rosetta_scripts::attributes_for_parse_task_operations(DetailedControls_subelement_attributes);
-
-	XMLSchemaSimpleSubelementList subelements;
-	subelements.complex_type_naming_func( & hybridize_subelement_ct_name );
-	subelements.add_simple_subelement( "Fragments", fragment_subelement_attributes, "Instructions for fragments files.  Should occur exactly once.");
-	subelements.add_simple_subelement( "Template", template_subelement_attributes, "Instructions for templates. Must occur at least once, may occur as many times as you wish.");
-	subelements.add_simple_subelement( "Pairings", pairings_subelement_attributes, "Used with FoldTreeHybridize and poorly documented");
-	subelements.add_simple_subelement( "DetailedControls", DetailedControls_subelement_attributes, "Used to prevent regions from being sampled extensively (meaning, don't remodel regions where the model is already correct)");
-
-	protocols::moves::xsd_type_definition_w_attributes_and_repeatable_subelements( xsd, mover_name(), "This is the Hybridize mover at the core of comparative modeling (RosettaCM).  Typically its XML is written by a script rather than manually.", attlist, subelements );
-}
-
-/// @brief Provide the citation.
-void
-HybridizeProtocol::provide_citation_info(basic::citation_manager::CitationCollectionList & citations ) const {
-	basic::citation_manager::CitationCollectionOP collection(
-		utility::pointer::make_shared< basic::citation_manager::CitationCollection >(
-		mover_name(),
-		basic::citation_manager::CitedModuleType::Mover
-		)
-	);
-	collection->add_citation( basic::citation_manager::CitationManager::get_instance()->get_citation_by_doi("10.1016/j.str.2013.08.005") );
-
-	citations.add( collection );
-}
-
-std::string HybridizeProtocolCreator::keyname() const {
-	return HybridizeProtocol::mover_name();
-}
-
-protocols::moves::MoverOP
-HybridizeProtocolCreator::create_mover() const {
-	return utility::pointer::make_shared< HybridizeProtocol >();
-}
-
-void HybridizeProtocolCreator::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) const
-{
-	HybridizeProtocol::provide_xml_schema( xsd );
-}
+			}
 
 
-} // hybridization
-} // protocols
+		void
+			HybridizeProtocol::do_intrastage_docking(core::pose::Pose & pose) {
+				// call docking or symm docking
+				if ( core::pose::symmetry::is_symmetric(pose) ) {
+					/////
+					/////  SYMM LOGIC
+					protocols::symmetric_docking::SymDockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::symmetric_docking::SymDockingLowRes >(stage1_scorefxn_) );
+					docking_lowres_mover->apply(pose);
+
+					core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap>() );
+					mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( true );
+					core::pose::symmetry::make_symmetric_movemap( pose, *mm );
+
+					protocols::minimization_packing::MinMoverOP min_mover(
+							utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
+					min_mover->apply(pose);
+				} else {
+					/////
+					/////  ASYMM LOGIC
+					core::Size const rb_move_jump = 1; // use the first jump as the one between partners <<<< fpd: MAKE THIS A PARSIBLE OPTION
+					protocols::docking::DockingLowResOP docking_lowres_mover( utility::pointer::make_shared< protocols::docking::DockingLowRes >( stage1_scorefxn_, rb_move_jump ) );
+					docking_lowres_mover->apply(pose);
+
+					core::kinematics::MoveMapOP mm( utility::pointer::make_shared< core::kinematics::MoveMap >() );
+					mm->set_bb( false ); mm->set_chi( false ); mm->set_jump( rb_move_jump, true );
+					protocols::minimization_packing::MinMoverOP min_mover( utility::pointer::make_shared< protocols::minimization_packing::MinMover >( mm, stage1_scorefxn_, "lbfgs_armijo_nonmonotone", 0.01, true ) );
+					min_mover->apply(pose);
+				}
+			}
+
+		protocols::moves::MoverOP HybridizeProtocol::clone() const { return utility::pointer::make_shared< HybridizeProtocol >( *this ); }
+		protocols::moves::MoverOP HybridizeProtocol::fresh_instance() const { return utility::pointer::make_shared< HybridizeProtocol >(); }
+
+
+		void
+			HybridizeProtocol::parse_my_tag(
+					utility::tag::TagCOP tag,
+					basic::datacache::DataMap & data
+					)
+			{
+				// basic options
+				stage1_increase_cycles_ = tag->getOption< core::Real >( "stage1_increase_cycles", 1. );
+				stage2_increase_cycles_ = tag->getOption< core::Real >( "stage2_increase_cycles", 1. );
+				stage2_temperature_ = tag->getOption< core::Real >( "stage2_temperature", 2. );
+				stage25_increase_cycles_ = tag->getOption< core::Real >( "stage2.5_increase_cycles", 1. );
+				fa_cst_fn_ = tag->getOption< std::string >( "fa_cst_file", "" );
+				batch_relax_ = tag->getOption< core::Size >( "batch" , 1 );
+				jump_move_= tag->getOption< bool >( "jump_move" , false );
+				jump_move_repeat_= tag->getOption< core::Size >( "jump_move_repeat" , 1 );
+				keep_pose_constraint_= tag->getOption< bool >( "keep_pose_constraint" , false );
+				cenrot_= tag->getOption< bool >( "cenrot" , false );
+
+				//if( tag->hasOption( "task_operations" ) ){
+				//FPD   remove this option, it was used as a residue selector and not as options controlling packing
+				//      the 'DetailedControls' tag should replace one part of this, and a separate mover should generate interface constraints
+
+				// force starting template
+				//FPD   removed this option; it is redundant with weights! (set weight to 0 for templates we do not start with)
+
+
+				if ( tag->hasOption( "csts_from_frags" ) ) {
+					csts_from_frags_ = tag->getOption< bool >( "csts_from_frags" );
+				}
+				if ( tag->hasOption( "max_contig_insertion" ) ) {
+					max_contig_insertion_ = tag->getOption< int >( "max_contig_insertion" );
+				}
+
+				if ( tag->hasOption( "min_after_stage1" ) ) {
+					min_after_stage1_ = tag->getOption< bool >( "min_after_stage1" );
+				}
+				if ( tag->hasOption( "fragprob_stage2" ) ) {
+					fragprob_stage2_ = tag->getOption< core::Real >( "fragprob_stage2" );
+				}
+				if ( tag->hasOption( "randfragprob_stage2" ) ) {
+					randfragprob_stage2_ = tag->getOption< core::Real >( "randfragprob_stage2" );
+				}
+
+
+				// tons of ab initio options
+				if ( tag->hasOption( "stage1_1_cycles" ) ) {
+					stage1_1_cycles_ = tag->getOption< core::Size >( "stage1_1_cycles" );
+				}
+				if ( tag->hasOption( "stage1_2_cycles" ) ) {
+					stage1_2_cycles_ = tag->getOption< core::Size >( "stage1_2_cycles" );
+				}
+				if ( tag->hasOption( "stage1_3_cycles" ) ) {
+					stage1_3_cycles_ = tag->getOption< core::Size >( "stage1_3_cycles" );
+				}
+				if ( tag->hasOption( "stage1_4_cycles" ) ) {
+					stage1_4_cycles_ = tag->getOption< core::Size >( "stage1_4_cycles" );
+				}
+				if ( tag->hasOption( "stage1_probability" ) ) {
+					stage1_probability_ = tag->getOption< core::Real >( "stage1_probability" );
+				}
+				if ( tag->hasOption( "add_hetatm" ) ) {
+					add_hetatm_ = tag->getOption< bool >( "add_hetatm" );
+				}
+				if ( tag->hasOption( "hetatm_cst_weight" ) ) {
+					hetatm_self_cst_weight_ = tag->getOption< core::Real >( "hetatm_cst_weight" );
+				}
+				if ( tag->hasOption( "hetatm_to_protein_cst_weight" ) ) {
+					hetatm_prot_cst_weight_ = tag->getOption< core::Real >( "hetatm_to_protein_cst_weight" );
+				}
+				if ( tag->hasOption( "realign_domains" ) ) {
+					realign_domains_ = tag->getOption< bool >( "realign_domains" );
+				}
+				if ( tag->hasOption( "realign_domains_stage2" ) ) {
+					realign_domains_stage2_ = tag->getOption< bool >( "realign_domains_stage2" );
+				}
+				if ( tag->hasOption( "add_non_init_chunks" ) ) {
+					add_non_init_chunks_ = tag->getOption< core::Real >( "add_non_init_chunks" );
+				}
+				if ( tag->hasOption( "frag_1mer_insertion_weight" ) ) {
+					frag_1mer_insertion_weight_ = tag->getOption< core::Real >( "frag_1mer_insertion_weight" );
+				}
+				if ( tag->hasOption( "small_frag_insertion_weight" ) ) {
+					small_frag_insertion_weight_ = tag->getOption< core::Real >( "small_frag_insertion_weight" );
+				}
+				if ( tag->hasOption( "big_frag_insertion_weight" ) ) {
+					big_frag_insertion_weight_ = tag->getOption< core::Real >( "big_frag_insertion_weight" );
+				}
+				if ( tag->hasOption( "chunk_insertion_weight" ) ) {
+					chunk_insertion_weight_ = tag->getOption< core::Real >( "chunk_insertion_weight" );
+				}
+				if ( tag->hasOption( "frag_weight_aligned" ) ) {
+					frag_weight_aligned_ = tag->getOption< core::Real >( "frag_weight_aligned" );
+				}
+				if ( tag->hasOption( "auto_frag_insertion_weight" ) ) {
+					auto_frag_insertion_weight_ = tag->getOption< bool >( "auto_frag_insertion_weight" );
+				}
+				if ( tag->hasOption( "max_registry_shift" ) ) {
+					max_registry_shift_ = tag->getOption< core::Size >( "max_registry_shift" );
+				}
+				if ( tag->hasOption( "repeats" ) ) {
+					relax_repeats_ = tag->getOption< core::Size >( "repeats" );
+				}
+				if ( tag->hasOption( "disulf_file" ) ) {
+					disulf_file_ = tag->getOption< std::string >( "disulf_file" );
+				}
+
+				// stage 2-specific options
+				if ( tag->hasOption( "no_global_frame" ) ) {
+					no_global_frame_ = tag->getOption< bool >( "no_global_frame" );
+				}
+				if ( tag->hasOption( "linmin_only" ) ) {
+					linmin_only_ = tag->getOption< bool >( "linmin_only" );
+				}
+				if ( tag->hasOption( "cartfrag_overlap" ) ) {
+					cartfrag_overlap_ = tag->getOption< core::Size >( "cartfrag_overlap" );
+				}
+				if ( tag->hasOption( "seqfrags_only" ) ) {
+					seqfrags_only_ = tag->getOption< core::Size >( "seqfrags_only" );
+				}
+				if ( tag->hasOption( "skip_long_min" ) ) {
+					skip_long_min_ = tag->getOption< core::Size >( "skip_long_min" );
+				}
+
+
+				// scorefxns
+				if ( tag->hasOption( "stage1_scorefxn" ) ) {
+					std::string const scorefxn_name( tag->getOption<std::string>( "stage1_scorefxn" ) );
+					stage1_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+				}
+				if ( tag->hasOption( "stage2_scorefxn" ) ) {
+					std::string const scorefxn_name( tag->getOption<std::string>( "stage2_scorefxn" ) );
+					stage2_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+				}
+				if ( tag->hasOption( "stage2_min_scorefxn" ) ) {
+					std::string const scorefxn_name( tag->getOption<std::string>( "stage2_min_scorefxn" ) );
+					stage2min_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+				}
+				if ( tag->hasOption( "stage2_pack_scorefxn" ) ) {
+					if ( !cenrot_ ) {
+						TR << "Warning! Ignoring stage2_pack_scorefxn declaration since cenrot is not set." << std::endl;
+					} else {
+						std::string const scorefxn_name( tag->getOption<std::string>( "stage2_pack_scorefxn" ) );
+						stage2pack_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+					}
+				}
+				if ( tag->hasOption( "fa_scorefxn" ) ) {
+					std::string const scorefxn_name( tag->getOption<std::string>( "fa_scorefxn" ) );
+					fa_scorefxn_ = (data.get< ScoreFunction * >( "scorefxns", scorefxn_name ))->clone();
+				}
+
+				// ddomain options
+				hcut_ = tag->getOption< core::Real >( "domain_hcut" , 0.18);
+				pcut_ = tag->getOption< core::Real >( "domain_pcut" , 0.81);
+				length_ = tag->getOption< core::Size >( "domain_length" , 38);
+
+				// user constraints
+				coord_cst_res_ = tag->getOption<std::string>( "coord_cst_res", "" );
+
+				// if user constraints are defined, make sure coord_csts are defined in at least one stage
+				if ( coord_cst_res_.size() > 0 ) {
+					runtime_assert(
+							stage1_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
+							stage2_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 ||
+							fa_scorefxn_->get_weight( core::scoring::coordinate_constraint ) > 0 );
+				}
+
+				// fragments
+				utility::vector1< utility::tag::TagCOP > const branch_tags( tag->getTags() );
+				utility::vector1< utility::tag::TagCOP >::const_iterator tag_it;
+				for ( tag_it = branch_tags.begin(); tag_it != branch_tags.end(); ++tag_it ) {
+					if ( (*tag_it)->getName() == "Fragments" ) {
+						using namespace core::fragment;
+						if ( (*tag_it)->hasOption( "three_mers" ) ) {
+							core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "three_mers" )  );
+							fragments_small_.push_back(frags);
+						} else if ( (*tag_it)->hasOption( "small" ) ) {
+							utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "small" ), ',');
+							for ( core::Size i=1; i<= frag_files.size(); ++i ) {
+								fragments_small_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
+							}
+						}
+						if ( (*tag_it)->hasOption( "nine_mers" ) ) {
+							core::fragment::FragSetOP frags = core::fragment::FragmentIO().read_data( (*tag_it)->getOption<std::string>( "nine_mers" ) );
+							fragments_big_.push_back(frags);
+						} else if ( (*tag_it)->hasOption( "big" ) ) {
+							utility::vector1<std::string> frag_files = utility::string_split((*tag_it)->getOption<std::string>( "big" ), ',');
+							for ( core::Size i=1; i<= frag_files.size(); ++i ) {
+								fragments_big_.push_back(core::fragment::FragmentIO().read_data( frag_files[i] ));
+							}
+						}
+					}
+
+					if ( (*tag_it)->getName() == "Template" ) {
+						std::string const template_fn = (*tag_it)->getOption<std::string>( "pdb" );
+						std::string const cst_fn = (*tag_it)->getOption<std::string>( "cst_file", "AUTO" );  // should this be NONE?
+						auto const weight = (*tag_it)->getOption<core::Real>( "weight", 1.0 );
+						std::string const symm_file = (*tag_it)->getOption<std::string>( "symmdef", "" );
+
+						// randomize some chains
+						utility::vector1< char > rand_chains;
+						if ( (*tag_it)->hasOption( "randomize" ) ) {
+							std::string rand_chain_str = (*tag_it)->getOption<std::string>( "randomize", "" );
+							utility::vector1< std::string > rand_chain_strs = utility::string_split( rand_chain_str, ',');
+							for ( core::Size j = 1; j<=rand_chain_strs.size(); ++j ) {
+								if ( rand_chain_strs[j].length() != 0 ) {
+									rand_chains.push_back( rand_chain_strs[j][0] );
+								}
+							}
+						}
+						bool const align_pdb_info = (*tag_it)->getOption<bool>( "auto_align", true );
+						add_template(template_fn, cst_fn, symm_file, weight, rand_chains, align_pdb_info);
+					}
+
+					// strand pairings
+					if ( (*tag_it)->getName() == "Pairings" ) {
+						pairings_file_ = (*tag_it)->getOption< std::string >( "file", "" );
+						if ( (*tag_it)->hasOption("sheets") ) {
+							auto sheets = (*tag_it)->getOption< core::Size >( "sheets" );
+							sheets_.clear();
+							random_sheets_.clear();
+							sheets_.push_back(sheets);
+						} else if ( (*tag_it)->hasOption("random_sheets") ) {
+							auto random_sheets = (*tag_it)->getOption< core::Size >( "random_sheets" );
+							sheets_.clear();
+							random_sheets_.clear();
+							random_sheets_.push_back(random_sheets);
+						}
+						filter_templates_ = (*tag_it)->getOption<bool>( "filter_templates" , false );
+					}
+
+					// per-residue control
+					if ( (*tag_it)->getName() == "DetailedControls" ) {
+						if ( (*tag_it)->hasOption( "task_operations" ) ) {
+							core::pack::task::TaskFactoryOP task_factory = protocols::rosetta_scripts::parse_task_operations( *tag_it, data );
+							detailed_controls_settings_.push_back(
+									detailedControlsTagSetting("task_operations", task_factory, 0, 0, sampleEnum::unset, sampleEnum::unset));
+						} else {
+							core::Size const start_res = (*tag_it)->getOption<core::Size>( "start_res", 1 );
+							core::Size const stop_res = (*tag_it)->getOption<core::Size>( "stop_res", 0 );
+
+							sampleEnum sample_template(sampleEnum::unset), sample_abinitio(sampleEnum::unset);
+							if ( (*tag_it)->hasOption( "sample_template" ) ) {
+								sample_template = (*tag_it)->getOption<bool>( "sample_template", true ) ? sampleEnum::on : sampleEnum::off;
+							}
+							if ( (*tag_it)->hasOption( "sample_abinitio" ) ) {
+								sample_abinitio = (*tag_it)->getOption<bool>( "sample_abinitio", true ) ? sampleEnum::on : sampleEnum::off;
+							}
+							detailed_controls_settings_.push_back(
+									detailedControlsTagSetting("else", nullptr, start_res, stop_res, sample_template, sample_abinitio));
+						} // if tag == DetailedControls
+					} //forach tag
+				}
+			}
+
+			std::string HybridizeProtocol::get_name() const {
+				return mover_name();
+			}
+
+			std::string HybridizeProtocol::mover_name() {
+				return "Hybridize";
+			}
+
+			std::string hybridize_subelement_ct_name( std::string const & name ) {
+				return "Hybridize_subelement_" + name + "Type";
+			}
+
+			void HybridizeProtocol::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd )
+			{
+
+				using namespace utility::tag;
+				AttributeList attlist;
+
+				//basic direct attributes
+				attlist
+					+ XMLSchemaAttribute::attribute_w_default( "stage1_increase_cycles", xsct_real, "Increase/decrease sampling in stage 1", "1.0" ) //XRW TODO: should be nonnegative real
+					+ XMLSchemaAttribute::attribute_w_default( "stage2_increase_cycles", xsct_real, "Increase/decrease sampling in stage 2", "1.0" ) //XRW TODO: should be nonnegative real
+					+ XMLSchemaAttribute::attribute_w_default( "stage2_temperature", xsct_real, "kT for the Monte Carlo simulation", "2.0" ) //XRW TODO: should be nonnegative real
+					+ XMLSchemaAttribute::attribute_w_default( "stage2.5_increase_cycles", xsct_real, "Increase/decrease number of minimization steps following stage 2", "1.0" ) //XRW TODO: should be nonnegative real
+					+ XMLSchemaAttribute( "fa_cst_file", xs_string, "constraints file for fullatom stage" )
+					+ XMLSchemaAttribute::attribute_w_default( "batch", xsct_non_negative_integer, "The number of centroid structures to generate per fullatom model. Setting this to 0 will only run centroid modeling.", "1" )
+					+ XMLSchemaAttribute::attribute_w_default( "jump_move", xsct_rosetta_bool, "rigid body moves in stage 1", "false" )
+					+ XMLSchemaAttribute::attribute_w_default( "jump_move_repeat", xsct_non_negative_integer, "cycles in stage 1 that handle rigid body moves", "1" )
+					+ XMLSchemaAttribute::attribute_w_default( "keep_pose_constraint", xsct_rosetta_bool, "If set to true, keep constraints on the incoming pose (useful if constraints are generated in a mover prior to hybridize)", "false" )
+					+ XMLSchemaAttribute::attribute_w_default( "cenrot", xsct_rosetta_bool, "centroid rotamer modeling; necessary for stage2_pack_scorefxn to be useful; probably requires command line option -corrections:score:cenrot", "false" )
+					+ XMLSchemaAttribute( "csts_from_frags", xsct_rosetta_bool, "when set, derives dihedral constraints from input fragments; you need to set 'dihedral_constraint' weight in the stages you want to use this")
+					+ XMLSchemaAttribute( "max_contig_insertion", xsct_non_negative_integer, "Limits the length of 'template recombination' moves. Useful when inputs are full-length (no gaps).")
+					+ XMLSchemaAttribute( "min_after_stage1", xsct_rosetta_bool, "minimize after stage 1 (?)")
+					+ XMLSchemaAttribute( "fragprob_stage2", xsct_real, "controls the ratio of fragment insertions versus template recombination moves, implicit default 0.3")
+					+ XMLSchemaAttribute( "randfragprob_stage2", xsct_real, "controls the number of random fragfile insertions versus 'cutpoint' insertions, implicit default 0.5")
+					//ab initio options
+					+ XMLSchemaAttribute( "stage1_1_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+					+ XMLSchemaAttribute( "stage1_2_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+					+ XMLSchemaAttribute( "stage1_3_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+					+ XMLSchemaAttribute( "stage1_4_cycles", xsct_non_negative_integer, "set number of cycles for this stage")
+					+ XMLSchemaAttribute( "stage1_probability", xsct_real, "probability of doing 'fold tree hybridize' for stage one (with rigid body moves(?) instead of 'frag insertion in unaligned regions'")
+					+ XMLSchemaAttribute( "add_hetatm", xsct_rosetta_bool, "If true, use ligands from input template files")
+					+ XMLSchemaAttribute( "hetatm_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated intra-ligand restraints.  Called hetatm_self_cst_weight in documentation.")
+					+ XMLSchemaAttribute( "hetatm_to_protein_cst_weight", xsct_real, "If add_hetatm is enabled, this will set the weight on automatically generated ligand-protein restraints. Called hetatm_prot_cst_weight in documentation.")
+					+ XMLSchemaAttribute( "realign_domains", xsct_rosetta_bool, "If unset, this will not align the input domains to each other before running the protocol. Unsetting this option requires that input domains be previously aligned to a common reference frame. This option may be useful to unset for building models into density (if all inputs are docking into density).")
+					+ XMLSchemaAttribute( "realign_domains_stage2", xsct_rosetta_bool, "If set, realign domains in between the two centroid stages; default only aligns the initial models.")
+					+ XMLSchemaAttribute( "add_non_init_chunks", xsct_real, "Normally, secondary structure chunks are used from the starting model to set the foldtree. This option will steal chunks from other templates as well (as long as they do not overlap with current chunks); the number is the expected number of chunks (poisson distribution). This option is recommended when starting from an extended chain.")
+					+ XMLSchemaAttribute( "frag_1mer_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+					+ XMLSchemaAttribute( "small_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+					+ XMLSchemaAttribute( "big_frag_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+					+ XMLSchemaAttribute( "chunk_insertion_weight", xsct_real, "For fine control of protocol behavior, control the relative weight of this move type.") //XRW TODO should be positive real
+					+ XMLSchemaAttribute( "frag_weight_aligned", xsct_real, "Allow fragment insertions in template regions. The default is 0; increasing this will lead to increased model diversity.")
+					+ XMLSchemaAttribute( "auto_frag_insertion_weight", xsct_rosetta_bool, "automatically set fragment insertion weights")
+					+ XMLSchemaAttribute( "max_registry_shift", xsct_non_negative_integer, "Add a random move that shifts the sequence during model-building")
+					+ XMLSchemaAttribute( "repeats", xsct_non_negative_integer, "repeats for relax step")
+					+ XMLSchemaAttribute( "disulf_file", xs_string, "If specified, force the attached disulfide patterning")
+					//stage 2 options
+					+ XMLSchemaAttribute( "no_global_frame", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
+					+ XMLSchemaAttribute( "linmin_only", xsct_rosetta_bool, "only valid in Cartesian Hybridize; undocumented")
+					+ XMLSchemaAttribute( "cartfrag_overlap", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
+					+ XMLSchemaAttribute( "seqfrags_only", xsct_non_negative_integer, "only valid in Cartesian Hybridize; undocumented")
+					+ XMLSchemaAttribute( "skip_long_min", xsct_non_negative_integer, "only valid in Cartesian Hybridize; skip a final minimization")
+					//scorefunctions
+					+ XMLSchemaAttribute( "stage1_scorefxn", xs_string, "Scorefunction for stage 1 (looked up from DataMap")
+					+ XMLSchemaAttribute( "stage2_scorefxn", xs_string, "Scorefunction for stage 2 (looked up from DataMap")
+					+ XMLSchemaAttribute( "stage2_min_scorefxn", xs_string, "Scorefunction for stage 2 minimization (looked up from DataMap")
+					+ XMLSchemaAttribute( "stage2_pack_scorefxn", xs_string, "Scorefunction for stage 2 'packing' (looked up from DataMap. Only valid if boolean cenrot is true.")
+					+ XMLSchemaAttribute( "fa_scorefxn", xs_string, "Scorefunction for fullatom stage (looked up from DataMap")
+					//ddomain options (not a typo)
+					+ XMLSchemaAttribute::attribute_w_default( "domain_pcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.18")
+					+ XMLSchemaAttribute::attribute_w_default( "domain_hcut", xsct_real, "Used in DDomainParse. Aggressively undocumented.", "0.81")
+					+ XMLSchemaAttribute::attribute_w_default( "domain_length", xsct_non_negative_integer, "Used in DDomainParse.  Aggressively undocumented.", "38");
+				//user constraints
+				core::pose::attributes_for_get_resnum_selector( attlist, xsd, "coord_cst_res");
+				//orphaned docstring: "residues with user-provided CoordinateConstraints; If defined, at least one of the scorefunctions in [stage1_scorefxn, stage2_scorefxn, fa_scorefxn] must have nonzero coordinate_constraint weights"); //XRW TODO maybe
+
+				// attributes for Fragments subelement
+				AttributeList fragment_subelement_attributes;
+				fragment_subelement_attributes
+					+ XMLSchemaAttribute( "three_mers", xs_string, "3mers fragments file")
+					+ XMLSchemaAttribute( "small", xs_string, "comma separated vector of small (probably 3mer) fragments files")
+					+ XMLSchemaAttribute( "nine_mers", xs_string, "9mers fragments file")
+					+ XMLSchemaAttribute( "big", xs_string, "comma separated vector of small (probably 3mer) fragments files");
+
+				// attributes for Template subelement
+				AttributeList template_subelement_attributes;
+				template_subelement_attributes
+					+ XMLSchemaAttribute::required_attribute( "pdb", xs_string, "file path to pdb template")
+					+ XMLSchemaAttribute::attribute_w_default( "cst_file", xs_string, "file path to constraints file associated with this template", "AUTO")
+					+ XMLSchemaAttribute::attribute_w_default( "weight", xsct_real, "Sampling frequency weight for this template", "1.0")
+					+ XMLSchemaAttribute( "symmdef", xs_string, "symmdef file associated with this template (only if using symmetry)")
+					+ XMLSchemaAttribute( "randomize", xs_string, "comma-seprated list of chains to randomize - not documented")
+					+ XMLSchemaAttribute::attribute_w_default( "auto_align", xsct_rosetta_bool, "frustratingly undocumented", "true");
+
+				std::string const pairings_warning(" sheets and random_sheets are mutually exclusive.");
+				// attributes for Pairings subelement
+				AttributeList pairings_subelement_attributes;
+				pairings_subelement_attributes
+					+ XMLSchemaAttribute::required_attribute( "file", xs_string, "path to pairings file")
+					+ XMLSchemaAttribute( "sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
+					+ XMLSchemaAttribute( "random_sheets", xsct_non_negative_integer, "used with FoldTreeHybridize, undocumented" + pairings_warning)
+					+ XMLSchemaAttribute::attribute_w_default( "filter_templates", xsct_rosetta_bool, "remove templates with incorrect pairings", "false");
+
+				// attributes for DetailedControls subelement
+				AttributeList DetailedControls_subelement_attributes;
+				DetailedControls_subelement_attributes
+					+ XMLSchemaAttribute::attribute_w_default( "start_res", xsct_non_negative_integer, "starting residue for a DetailedControl region", "1")
+					+ XMLSchemaAttribute( "stop_res", xsct_non_negative_integer, "ending residue for a DetailedControl region; defaults to the rest of the Pose")
+					+ XMLSchemaAttribute::attribute_w_default( "sample_template", xsct_rosetta_bool, "if false, disallow template hybridization moves", "true")
+					+ XMLSchemaAttribute::attribute_w_default( "sample_abinitio", xsct_rosetta_bool, "if false, disallow fragment insertion moves", "true");
+				rosetta_scripts::attributes_for_parse_task_operations(DetailedControls_subelement_attributes);
+
+				XMLSchemaSimpleSubelementList subelements;
+				subelements.complex_type_naming_func( & hybridize_subelement_ct_name );
+				subelements.add_simple_subelement( "Fragments", fragment_subelement_attributes, "Instructions for fragments files.  Should occur exactly once.");
+				subelements.add_simple_subelement( "Template", template_subelement_attributes, "Instructions for templates. Must occur at least once, may occur as many times as you wish.");
+				subelements.add_simple_subelement( "Pairings", pairings_subelement_attributes, "Used with FoldTreeHybridize and poorly documented");
+				subelements.add_simple_subelement( "DetailedControls", DetailedControls_subelement_attributes, "Used to prevent regions from being sampled extensively (meaning, don't remodel regions where the model is already correct)");
+
+				protocols::moves::xsd_type_definition_w_attributes_and_repeatable_subelements( xsd, mover_name(), "This is the Hybridize mover at the core of comparative modeling (RosettaCM).  Typically its XML is written by a script rather than manually.", attlist, subelements );
+			}
+
+			/// @brief Provide the citation.
+			void
+				HybridizeProtocol::provide_citation_info(basic::citation_manager::CitationCollectionList & citations ) const {
+					basic::citation_manager::CitationCollectionOP collection(
+							utility::pointer::make_shared< basic::citation_manager::CitationCollection >(
+								mover_name(),
+								basic::citation_manager::CitedModuleType::Mover
+								)
+							);
+					collection->add_citation( basic::citation_manager::CitationManager::get_instance()->get_citation_by_doi("10.1016/j.str.2013.08.005") );
+
+					citations.add( collection );
+				}
+
+			std::string HybridizeProtocolCreator::keyname() const {
+				return HybridizeProtocol::mover_name();
+			}
+
+			protocols::moves::MoverOP
+				HybridizeProtocolCreator::create_mover() const {
+					return utility::pointer::make_shared< HybridizeProtocol >();
+				}
+
+			void HybridizeProtocolCreator::provide_xml_schema( utility::tag::XMLSchemaDefinition & xsd ) const
+			{
+				HybridizeProtocol::provide_xml_schema( xsd );
+			}
+
+
+			} // hybridization
+	} // protocols


### PR DESCRIPTION
RosettaCM, with a branched glycan ligand, was segfaulting. In 2 locations, the "previous residue" of the given polymer entity was selected by choosing the position prior to the one in question, which is not appropriate for a branched glycan. The fix was to set a conditional for carbohydrates that uses conformation::carbohydrates::find_seqpos_of_saccharides_parent_residue to find the previous residue.