### PR TITLE
fix Mac RC release package

### DIFF
--- a/source/tools/build/basic.settings
+++ b/source/tools/build/basic.settings
@@ -2243,7 +2243,7 @@ settings = {
             "flags" : {
                 # Change 'abspath' to 'file' to use DYLD_LIBRARY_PATH environ-
                 # ment variable.
-                "compile" : [ "march=native", "mtune=native", "stdlib=libc++", ],
+                "compile" : ["mtune=native", "stdlib=libc++", ],
                 "shlink" : [ "install_name ${TARGET.abspath}", "stdlib=libc++", ],
                 "link"   : [ "stdlib=libc++"],
                 # There is at least one variable only used on non-Macs.


### PR DESCRIPTION
Current Issue: Our Mac binary releases are currently built using the instruction set of the local Intel Xeon CPU (via -march=native), which can result in binaries that fail to run on other x86 CPUs due to unsupported instructions.

Fix: This PR addresses the issue by explicitly setting the instruction set to core2 when compiling on macOS with an x86 CPU, ensuring the resulting binaries are compatible with a wider range of Intel-based Macs.