### PR TITLE
Fixing gcc errors from LigandDiscoverySearch merge

### DIFF
--- a/source/src/protocols/motifs/LigandDiscoverySearch.cc
+++ b/source/src/protocols/motifs/LigandDiscoverySearch.cc
@@ -753,7 +753,7 @@ core::Size LigandDiscoverySearch::discover(std::string output_prefix)
 				binding_pocket_dimensions = option[ OptionKeys::motifs::binding_pocket_dimensions_sf ]();
 
 				//now derive the binding pocket center, and ensure the input is valid
-				numeric::xyzVector<int> bp_xyz;
+				numeric::xyzVector<int> bp_xyz(0, 0, 0);
 				utility::vector1<int> binding_pocket_center_xyz = option[ OptionKeys::motifs::binding_pocket_center_sf ]();
 
 				//ensure that there are enough entries in the center vector


### PR DESCRIPTION
The purpose of this PR is to address a few broken gcc tests that were not tested for in the original branch for updating LigandDiscoverySearch with ProteinGrid and other additions.