### PR TITLE
increase default unit-test-timeout to 8min

### DIFF
--- a/source/test/run.py
+++ b/source/test/run.py
@@ -722,7 +722,7 @@ def main(args):
     )
 
     parser.add_option("--timeout",
-      action="store",type="float", default=6,
+      action="store",type="float", default=8,
       help="Automatically cancel test runs if they are taking longer than the given number of minutes. A value of zero turns off the timeout. Note that some tests might have custom (longer) timeout value for historical reasons."
     )
 


### PR DESCRIPTION
Recently we started to see frequent unit test timeouts, particularly when run on higher versions of GCC/Clang (probably more debug checks?). These create a false-negative reports which are destructive.