### PR TITLE
Better debugging on CIF file read in.

### DIFF
--- a/source/src/core/import_pose/import_pose.cc
+++ b/source/src/core/import_pose/import_pose.cc
@@ -441,7 +441,7 @@ pose_from_file(
 		CifParserOP cifParser( new CifParser( cifFile.get() ) );
 		cifParser->ParseString( contents_of_file, diagnostics );
 		if ( !diagnostics.empty() ) {
-			TR.Warning << "mmCIF parser reports issues with file '" << filename "' : " << std:;endl;
+			TR.Warning << "mmCIF parser reports issues with file '" << filename << "' : " << std::endl;
 			TR.Warning << diagnostics << std::endl;
 		}
 		io::StructFileRepOP sfr ( io::mmcif::create_sfr_from_cif_file_op( cifFile, options ) );

--- a/source/src/core/import_pose/import_pose.hh
+++ b/source/src/core/import_pose/import_pose.hh
@@ -71,6 +71,14 @@ extension_from_filetype(
 	FileType const filetype
 );
 
+
+/// @brief Given a filename, attempt to determine which type it is from the extension.
+/// @details Pass the whole name, not just the extension.
+FileType
+filetype_from_extension(
+	std::string const & filename
+);
+
 void
 read_all_poses(
 	utility::vector1< std::string > const & filenames,


### PR DESCRIPTION
Issue #355 indicates that errors in mmCIF parsing are not well handled. This commit attempts to fix that in two ways.

The first is to add a 'from extension' fallback if the from-contents parser doesn't like it. We assume that if you're naming it xyz.pdb, you want it parsed as a PDB.

The second is to print the diagnostics report for mmCIF files to the tracer -- this is what's being used to autodetect mmCIF format, so better transparency of what the failure issue is would be warranted.