### PR TITLE
Minor changes to PyRosetta logging messages

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -206,14 +206,14 @@ def _version_string():
 
 def version():
     return (
-        '┌──────────────────────────────────────────────────────────────────────────────┐\n'
-        '│                                 PyRosetta-4                                  │\n'
-        '│              Created in JHU by Sergey Lyskov and PyRosetta Team              │\n'
-        '│              (C) Copyright Rosetta Commons Member Institutions               │\n'
-        '│                                                                              │\n'
-        '│ NOTE: USE OF PyRosetta FOR COMMERCIAL PURPOSES REQUIRE PURCHASE OF A LICENSE │\n'
-        '│         See LICENSE.PyRosetta.md or email license@uw.edu for details         │\n'
-        '└──────────────────────────────────────────────────────────────────────────────┘\n'
+        '┌───────────────────────────────────────────────────────────────────────────────┐\n'
+        '│                                  PyRosetta-4                                  │\n'
+        '│               Created in JHU by Sergey Lyskov and PyRosetta Team              │\n'
+        '│               (C) Copyright Rosetta Commons Member Institutions               │\n'
+        '│                                                                               │\n'
+        '│ NOTE: USE OF PyRosetta FOR COMMERCIAL PURPOSES REQUIRES PURCHASE OF A LICENSE │\n'
+        '│          See LICENSE.PyRosetta.md or email license@uw.edu for details         │\n'
+        '└───────────────────────────────────────────────────────────────────────────────┘\n'
     ) + \
     'PyRosetta-4 ' + rosetta.utility.Version.date().split('-').pop(0) + \
     ' [Rosetta ' + _version_string() + ' ' + rosetta.utility.Version.date() + \

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -158,7 +158,7 @@ def init(options='-ex1 -ex2aro', extra_options='', set_logging_handler=None, not
         set_logging_handler = "interactive"
     elif notebook is not None:
         warnings.warn(
-            "pyrosetta.init 'notebook' argument is deprecated and may be removed in 2018. "
+            "pyrosetta.init 'notebook' argument is deprecated and may be removed in a future release. "
             "See set_logging_handler='interactive'.",
             stacklevel=2
         )
@@ -188,8 +188,9 @@ def init(options='-ex1 -ex2aro', extra_options='', set_logging_handler=None, not
     v = rosetta.utility.vector1_string()
     v.extend(args)
 
-    if not silent: print( version() )
-    logger.info( version() )
+    if not silent:
+        print( version() )
+        logger.info( version() )
     rosetta.protocols.init.init(v)
     pyrosetta.protocols.h5_fragment_store_provider.init_H5FragmentStoreProvider()
     pyrosetta.protocols.h5_structure_store_provider.init_H5StructureStoreProvider()

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -191,6 +191,8 @@ def init(options='-ex1 -ex2aro', extra_options='', set_logging_handler=None, not
     if not silent:
         print( version() )
         logger.info( version() )
+    else:
+        logger.debug( version() )
     rosetta.protocols.init.init(v)
     pyrosetta.protocols.h5_fragment_store_provider.init_H5FragmentStoreProvider()
     pyrosetta.protocols.h5_structure_store_provider.init_H5StructureStoreProvider()

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/tools.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/tools.py
@@ -70,27 +70,28 @@ def _print_conda_warnings() -> None:
     Print warning message if Anaconda or Miniconda are not installed and we are
     not in an active conda environment on the client.
     """
-    if shutil.which("conda"):  # Anaconda or Miniconda is installed
-        try:
-            _worker = distributed.get_worker()
-        except ValueError:
-            _worker = None
-        if not _worker and get_yml() == "":
+    try:
+        _worker = distributed.get_worker()
+    except ValueError:
+        _worker = None
+    if not _worker:
+        if shutil.which("conda"):  # Anaconda or Miniconda is installed
+            if get_yml() == "":
+                print(
+                    "Warning: To use the `pyrosetta.distributed.cluster` namespace, please "
+                    + "create and activate a conda environment (other than 'base') to ensure "
+                    + "reproducibility of PyRosetta simulations. For instructions, visit:\n"
+                    + "https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html\n"
+                    + "https://conda.io/activation\n"
+                )  # Warn that we are not in an active conda environment
+        else:  # Anaconda or Miniconda is not installed
             print(
-                "Warning: To use the `pyrosetta.distributed.cluster` namespace, please "
-                + "create and activate a conda environment (other than 'base') to ensure "
-                + "reproducibility of PyRosetta simulations. For instructions, visit:\n"
-                + "https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html\n"
-                + "https://conda.io/activation\n"
-            )  # Warn that we are not in an active conda environment
-    else:  # Anaconda or Miniconda is not installed
-        print(
-            "Warning: Use of `pyrosetta.distributed.cluster` namespace requires Anaconda "
-            + "(or Miniconda) to be properly installed for reproducibility of PyRosetta "
-            + "simulations. Please install Anaconda (or Miniconda) onto your system "
-            + "to enable running `which conda`. For installation instructions, visit:\n"
-            + "https://docs.anaconda.com/anaconda/install\n"
-        )  # Warn that `conda` is not in $PATH
+                "Warning: Use of `pyrosetta.distributed.cluster` namespace requires Anaconda "
+                + "(or Miniconda) to be properly installed for reproducibility of PyRosetta "
+                + "simulations. Please install Anaconda (or Miniconda) onto your system "
+                + "to enable running `which conda`. For installation instructions, visit:\n"
+                + "https://docs.anaconda.com/anaconda/install\n"
+            )  # Warn that `conda` is not in $PATH
 
 
 def get_protocols(


### PR DESCRIPTION
Quick fixes to PyRosetta logging functionality:

- Change logging level when `pyrosetta.init(silent=True)`, which can really pollute logging files in `PyRosettaCluster` every time a new task is distributed to a dask worker (e.g., can be thousands of banners per log file).
- Do not print `conda` warnings on dask workers
- Typo in banner