### PR TITLE
removing "defaults" Conda channel in favor of "conda-forge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Example `~/.condarc` for US WEST coast (if unsure use this mirror):
 ```
 channels: 
 - https://conda.rosettacommons.org
-- defaults
+- conda-forge
 ```
 
 Example `~/.condarc` for US EAST coast:
@@ -60,7 +60,7 @@ Example `~/.condarc` for US EAST coast:
 ```
 channels: 
 - https://conda.graylab.jhu.edu
-- defaults
+- conda-forge
 ```
 
 


### PR DESCRIPTION
Conda recently changed the licensing terms for they "defaults" channel so let use conda-forge instead.