### PR TITLE
Add support for filtering results in PyRosettaCluster

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
@@ -35,6 +35,7 @@ from pyrosetta.distributed.cluster.converter_tasks import (
     get_yml,
     is_bytes,
     is_dict,
+    is_empty,
     is_packed,
     parse_input_packed_pose as _parse_input_packed_pose,
     to_int,

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
@@ -197,6 +197,16 @@ Args:
         It's recommended to set this option to at least 1 second, but longer times may
         be used as a safety throttle in cases of overwhelmed dask scheduler processes.
         Default: 3.0
+    filter_results: A `bool` object specifying whether or not to filter out empty
+        `PackedPose` objects between user-provided PyRosetta protocols. When a protocol
+        returns or yields `NoneType`, PyRosettaCluster converts it to an empty `PackedPose`
+        object that gets passed to the next protocol. If `True`, then filter out any empty
+        `PackedPose` objects where there are no residues in the conformation as given by
+        `Pose.empty()`, otherwise if `False` then continue to pass empty `PackedPose` objects
+        to the next protocol. This is used for filtering out decoys mid-trajectory through
+        user-provided PyRosetta protocols if protocols return or yield any `None`, empty
+        `Pose`, or empty `PackedPose` objects.
+        Default: False
     save_all: A `bool` object specifying whether or not to save all of the returned
         or yielded `Pose` and `PackedPose` objects from all user-provided
         PyRosetta protocols. This option may be used for checkpointing trajectories.
@@ -247,6 +257,7 @@ import os
 from datetime import datetime
 from pyrosetta.distributed.cluster.base import TaskBase, _get_residue_type_set
 from pyrosetta.distributed.cluster.converters import (
+    is_empty as _is_empty,
     _parse_decoy_ids,
     _parse_environment,
     _parse_input_packed_pose,
@@ -546,6 +557,12 @@ class PyRosettaCluster(IO[G], LoggingSupport[G], SchedulerManager[G], TaskBase[G
         validator=[_validate_float, attr.validators.instance_of((float, int))],
         converter=attr.converters.default_if_none(default=3.0),
     )
+    filter_results = attr.ib(
+        type=bool,
+        default=False,
+        validator=attr.validators.instance_of(bool),
+        converter=attr.converters.default_if_none(default=False),
+    )
     save_all = attr.ib(
         type=bool,
         default=False,
@@ -749,6 +766,8 @@ class PyRosettaCluster(IO[G], LoggingSupport[G], SchedulerManager[G], TaskBase[G
                             compressed_packed_pose,
                             self.serializer.deepcopy_kwargs(kwargs),
                         )
+                    if self.filter_results and _is_empty(self.serializer.decompress_packed_pose(compressed_packed_pose)):
+                        continue
                     compressed_kwargs, pyrosetta_init_kwargs, protocol, clients_index, resource = self._setup_kwargs(
                         kwargs, clients_indices, resources
                     )


### PR DESCRIPTION
Similar to the idea of filters in RosettaScripts, it can be useful to filter a result mid-trajectory in `PyRosettaCluster` (rather than solely post hoc filtering data). This PR supports optionally filtering results between user-defined PyRosetta protocols in `PyRosettaCluster`. 

Currently, when a user-defined PyRosetta protocol returns or yields `None` (e.g., a `PackedPose` was discarded in a protocol), `PyRosettaCluster` converts it to an empty `PackedPose` object that gets passed to the next protocol. This can result in needless additional overhead in `dask` because the empty `PackedPose`s still get distributed to all downstream PyRosetta protocols -- even if the protocols don't operate on empty input `PackedPose`s. The user usually has to catch these at the top of their protocols (e.g., with `if packed_pose.pose.empty(): return None`). This PR supports a new `PyRosettaCluster` instance attribute, `filter_results`, that dynamically filters out any empty `PackedPose`s that arrive back to the head node. If enabled, this is used for filtering out decoys mid-trajectory between user-provided PyRosetta protocols. 

Because this changes `PyRosettaCluster` behavior, if there are any users who happen to rely on these empty `PackedPose`s to generate results in downstream protocols (which are user-defined, so there may be scripts in the wild that depend on it not filtering), then decoy IDs in downstream protocols would be changed if enabled. Hence, for reproducibility of existing data with backward compatibility, this PR sets the default to `False` (although users ought to be implementing an identical PyRosetta version when reproducing results). Additionally, this PR ensures that the `filter_results` instance attribute cannot be overridden during reproduction. Hence, this is a new feature that can optionally be enabled for reduced overhead.