### PR TITLE
Change Gemmi submodule from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	branch = bcl_rosetta
 [submodule "source/external/gemmi_repo"]
 	path = source/external/gemmi_repo
-	url = git@github.com:project-gemmi/gemmi.git
+	url = https://github.com/project-gemmi/gemmi.git
 ############################
 # Boost Modules
 ############################


### PR DESCRIPTION
Issue #492 indicates there's issues with having the Gemmi submodule loaded by SSH. Change that to HTTPS, to match other external submodules.