### PR TITLE
Fix parse_options arguments with local OptionsCollection in ProtocolSettingsMetric.cc

### DIFF
--- a/source/src/core/simple_metrics/composite_metrics/ProtocolSettingsMetric.cc
+++ b/source/src/core/simple_metrics/composite_metrics/ProtocolSettingsMetric.cc
@@ -147,7 +147,7 @@ ProtocolSettingsMetric::parse_my_tag(
 		set_only_report_these_options(limit_to);
 	}
 	if ( datamap.has_resource("options") ) {
-		parse_options(*datamap.get_resource<OptionCollection const>("options"), base_name_only, get_user_options, get_script_vars, skip_corrections);
+		parse_options(*datamap.get_resource<OptionCollection const>("options"), base_name_only, get_script_vars, get_user_options, skip_corrections);
 	} else {
 		parse_options(basic::options::option, base_name_only, get_script_vars, get_user_options, skip_corrections);
 	}


### PR DESCRIPTION
If using the local `OptionsCollection` in the `ProtocolSettingsMetric` CompositeStringMetric, the `get_script_vars` and `get_user_options` arguments are swapped relative to the `parse_options` signature. These options are both `true` by default, so this bug has likely gone unnoticed, but would only have an effect when `get_script_vars` and `get_user_options` have different values.