### PR TITLE
fix Conda release procedure

### DIFF
--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -790,12 +790,12 @@ def native_libc_pyrosetta_conda_release(kind, rosetta_dir, working_dir, platform
 
                 # m = re_module.search(r"pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)
                 # .tar.bz2 is no longer when `--output-folder` option is used
-                m = re_module.search(r"pyrosetta-.*\.conda", conda_package_output, re_module.MULTILINE)
+                m = re_module.search(r"pyrosetta-.*\.(tar\.bz2|conda)", conda_package_output, re_module.MULTILINE)
 
                 conda_package = m.group(0) if m else 'unknown'
                 # conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE).group(1)
                 # .tar.bz2 is no longer when `--output-folder` option is used
-                conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.conda", conda_package_output, re_module.MULTILINE).group(1)
+                conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.(tar\.bz2|conda)", conda_package_output, re_module.MULTILINE).group(1)
 
                 TR(f'Building Conda package: {conda_package}...')
                 res, conda_log = execute('Creating Conda package...', conda_build_command_line, return_='tuple', add_message_and_command_line_to_output=True)
@@ -1144,9 +1144,9 @@ def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, 
 
         with open(f'{working_dir}/conda_package_output_folder.log', 'w') as f: f.write(conda_package_output)
 
-        m = re_module.search(r"rosetta-.*\.conda", conda_package_output, re_module.MULTILINE)
+        m = re_module.search(r"rosetta-.*\.(tar\.bz2|conda)", conda_package_output, re_module.MULTILINE)
         conda_package = m.group(0) if m else 'unknown'
-        conda_package_dir = re_module.search(r"/([^/]*)/rosetta-.*\.conda", conda_package_output, re_module.MULTILINE).group(1)
+        conda_package_dir = re_module.search(r"/([^/]*)/rosetta-.*\.(tar\.bz2|conda)", conda_package_output, re_module.MULTILINE).group(1)
 
         TR(f'Building Conda package: {conda_package}...')
         res, conda_log = execute('Creating Conda package...', conda_build_command_line, return_='tuple', add_message_and_command_line_to_output=True)

--- a/tests/benchmark/tests/release.py
+++ b/tests/benchmark/tests/release.py
@@ -786,9 +786,16 @@ def native_libc_pyrosetta_conda_release(kind, rosetta_dir, working_dir, platform
                 conda_build_command_line = f'{conda.activate_base} && conda build purge && conda build --no-locking --quiet {recipe_dir} --output-folder {working_dir_release_path}' # --channel conda-forge
                 conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
 
-                m = re_module.search(r"pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)
+                with open(f'{working_dir}/conda_package_output_folder.log', 'w') as f: f.write(conda_package_output)
+
+                # m = re_module.search(r"pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)
+                # .tar.bz2 is no longer when `--output-folder` option is used
+                m = re_module.search(r"pyrosetta-.*\.conda", conda_package_output, re_module.MULTILINE)
+
                 conda_package = m.group(0) if m else 'unknown'
-                conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE).group(1)
+                # conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE).group(1)
+                # .tar.bz2 is no longer when `--output-folder` option is used
+                conda_package_dir = re_module.search(r"/([^/]*)/pyrosetta-.*\.conda", conda_package_output, re_module.MULTILINE).group(1)
 
                 TR(f'Building Conda package: {conda_package}...')
                 res, conda_log = execute('Creating Conda package...', conda_build_command_line, return_='tuple', add_message_and_command_line_to_output=True)
@@ -1135,9 +1142,11 @@ def native_libc_rosetta_conda_release(kind, rosetta_dir, working_dir, platform, 
         #if platform['os'] == 'm1': conda_build_command_line += ' --prefix-length 80'
         conda_package_output = execute('Getting Conda package name...', f'{conda_build_command_line} --output', return_='output', silent=True)
 
-        m = re_module.search(r"rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE)
+        with open(f'{working_dir}/conda_package_output_folder.log', 'w') as f: f.write(conda_package_output)
+
+        m = re_module.search(r"rosetta-.*\.conda", conda_package_output, re_module.MULTILINE)
         conda_package = m.group(0) if m else 'unknown'
-        conda_package_dir = re_module.search(r"/([^/]*)/rosetta-.*\.tar\.bz2", conda_package_output, re_module.MULTILINE).group(1)
+        conda_package_dir = re_module.search(r"/([^/]*)/rosetta-.*\.conda", conda_package_output, re_module.MULTILINE).group(1)
 
         TR(f'Building Conda package: {conda_package}...')
         res, conda_log = execute('Creating Conda package...', conda_build_command_line, return_='tuple', add_message_and_command_line_to_output=True)


### PR DESCRIPTION
Recently Conda changed extension suffix for its packages which broke our release procedure. This PR is intended to fix this.