### PR TITLE
Add option to control intermediate dumping in BackrubProtocol

### DIFF
--- a/source/src/protocols/backrub/BackrubProtocol.hh
+++ b/source/src/protocols/backrub/BackrubProtocol.hh
@@ -81,6 +81,10 @@ public:
 	void
 	set_taskfactory( core::pack::task::TaskFactoryCOP tf);
 
+	/// @brief Control whether the mover dumps the _last and _low intermediate structures.
+	void
+	set_dump_poses(bool);
+
 	////////////////////////////////////////////////////////////////////////
 	/// ScoreFunction
 	///
@@ -197,6 +201,7 @@ private:
 	bool trajectory_;
 	bool trajectory_gz_;
 	bool recover_low_;
+	bool dump_poses_ = true; // Historical behavior
 	core::Size trajectory_stride_;
 
 	protocols::moves::MoverOP trajectory_apply_mover_;


### PR DESCRIPTION
Especially with XML (where the Backrub protocol is part of a more extensive protocol),  you don't necessarily want an unconditional dumping of the last & low results from the Backrub stage.  This PR adds an XML option which will allow the dumping of the poses (old behavior), but turns it off by default.  This only changes XML usage -- I didn't change how the backrub application behaves.

 Changes to the backrub_interface_ddG integration test is expected.