### PR TITLE
Add cartesian option to RosettaLigand FinalMinimizer.

### DIFF
--- a/source/src/protocols/ligand_docking/FinalMinimizer.hh
+++ b/source/src/protocols/ligand_docking/FinalMinimizer.hh
@@ -76,7 +76,7 @@ private:
 	MoveMapBuilderOP movemap_builder_;
 	/// @brief If true, remove any backbone constraints added during minimization
 	bool remove_bb_constraints_ = false;
-	/// @brief Use Cartesian minimization?"
+	/// @brief Use Cartesian minimization
 	bool cartesian_ = false;
 
 	/// @brief Get the minimization submover

--- a/source/src/protocols/ligand_docking/FinalMinimizer.hh
+++ b/source/src/protocols/ligand_docking/FinalMinimizer.hh
@@ -75,7 +75,9 @@ private:
 	core::scoring::ScoreFunctionOP score_fxn_;
 	MoveMapBuilderOP movemap_builder_;
 	/// @brief If true, remove any backbone constraints added during minimization
-	bool remove_bb_constraints_;
+	bool remove_bb_constraints_ = false;
+	/// @brief Use Cartesian minimization?"
+	bool cartesian_ = false;
 
 	/// @brief Get the minimization submover
 	/// If backbone is true, make sure that things are set up for backbone minimization


### PR DESCRIPTION
Alex was interested in potentially having Cartesian minimization in RosettaLigand docking (to possibly better optimize a interaction controlled by a non-torsion.

This is straightforward to add.