### PR TITLE
Supporting secure unpickling in PyRosetta

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -67,16 +67,6 @@ from pyrosetta.io import (
     get_score_function,
     Pose,
 )
-from pyrosetta.secure_unpickle import (
-    add_secure_package,
-    remove_secure_package,
-    clear_secure_packages,
-    get_disallowed_packages,
-    get_secure_packages,
-    set_secure_packages,
-    UnpickleSecurityError,
-    UnpickleIntegrityError,
-)
 
 ###############################################################################
 # Exception handling.

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -67,6 +67,16 @@ from pyrosetta.io import (
     get_score_function,
     Pose,
 )
+from pyrosetta.secure_unpickle import (
+    add_secure_package,
+    remove_secure_package,
+    clear_secure_packages,
+    get_disallowed_packages,
+    get_secure_packages,
+    set_secure_packages,
+    UnpickleSecurityError,
+    UnpickleIntegrityError,
+)
 
 ###############################################################################
 # Exception handling.

--- a/source/src/python/PyRosetta/src/pyrosetta/bindings/scores/serialization.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/bindings/scores/serialization.py
@@ -9,48 +9,36 @@
 __author__ = "Jason C. Klima"
 
 
-import base64
 import collections
-import pickle
+
+from pyrosetta.secure_unpickle import SecureSerializerBase
 
 
 class PoseScoreSerializerBase(object):
     """Base class for `PoseScoreSerializer` methods."""
-
     @staticmethod
     def to_pickle(value):
-        try:
-            return pickle.dumps(value)
-        except (TypeError, OverflowError, MemoryError, pickle.PicklingError) as ex:
-            raise TypeError(
-                "Only pickle-serializable object types are allowed to be set "
-                + "as score values. Received: %r. %s" % (type(value), ex)
-            )
+        return SecureSerializerBase.to_pickle(value)
 
     @staticmethod
     def from_pickle(value):
-        try:
-            return pickle.loads(value)
-        except (TypeError, OverflowError, MemoryError, EOFError, pickle.UnpicklingError) as ex:
-            raise TypeError(
-                "Could not deserialize score value of type %r. %s" % (type(value), ex)
-            )
+        return SecureSerializerBase.secure_loads(value)
 
     @staticmethod
     def to_base64(value):
-        return base64.b64encode(value).decode()
+        return SecureSerializerBase.to_base64(value)
 
     @staticmethod
     def from_base64(value):
-        return base64.b64decode(value, validate=True)
+        return SecureSerializerBase.from_base64(value)
 
     @staticmethod
-    def to_base64_pickle(value):
-        return PoseScoreSerializerBase.to_base64(PoseScoreSerializerBase.to_pickle(value))
+    def to_base64_pickle(obj):
+        return SecureSerializerBase.secure_to_base64_pickle(obj)
 
     @staticmethod
     def from_base64_pickle(value):
-        return PoseScoreSerializerBase.from_pickle(PoseScoreSerializerBase.from_base64(value))
+        return SecureSerializerBase.secure_from_base64_pickle(value)
 
     @staticmethod
     def bool_from_str(value):

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/__init__.py
@@ -49,7 +49,7 @@ __all__: List[str] = [
     "run",
     "update_scores",
 ]
-__version__: str = "2.1.1"
+__version__: str = "2.1.2"
 
 _print_conda_warnings()
 

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/packed_pose/core.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/packed_pose/core.py
@@ -13,6 +13,9 @@ import base64
 import pyrosetta.rosetta.core.pose as pose
 import pyrosetta.distributed
 
+from pyrosetta.secure_unpickle import SecureSerializerBase
+
+
 __all__ = ["pack_result", "pose_result", "to_packed", "to_pose", "to_dict", "to_base64", "to_pickle", "PackedPose"]
 
 
@@ -38,7 +41,7 @@ class PackedPose:
     def __init__(self, pose_or_pack):
         """Create a packed pose from pose, pack, or pickled bytes."""
         if isinstance(pose_or_pack, pose.Pose):
-            self.pickled_pose = pickle.dumps(pose_or_pack)
+            self.pickled_pose = SecureSerializerBase.to_pickle(pose_or_pack)
             self.scores = dict(pose_or_pack.cache)
 
         elif isinstance(pose_or_pack, PackedPose):
@@ -55,7 +58,7 @@ class PackedPose:
     @property
     @pyrosetta.distributed.requires_init
     def pose(self):
-        return pickle.loads(self.pickled_pose)
+        return SecureSerializerBase.secure_loads(self.pickled_pose)
 
     def update_scores(self, *score_dicts, **score_kwargs):
         new_scores = {}
@@ -71,7 +74,9 @@ class PackedPose:
 
     def clone(self):
         result = PackedPose(self.pose)
-        result.scores = pickle.loads(pickle.dumps(self.scores))
+        result.scores = SecureSerializerBase.secure_loads(
+            SecureSerializerBase.to_pickle(self.scores)
+        )
         return result
 
     def empty(self):

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -510,4 +510,7 @@ class SecureSerializerBase(object):
 
     @staticmethod
     def _get_stream_protocol(obj: bytes) -> int:
-        return obj[1] if len(obj) >= 2 and obj[0] == pickle.PROTO[0] else -1
+        if len(obj) >= 2 and obj[0] == pickle.PROTO[0]:
+            return obj[1] if 0 <= obj[1] <= pickle.HIGHEST_PROTOCOL else -1
+        else:
+            return 0

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -42,7 +42,6 @@ SECURE_PYTHON_BUILTINS: FrozenSet[str] = frozenset({
     "slice",
     "str",
     "tuple",
-    "type",
 })
 
 # Default secure packages, not including PyRosetta:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -279,7 +279,7 @@ class ModuleCache(object):
     Resolve modules and packages by path, and determine if they are allowed or blocked.
     """
     @staticmethod
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=1024, typed=True)
     def _package_base_dir(package_name: str) -> Optional[Path]:
         try:
             _package = importlib.import_module(package_name)
@@ -290,7 +290,7 @@ class ModuleCache(object):
         return Path(_file).resolve().parent if _file else None
 
     @staticmethod
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=4096, typed=True)
     def _module_file(module_name: str) -> Optional[Path]:
         try:
             _module = importlib.import_module(module_name)
@@ -388,7 +388,7 @@ class SecureSerializerBase(object):
             )
 
     @staticmethod
-    def from_base64(value: str) -> bytes:
+    def from_base64(value: Union[str, bytes]) -> bytes:
         return base64.b64decode(value, validate=True)
 
     @staticmethod

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -38,7 +38,9 @@ SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
     "list",
     "NoneType",
     "memoryview",
+    "range",
     "set",
+    "slice",
     "str",
     "tuple",
 }

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -459,7 +459,7 @@ class SecureSerializerBase(object):
     @staticmethod
     def secure_loads(value: bytes) -> Any:
         """Secure replacement for `pickle.loads`."""
-        stream = io.BytesIO(initial_bytes=value)
+        stream = io.BytesIO(value)
         stream_protocol = SecureSerializerBase._get_stream_protocol(value)
         try:
             return SecureUnpickler(stream, stream_protocol=stream_protocol).load()

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -183,10 +183,12 @@ class UnpickleCompatibilityError(pickle.UnpicklingError):
         self.name = name
         self._top_package = _top_package
 
+
 class UnpickleIntegrityError(pickle.UnpicklingError):
     """Subclass of `pickle.UnpicklingError` raised on failed HMAC verification."""
     def __init__(self, *args: Any) -> None:
         super().__init__(*args)
+
 
 class UnpickleSecurityError(pickle.UnpicklingError):
     """
@@ -210,7 +212,7 @@ class UnpickleSecurityError(pickle.UnpicklingError):
             _msg += (
                 "However, the '%s.%s' namespace cannot be added to the set of trusted packages " % (module, name,)
                 + "since it is permanently disallowed! To view the set of permanently disallowed packages, "
-                + "please run:\n    `pyrosetta.get_disallowed_packages()`\n"
+                + "please run:\n    `pyrosetta.secure_unpickle.get_disallowed_packages()`\n"
             )
         elif (module == "builtins" and name not in SECURE_PYTHON_BUILTINS):
             _msg += (
@@ -227,7 +229,7 @@ class UnpickleSecurityError(pickle.UnpicklingError):
             else:
                 _msg += (
                     "To add it to the set of trusted packages, please run the following then try again:\n"
-                    + "    `pyrosetta.add_secure_package(%r)`\n" % (_top_package,)
+                    + "    `pyrosetta.secure_unpickle.add_secure_package(%r)`\n" % (_top_package,)
                 )
         super().__init__(_msg)
         self.module = module

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -309,7 +309,7 @@ def _split_top_package(module: str) -> str:
 
 class ModuleCache(object):
     """
-    Resolve modules and packages by path, and determine if they are allowed or blocked.
+    Resolve modules and packages by path, and determine if they are allowed or disallowed.
     """
     @staticmethod
     @lru_cache(maxsize=1)
@@ -472,6 +472,7 @@ class SecureUnpickler(pickle.Unpickler):
             raise UnpickleSecurityError(module, name, get_secure_packages())
         if ModuleCache._is_allowed_module(module):
             return ModuleCache._get_allowed_module_attr(module, name)
+
         raise UnpickleSecurityError(module, name, get_secure_packages())
 
 
@@ -504,7 +505,7 @@ class SecureSerializerBase(object):
         return base64.b64encode(value).decode(SecureSerializerBase._encoder)
 
     @staticmethod
-    def secure_loads(value: bytes) -> Any:
+    def secure_loads(value: bytes) -> Union[Any, NoReturn]:
         """Secure replacement for `pickle.loads`."""
         stream = io.BytesIO(value)
         stream_protocol = SecureSerializerBase._get_stream_protocol(value)

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -8,10 +8,10 @@
 # Secure unpickling in PyRosetta
 """
 **Warning**: ONLY LOAD DATA YOU TRUST. 
-The pose.cache dictionary uses the pickle module to serialze and deserialize arbitrary scores in the Pose object. 
-When depickling (deserializing) is performed arbitrary code can be executed, learn more `here <https://docs.python.org/3/library/pickle.html>`_.
-The pose.cache object is only stored in memory, so this is only a risk if these objects are sent to a user in memory over a network
-such as a socket, queue, shared cache, etc. If you need to retrieve a pose.cache dictionary this way please make sure it is from a trusted source.
+When depickling (deserializing) is performed arbitrary code can be executed, learn more at https://docs.python.org/3/library/pickle.html
+We (the PyRosetta developers) have made reasonable efforts to prevent malicious usage, however 
+the system’s complexity means it cannot be guaranteed to be entirely foolproof. To avoid finding
+any remaining security issues from the pickle module, only use inputs and data from known, trusted sources.
 """
 
 

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -359,12 +359,8 @@ class ModuleCache(object):
         _rosetta_origin = ModuleCache._rosetta_origin()
         _pyrosetta_base_dir = ModuleCache._package_base_dir("pyrosetta")
         # Ensure that the `rosetta.so` binary is under the 'pyrosetta' package base directory
-        print("Checking module:", module)
-        print("Rosetta module/origin:", _rosetta_module, _rosetta_origin)
-        print("PyRosetta base directory:", _pyrosetta_base_dir)
-        print("Rosetta origin is relative to PyRosetta base directory:", ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir))
-        # if _rosetta_origin and _pyrosetta_base_dir and not ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir):
-        #     raise PyRosettaModuleNotFoundError("pyrosetta.rosetta")
+        if _rosetta_origin and _pyrosetta_base_dir and not ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir):
+            raise PyRosettaModuleNotFoundError("pyrosetta.rosetta")
         # Check if submodule has an origin identical to the 'pyrosetta.rosetta' origin
         _module = sys.modules.get(module, None)
         if _module is not None:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -576,7 +576,8 @@ class SecureSerializerBase(object):
 
     @staticmethod
     def _get_stream_protocol(obj: bytes) -> int:
-        if len(obj) >= 2 and obj[0] == pickle.PROTO[0]:
+        _proto = getattr(pickle, "PROTO", b'\x80')
+        if len(obj) >= 2 and obj[0] == _proto[0]:
             return obj[1] if 0 <= obj[1] <= pickle.HIGHEST_PROTOCOL else -1
         else:
             return -1

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -22,11 +22,11 @@ import sys
 
 from pathlib import Path
 from functools import lru_cache, partial
-from typing import AbstractSet, Any, Dict, Iterable, NoReturn, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, Iterable, NoReturn, Optional, Tuple, Union
 
 
 # Default secure python builtins:
-SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
+SECURE_PYTHON_BUILTINS: FrozenSet[str] = frozenset({
     "bool",
     "bytearray",
     "bytes",
@@ -43,13 +43,13 @@ SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
     "str",
     "tuple",
     "type",
-}
+})
 
 # Default secure packages, not including PyRosetta:
 SECURE_EXTRA_PACKAGES: Tuple[str, ...] = ("numpy",)
 
 # Modules that will not be callable targets via the `pickle` module:
-BLOCKED_PACKAGES: AbstractSet[str] = {
+BLOCKED_PACKAGES: FrozenSet[str] = frozenset({
     "subprocess",  # Block `subprocess.*` calls
     "ctypes",  # Block arbitrary code
     # Block pickle and relatives:
@@ -75,10 +75,10 @@ BLOCKED_PACKAGES: AbstractSet[str] = {
     "tempfile",
     "xml",
     "zipfile",
-}
+})
 
 # Globals that will always be blocked:
-BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
+BLOCKED_GLOBALS: FrozenSet[Tuple[str, str]] = frozenset({
     ("builtins",  "__import__"),
     ("builtins",  "compile"),
     ("builtins",  "eval"),
@@ -92,7 +92,7 @@ BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
     ("posix",     "popen"),
     ("posix",     "system"),
     ("sys",       "exit"),
-}
+})
 
 # Package:prefix pairs for specific method prefixes that will always be blocked:
 BLOCKED_PREFIXES: Dict[str, Tuple[str, ...]] = {

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -470,9 +470,7 @@ class SecureSerializerBase(object):
 
     @staticmethod
     def secure_from_base64_pickle(string: str) -> Any:
-        raw = SecureSerializerBase.from_base64(
-            string.encode(SecureSerializerBase._encoder)
-        )
+        raw = SecureSerializerBase.from_base64(string)
         key = get_unpickle_hmac_key()
         if key is not None:
             raw = SecureSerializerBase._verify_and_remove_hmac_tag(key, raw)

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -129,14 +129,14 @@ class UnpickleIntegrityError(pickle.UnpicklingError):
 class UnpickleSecurityError(pickle.UnpicklingError):
     """
     Subclass of `pickle.UnpicklingError` raised when pickled objects
-    reference disallowed globals, classes, or modules.
+    reference disallowed globals and modules.
     """
     def __init__(self, module: str, name: str, allowed: Tuple[str, ...]) -> None:
         self.module = module
         self.name = name
         self.allowed = allowed
         top_package = _split_top_package(module)
-        allowed_sorted = tuple(sorted(set(("pyrosetta",) + allowed)))
+        allowed_sorted = tuple(sorted(set(("pyrosetta",) + self.allowed)))
         msg = (
             "Disallowed unpickling of the '%s.%s' namespace!\n" % (module, name)
             + "The currently allowed packages to be securely unpickled are: %s\n" % (allowed_sorted,)
@@ -150,8 +150,8 @@ class UnpickleSecurityError(pickle.UnpicklingError):
         ):
             msg += (
                 "However, the '%s.%s' namespace cannot be added to the set of trusted packages " % (module, name)
-                + "since it is permanently disallowed! To view the set of permanently disallowed packages, please run:\n"
-                + "    `pyrosetta.get_disallowed_packages()`\n"
+                + "since it is permanently disallowed! To view the set of permanently disallowed packages, "
+                + "please run:\n    `pyrosetta.get_disallowed_packages()`\n"
             )
         else:
             msg += (
@@ -165,7 +165,7 @@ class UnpickleSecurityError(pickle.UnpicklingError):
 
 def add_secure_package(package: str) -> None:
     """
-    Add a secure package by top-level name to the unpickle allowed list.
+    Add a secure package by top-level name to the unpickle-allowed list.
     """
     if not package:
         return None
@@ -189,7 +189,7 @@ def get_secure_packages() -> Tuple[str, ...]:
 
 def remove_secure_package(package: str) -> None:
     """
-    Remove a secure pacakge by top-level name if present in the unpickle allowed list.
+    Remove a secure package by top-level name if present in the unpickle-allowed list.
     """
     if not package:
         return None
@@ -199,7 +199,7 @@ def remove_secure_package(package: str) -> None:
 
 def set_secure_packages(packages: Iterable[str]) -> None:
     """
-    Set the secure extra packages in the unpickle allowed list, excluding 'pyrosetta' which is
+    Set the secure extra packages in the unpickle-allowed list, excluding 'pyrosetta' which is
     always implicitly allowed.
 
     Example:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -269,35 +269,42 @@ class ModuleCache(object):
     @lru_cache(maxsize=None)
     def _package_base_dir(package_name: str) -> Optional[Path]:
         try:
-            package = importlib.import_module(package_name)
+            _package = importlib.import_module(package_name)
         except Exception:
             return None
-        f = getattr(package, "__file__", None)
-        return Path(f).resolve().parent if f else None
+        _file = getattr(_package, "__file__", None)
+
+        return Path(_file).resolve().parent if _file else None
 
     @staticmethod
     @lru_cache(maxsize=None)
-    def _module_file(module: str) -> Optional[Path]:
+    def _module_file(module_name: str) -> Optional[Path]:
         try:
-            mod = importlib.import_module(module)
+            _module = importlib.import_module(module_name)
         except Exception:
             return None
-        f = getattr(mod, "__file__", None)
-        return Path(f).resolve() if f else None
+        _file = getattr(_module, "__file__", None)
+
+        return Path(_file).resolve() if _file else None
 
     @staticmethod
-    def _is_relative_to(p: Path, base: Path) -> bool:
+    def _is_relative_to(path: Path, base: Path) -> bool:
         try:
-            p.relative_to(base)
+            path.relative_to(base)
             return True
         except Exception:
             return False
 
     @staticmethod
     def _is_under_package(module: str, package: str) -> bool:
-        base = ModuleCache._package_base_dir(package)
-        mf = ModuleCache._module_file(module)
-        return bool(base and mf and ModuleCache._is_relative_to(mf, base))
+        _base_dir = ModuleCache._package_base_dir(package)
+        _module_file = ModuleCache._module_file(module)
+
+        return bool(
+            _base_dir
+            and _module_file
+            and ModuleCache._is_relative_to(_module_file, _base_dir)
+        )
 
     @staticmethod
     def _is_allowed_module(module: str) -> bool:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -573,4 +573,4 @@ class SecureSerializerBase(object):
         if len(obj) >= 2 and obj[0] == pickle.PROTO[0]:
             return obj[1] if 0 <= obj[1] <= pickle.HIGHEST_PROTOCOL else -1
         else:
-            return 0
+            return -1

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -208,7 +208,7 @@ class UnpickleSecurityError(pickle.UnpicklingError):
         elif (module == "builtins" and name not in SECURE_PYTHON_BUILTINS):
             _msg += (
                 "However, the '%s.%s' method cannot be added to the set of trusted packages " % (module, name,)
-                + "since it is not allowed! Please consider reporting an issue if the %r python builtins " % (name,)
+                + "since it is not allowed! Please consider reporting an issue if the %r python builtin " % (name,)
                 + "needs to be unpickled for your application."
             )
         else:
@@ -298,6 +298,7 @@ def set_secure_packages(packages: Iterable[str]) -> None:
     with _CONFIG_LOCK:
         SECURE_EXTRA_PACKAGES = tuple(sorted(_out))
 
+@lru_cache(maxsize=1)
 def get_disallowed_packages() -> Tuple[str, ...]:
     """
     Return a `tuple` of packages and methods that are permanently disallowed
@@ -563,7 +564,7 @@ class SecureSerializerBase(object):
 
     @staticmethod
     def _get_hmac_tag(key: bytes, data: bytes) -> bytes:
-        return hmac.digest(key, data, HASHMOD)
+        return hmac.new(key, data, HASHMOD).digest()
 
     @staticmethod
     def _prepend_hmac_tag(key: bytes, data: bytes) -> bytes:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -108,14 +108,14 @@ BLOCKED_PREFIXES: Dict[str, Tuple[str, ...]] = {
 
 
 # Hash-based Message Authentication Code (HMAC) key for data integrity:
-HASHMOD: partial = partial(hashlib.blake2s, digest_size=8)
+HASHMOD: partial = partial(hashlib.blake2s, digest_size=16, salt=b'cache')
 HMAC_SIZE: int = HASHMOD().digest_size
 HMAC_KEY: Optional[bytes] = None  # Disabled by default
 
 def set_unpickle_hmac_key(key: Optional[bytes]) -> None:
     """
     Set the global Hash-based Message Authentication Code (HMAC) key
-    for Pose.cache` score object secure serialization.
+    for `Pose.cache` score object secure serialization.
     """
     global HMAC_KEY
     if key is not None and not isinstance(key, bytes):
@@ -128,7 +128,7 @@ def set_unpickle_hmac_key(key: Optional[bytes]) -> None:
 def get_unpickle_hmac_key() -> Optional[bytes]:
     """
     Get the global Hash-based Message Authentication Code (HMAC) key
-    for Pose.cache` score object secure serialization.
+    for `Pose.cache` score object secure serialization.
     """
     return HMAC_KEY
 

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -385,7 +385,7 @@ class SecureSerializerBase(object):
             raise Exception(
                 "%s: %s. Only pickle-serializable object types are " % (type(ex).__name__, ex,)
                 + "allowed to be dumped. Received: %r. %s" % (type(value), ex,)
-            )
+            ) from ex
 
     @staticmethod
     def from_base64(value: Union[str, bytes]) -> bytes:
@@ -403,7 +403,7 @@ class SecureSerializerBase(object):
         except (TypeError, OverflowError, MemoryError, EOFError) as ex:
             raise Exception(
                 "%s: %s. Could not deserialize value of type %r." % (type(ex).__name__, ex, type(value),)
-            )
+            ) from ex
 
     @staticmethod
     def secure_from_base64_pickle(string: str) -> Any:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -80,10 +80,10 @@ BLOCKED_PACKAGES: AbstractSet[str] = {
 
 # Globals that will always be blocked:
 BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
+    ("builtins",  "__import__"),
+    ("builtins",  "compile"),
     ("builtins",  "eval"),
     ("builtins",  "exec"),
-    ("builtins",  "compile"),
-    ("builtins",  "__import__"),
     ("builtins",  "open"),
     ("http",      "server"),
     ("importlib", "import_module"),
@@ -98,28 +98,28 @@ BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
 # Package:prefix pairs for specific method prefixes that will always be blocked:
 BLOCKED_PREFIXES: Dict[str, Tuple[str, ...]] = {
     "os": (
-        "execl",       "execle",       "execlp",      "execlpe",
-        "execv",       "execve",       "execvp",      "execvpe",
-        "spawnl",      "spawnle",      "spawnlp",     "spawnlpe",
-        "spawnv",      "spawnve",      "spawnvp",     "spawnvpe",
-        "abort",       "access",       "chdir",       "chflags",
-        "chmod",       "chown",        "chroot",      "close",
-        "fchdir",      "fchmod",       "fchown",      "fdopen",
-        "fork",        "forkpty",      "fsync",       "kill",
-        "lchmod",      "lchown",       "link",        "pipe",
-        "posix_spawn", "posix_spawnp", "remove",      "rename",
-        "rmdir",       "startfile",    "sync",        "sys",
-        "unlink",      "write",
+        "execl",        "execle",       "execlp",      "execlpe",
+        "execv",        "execve",       "execvp",      "execvpe",
+        "spawnl",       "spawnle",      "spawnlp",     "spawnlpe",
+        "spawnv",       "spawnve",      "spawnvp",     "spawnvpe",
+        "abort",        "access",       "chdir",       "chflags",
+        "chmod",        "chown",        "chroot",      "close",
+        "fchdir",       "fchmod",       "fchown",      "fdopen",
+        "fork",         "forkpty",      "fsync",       "kill",
+        "lchmod",       "lchown",       "link",        "pipe",
+        "posix_spawn",  "posix_spawnp", "remove",      "rename",
+        "rmdir",        "startfile",    "sync",        "sys",
+        "unlink",       "write",
     ),
     "posix": (
-        "close", "execv", "execve", "kill",
+        "close",        "execv",        "execve",      "kill",
         "open",
     ),
     "shutil": (
-        "chown", "make_archive", "move", "rmtree",
+        "chown",        "make_archive", "move",        "rmtree",
     ),
     "sys": (
-        "addaudithook", "setprofile", "settrace",
+        "addaudithook", "setprofile",   "settrace",
     ),
 }
 
@@ -228,10 +228,10 @@ def add_secure_package(package: str) -> None:
     """
     if not package:
         return None
-    top = _split_top_package(str(package))
-    current = list(get_secure_packages())
-    if top not in current:
-        set_secure_packages(tuple(current + [top]))
+    _top_package = _split_top_package(str(package))
+    _secure_packages = list(get_secure_packages())
+    if _top_package not in _secure_packages:
+        set_secure_packages(tuple(_secure_packages + [_top_package]))
 
 def clear_secure_packages() -> None:
     """
@@ -252,9 +252,9 @@ def remove_secure_package(package: str) -> None:
     """
     if not package:
         return None
-    top = _split_top_package(str(package))
-    current = [p for p in get_secure_packages() if p != top]
-    set_secure_packages(tuple(current))
+    _top_package = _split_top_package(str(package))
+    _secure_packages = [p for p in get_secure_packages() if p != _top_package]
+    set_secure_packages(tuple(_secure_packages))
 
 def set_secure_packages(packages: Iterable[str]) -> None:
     """
@@ -271,8 +271,8 @@ def set_secure_packages(packages: Iterable[str]) -> None:
             "The 'packages' argument parameter must be a `list`, `tuple`, or `set` object. "
             + "Received: %s" % type(packages)
         )
-    seen = set()
-    out = []
+    _seen = set()
+    _out = []
     for package in packages:
         if not isinstance(package, str):
             raise TypeError(
@@ -280,11 +280,11 @@ def set_secure_packages(packages: Iterable[str]) -> None:
             )
         if not package:
             continue
-        top = _split_top_package(package)
-        if top not in seen:
-            seen.add(top)
-            out.append(top)
-    SECURE_EXTRA_PACKAGES = tuple(sorted(out))
+        _top_package = _split_top_package(package)
+        if _top_package not in _seen:
+            _seen.add(_top_package)
+            _out.append(_top_package)
+    SECURE_EXTRA_PACKAGES = tuple(sorted(_out))
 
 def get_disallowed_packages() -> Tuple[str, ...]:
     """
@@ -412,8 +412,8 @@ class ModuleCache(object):
                 return ModuleCache._is_under_rosetta(module)
             return ModuleCache._is_under_package(module, "pyrosetta")
         else: # Maybe trust other modules
-            top = _split_top_package(module)
-            if top in SECURE_EXTRA_PACKAGES and ModuleCache._is_under_package(module, top):
+            _top_package = _split_top_package(module)
+            if _top_package in SECURE_EXTRA_PACKAGES and ModuleCache._is_under_package(module, _top_package):
                 return True
             else:
                 return False

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -418,12 +418,12 @@ class SecureUnpickler(pickle.Unpickler):
             if (0 <= self._stream_protocol <= 1 and name == "_reconstructor") or (
                 2 <= self._stream_protocol <= pickle.HIGHEST_PROTOCOL and name in ("__newobj__", "__newobj_ex__",)
             ):
-                __import__(module)
-                return getattr(sys.modules[module], name)
+                _module = sys.modules.get(module, None) or importlib.import_module(module)
+                return getattr(_module, name)
             raise UnpickleSecurityError(module, name, get_secure_packages())
         if ModuleCache._is_allowed_module(module):
-            __import__(module)
-            return getattr(sys.modules[module], name)
+            _module = sys.modules.get(module, None) or importlib.import_module(module)
+            return getattr(_module, name)
 
         raise UnpickleSecurityError(module, name, get_secure_packages())
 

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -49,7 +49,10 @@ SECURE_EXTRA_PACKAGES: Tuple[str, ...] = ("numpy",)
 BLOCKED_PACKAGES: AbstractSet[str] = {
     "subprocess",  # Block `subprocess.*` calls (including `run`, `check_output`, `Popen`, etc.)
     "ctypes",  # Block arbitrary code
-    "dill",  # Block pickle alternative
+    # Block pickle alternatives:
+    "dill",
+    "joblib",
+    "zodbpickle",
     # Block process spawning:
     "billiard",
     "celery",
@@ -110,7 +113,7 @@ def set_unpickle_hmac_key(key: Optional[bytes]) -> None:
 
 def get_unpickle_hmac_key() -> Optional[bytes]:
     """
-    Set the global Hash-based Message Authentication Code (HMAC) key
+    Get the global Hash-based Message Authentication Code (HMAC) key
     for Pose.cache` score object secure serialization.
     """
     return HMAC_KEY

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -359,8 +359,12 @@ class ModuleCache(object):
         _rosetta_origin = ModuleCache._rosetta_origin()
         _pyrosetta_base_dir = ModuleCache._package_base_dir("pyrosetta")
         # Ensure that the `rosetta.so` binary is under the 'pyrosetta' package base directory
-        if _rosetta_origin and _pyrosetta_base_dir and not ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir):
-            raise PyRosettaModuleNotFoundError("pyrosetta.rosetta")
+        print("Checking module:", module)
+        print("Rosetta module/origin:", _rosetta_module, _rosetta_origin)
+        print("PyRosetta base directory:", _pyrosetta_base_dir)
+        print("Rosetta origin is relative to PyRosetta base directory:", ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir))
+        # if _rosetta_origin and _pyrosetta_base_dir and not ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir):
+        #     raise PyRosettaModuleNotFoundError("pyrosetta.rosetta")
         # Check if submodule has an origin identical to the 'pyrosetta.rosetta' origin
         _module = sys.modules.get(module, None)
         if _module is not None:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -515,11 +515,15 @@ class SecureSerializerBase(object):
             return SecureUnpickler(stream, stream_protocol=stream_protocol).load()
         except (UnpickleSecurityError, UnpickleIntegrityError, UnpickleCompatibilityError):
             raise
+        except MemoryError:
+            raise
+        except KeyboardInterrupt:
+            raise
         except pickle.UnpicklingError as ex:
             raise pickle.UnpicklingError(
                 f"{ex}. PyRosetta secure unpickle failed with stream protocol {stream_protocol}."
             ) from ex
-        except (TypeError, OverflowError, MemoryError, EOFError) as ex:
+        except (TypeError, OverflowError, EOFError) as ex:
             raise Exception(
                 "%s: %s. Could not deserialize value of type %r." % (type(ex).__name__, ex, type(value),)
             ) from ex

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -49,7 +49,8 @@ SECURE_EXTRA_PACKAGES: Tuple[str, ...] = ("numpy",)
 BLOCKED_PACKAGES: AbstractSet[str] = {
     "subprocess",  # Block `subprocess.*` calls (including `run`, `check_output`, `Popen`, etc.)
     "ctypes",  # Block arbitrary code
-    # Block pickle and alternatives:
+    # Block pickle and relatives:
+    "cloudpickle",
     "dill",
     "joblib",
     "pickle",
@@ -59,7 +60,18 @@ BLOCKED_PACKAGES: AbstractSet[str] = {
     "celery",
     "dask",
     "distributed",
-    "multiprocessing", 
+    "multiprocessing",
+    # https://docs.python.org/3/library/security_warnings.html:
+    "base64",
+    "hashlib",
+    "http",
+    "logging",
+    "random",
+    "shelve",
+    "ssl",
+    "tempfile",
+    "xml",
+    "zipfile",
 }
 
 # Globals that will always be blocked:
@@ -69,6 +81,7 @@ BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
     ("builtins", "compile"),
     ("builtins", "__import__"),
     ("builtins", "open"),
+    ("http", "server"),
     ("os", "system"),
     ("os", "popen"),
     ("posix", "system"),

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -164,6 +164,14 @@ class UnpickleSecurityError(pickle.UnpicklingError):
         self._allowed = _allowed
         self._disallowed = _disallowed
 
+class PyRosettaModuleNotFoundError(ModuleNotFoundError):
+    """
+    Subclass of `ModuleNotFoundError` raised when a PyRosetta module is not found under the
+    'pyrosetta.rosetta' namespace or found under the 'pyrosetta' package base directory.
+    """
+    def __init__(self, module: str) -> None:
+        super().__init__("The %r module cannot be found in the PyRosetta install." % (module,))
+
 
 # Methods to update the unpickle-allowed list of secure packages:
 
@@ -304,7 +312,7 @@ class ModuleCache(object):
             ):
                 return True
             else:
-                raise ModuleNotFoundError(module)
+                raise PyRosettaModuleNotFoundError(module)
         else: # Maybe trust other modules
             top = _split_top_package(module)
             if top in SECURE_EXTRA_PACKAGES and ModuleCache._is_under_package(module, top):

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -37,7 +37,6 @@ SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
     "int",
     "list",
     "NoneType",
-    "memoryview",
     "range",
     "set",
     "slice",
@@ -199,6 +198,12 @@ class UnpickleSecurityError(pickle.UnpicklingError):
                 "However, the '%s.%s' namespace cannot be added to the set of trusted packages " % (module, name,)
                 + "since it is permanently disallowed! To view the set of permanently disallowed packages, "
                 + "please run:\n    `pyrosetta.get_disallowed_packages()`\n"
+            )
+        elif (module == "builtins" and name not in SECURE_PYTHON_BUILTINS):
+            _msg += (
+                "However, the '%s.%s' method cannot be added to the set of trusted packages " % (module, name,)
+                + "since it is not allowed! Please consider reporting an issue if the %r python builtins " % (name,)
+                + "needs to be unpickled for your application."
             )
         else:
             if _top_package in allowed:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -50,7 +50,7 @@ SECURE_EXTRA_PACKAGES: Tuple[str, ...] = ("numpy",)
 
 # Modules that will not be callable targets via the `pickle` module:
 BLOCKED_PACKAGES: AbstractSet[str] = {
-    "subprocess",  # Block `subprocess.*` calls (including `run`, `check_output`, `Popen`, etc.)
+    "subprocess",  # Block `subprocess.*` calls
     "ctypes",  # Block arbitrary code
     # Block pickle and relatives:
     "cloudpickle",
@@ -64,7 +64,7 @@ BLOCKED_PACKAGES: AbstractSet[str] = {
     "dask",
     "distributed",
     "multiprocessing",
-    # https://docs.python.org/3/library/security_warnings.html:
+    # Other security concerns <https://docs.python.org/3/library/security_warnings.html>:
     "base64",
     "hashlib",
     "http",
@@ -79,34 +79,47 @@ BLOCKED_PACKAGES: AbstractSet[str] = {
 
 # Globals that will always be blocked:
 BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
-    ("builtins", "eval"),
-    ("builtins", "exec"),
-    ("builtins", "compile"),
-    ("builtins", "__import__"),
-    ("builtins", "open"),
-    ("http", "server"),
-    ("os", "system"),
-    ("os", "popen"),
-    ("posix", "system"),
-    ("posix", "popen"),
-    ("sys", "exit"),
+    ("builtins",  "eval"),
+    ("builtins",  "exec"),
+    ("builtins",  "compile"),
+    ("builtins",  "__import__"),
+    ("builtins",  "open"),
+    ("http",      "server"),
     ("importlib", "import_module")
+    ("os",        "_exit"),
+    ("os",        "popen"),
+    ("os",        "system"),
+    ("posix",     "popen"),
+    ("posix",     "system"),
+    ("sys",       "exit"),
 }
 
 # Package:prefix pairs for specific method prefixes that will always be blocked:
 BLOCKED_PREFIXES: Dict[str, Tuple[str, ...]] = {
     "os": (
-        "execl", "execle", "execlp", "execlpe",
-        "execv", "execve", "execvp", "execvpe",
-        "spawnl", "spawnle", "spawnlp", "spawnlpe",
-        "spawnv", "spawnve", "spawnvp", "spawnvpe",
-        "posix_spawn", "posix_spawnp",
-        "remove", "rmdir", "unlink",
-        "startfile",
+        "execl",       "execle",       "execlp",      "execlpe",
+        "execv",       "execve",       "execvp",      "execvpe",
+        "spawnl",      "spawnle",      "spawnlp",     "spawnlpe",
+        "spawnv",      "spawnve",      "spawnvp",     "spawnvpe",
+        "abort",       "access",       "chdir",       "chflags",
+        "chmod",       "chown",        "chroot",      "close",
+        "fchdir",      "fchmod",       "fchown",      "fdopen",
+        "fork",        "forkpty",      "fsync",       "kill",
+        "lchmod",      "lchown",       "link",        "pipe",
+        "posix_spawn", "posix_spawnp", "remove",      "rename",
+        "rmdir",       "startfile",    "sync",        "sys",
+        "unlink",      "write",
     ),
-    "posix": ("close", "execv", "execve", "kill", "open",),
-    "shutil": ("chown", "make_archive", "move", "rmtree",),
-    "sys": ("addaudithook", "setprofile", "settrace",),
+    "posix": (
+        "close", "execv", "execve", "kill",
+        "open",
+    ),
+    "shutil": (
+        "chown", "make_archive", "move", "rmtree",
+    ),
+    "sys": (
+        "addaudithook", "setprofile", "settrace",
+    ),
 }
 
 

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -286,7 +286,7 @@ class ModuleCache(object):
     Resolve modules and packages by path, and determine if they are allowed or blocked.
     """
     @staticmethod
-    @lru_cache(maxsize=1, typed=True)
+    @lru_cache(maxsize=1)
     def _rosetta_module() -> object:
         _module = sys.modules.get("pyrosetta.rosetta", None)
         if _module is None:
@@ -298,7 +298,7 @@ class ModuleCache(object):
         return _module
 
     @staticmethod
-    @lru_cache(maxsize=1, typed=True)
+    @lru_cache(maxsize=1)
     def _rosetta_origin() -> Optional[Path]:
         _rosetta_module = ModuleCache._rosetta_module()
         _rosetta_spec = getattr(_rosetta_module, "__spec__", None)

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -307,7 +307,10 @@ class ModuleCache(object):
 
 
 class SecureUnpickler(pickle.Unpickler):
-    def find_class(self, module, name):
+    """
+    Secure subclass of `pickle.Unpickler` predicated on allowed and disallowed globals, modules, and prefixes.
+    """
+    def find_class(self, module: str, name: str) -> Union[Any, NoReturn]:
         if module in BLOCKED_PACKAGES:
             raise UnpickleSecurityError(module, name, get_secure_packages())
         if (module, name) in BLOCKED_GLOBALS:
@@ -333,7 +336,7 @@ class SecureUnpickler(pickle.Unpickler):
 
 class SecureSerializerBase(object):
     """
-    Base class for for `PackedPose`, `Pose`, and `Pose.cache` score
+    Base class for `PackedPose`, `Pose`, and `Pose.cache` score
     object secure serialization.
     """
     _encoder: str = "utf-8"

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -1,0 +1,401 @@
+# :noTabs=true:
+#
+# (c) Copyright Rosetta Commons Member Institutions.
+# (c) This file is part of the Rosetta software suite and is made available under license.
+# (c) The Rosetta software is developed by the contributing members of the Rosetta Commons.
+# (c) For more information, see http://www.rosettacommons.org.
+# (c) Questions about this can be addressed to University of Washington CoMotion, email: license@uw.edu.
+# Secure unpickling in PyRosetta
+
+
+__author__ = "Jason C. Klima"
+
+
+import base64
+import hashlib
+import hmac
+import importlib
+import io
+import pickle
+import sys
+
+from pathlib import Path
+from functools import lru_cache, partial
+from typing import AbstractSet, Any, Dict, Iterable, NoReturn, Optional, Tuple, Union
+
+
+# Default secure python builtins:
+SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
+    "bool",
+    "bytearray",
+    "bytes",
+    "complex",
+    "dict",
+    "float",
+    "frozenset",
+    "int",
+    "list",
+    "NoneType",
+    "memoryview",
+    "set",
+    "str",
+    "tuple",
+}
+
+# Default secure packages, not including PyRosetta:
+SECURE_EXTRA_PACKAGES: Tuple[str, ...] = ("numpy",)
+
+# Modules that will not be callable targets via the `pickle` module:
+BLOCKED_PACKAGES: AbstractSet[str] = {
+    "subprocess",  # Block `subprocess.*` calls (including `run`, `check_output`, `Popen`, etc.)
+    "ctypes",  # Block arbitrary code
+    "dill",  # Block pickle alternative
+    # Block process spawning:
+    "billiard",
+    "celery",
+    "dask",
+    "distributed",
+    "multiprocessing", 
+}
+
+# Globals that will always be blocked:
+BLOCKED_GLOBALS: AbstractSet[Tuple[str, str]] = {
+    ("builtins", "eval"),
+    ("builtins", "exec"),
+    ("builtins", "compile"),
+    ("builtins", "__import__"),
+    ("builtins", "open"),
+    ("os", "system"),
+    ("os", "popen"),
+    ("posix", "system"),
+    ("posix", "popen"),
+    ("sys", "exit"),
+    ("importlib", "import_module")
+}
+
+# Package:prefix pairs for specific method prefixes that will always be blocked:
+BLOCKED_PREFIXES: Dict[str, Tuple[str, ...]] = {
+    "os": (
+        "execl", "execle", "execlp", "execlpe",
+        "execv", "execve", "execvp", "execvpe",
+        "spawnl", "spawnle", "spawnlp", "spawnlpe",
+        "spawnv", "spawnve", "spawnvp", "spawnvpe",
+        "posix_spawn", "posix_spawnp",
+        "remove", "rmdir", "unlink",
+        "startfile",
+    ),
+    "posix": ("close", "execv", "execve", "kill", "open",),
+    "shutil": ("chown", "make_archive", "move", "rmtree",),
+    "sys": ("addaudithook", "setprofile", "settrace",),
+}
+
+
+# Hash-based Message Authentication Code (HMAC) key for data integrity:
+HASHMOD: partial = partial(hashlib.blake2s, digest_size=8)
+HMAC_SIZE: int = HASHMOD().digest_size
+HMAC_KEY: Optional[bytes] = None  # Disabled by default
+
+def set_unpickle_hmac_key(key: Optional[bytes]) -> None:
+    """
+    Set the global Hash-based Message Authentication Code (HMAC) key
+    for Pose.cache` score object secure serialization.
+    """
+    global HMAC_KEY
+    if key is not None and not isinstance(key, bytes):
+        raise TypeError(
+            "The 'key' argument parameter must be a `bytes` or `NoneType` object. "
+            + "Received: %s" % type(key)
+        )
+    HMAC_KEY = key
+
+def get_unpickle_hmac_key() -> Optional[bytes]:
+    """
+    Set the global Hash-based Message Authentication Code (HMAC) key
+    for Pose.cache` score object secure serialization.
+    """
+    return HMAC_KEY
+
+
+# `UnpicklingError` exception subclasses:
+
+class UnpickleIntegrityError(pickle.UnpicklingError):
+    """Subclass of `pickle.UnpicklingError` raised on failed HMAC verification."""
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+
+class UnpickleSecurityError(pickle.UnpicklingError):
+    """
+    Subclass of `pickle.UnpicklingError` raised when pickled objects
+    reference disallowed globals, classes, or modules.
+    """
+    def __init__(self, module: str, name: str, allowed: Tuple[str, ...]) -> None:
+        self.module = module
+        self.name = name
+        self.allowed = allowed
+        top_package = _split_top_package(module)
+        allowed_sorted = tuple(sorted(set(("pyrosetta",) + allowed)))
+        msg = (
+            "Disallowed unpickling of the '%s.%s' namespace!\n" % (module, name)
+            + "The currently allowed packages to be securely unpickled are: %s\n" % (allowed_sorted,)
+            + "The received object requires the %r package. " % (top_package,)
+        )
+        if "%s.%s" % (module, name,) in get_disallowed_packages():
+            msg += (
+                "However, the '%s.%s' namespace cannot be added to the set of trusted packages " % (module, name)
+                + "since it is permanently disallowed! To view the set of permanently disallowed packages, please run:\n"
+                + "    `pyrosetta.get_disallowed_packages()`\n"
+            )
+        else:
+            msg += (
+                "To add it to the set of trusted packages, please run the following then try again:\n"
+                + "    `pyrosetta.add_secure_package(%r)`\n" % (top_package,)
+            )
+        super().__init__(msg)
+
+
+# Methods to update the unpickle-allowed list of secure packages:
+
+def add_secure_package(package: str) -> None:
+    """
+    Add a secure package by top-level name to the unpickle allowed list.
+    """
+    if not package:
+        return None
+    top = _split_top_package(str(package))
+    current = list(get_secure_packages())
+    if top not in current:
+        set_secure_packages(tuple(current + [top]))
+
+def clear_secure_packages() -> None:
+    """
+    Remove all secure packages, excluding 'pyrosetta' which is always implicitly allowed.
+    """
+    set_secure_packages(tuple())
+
+def get_secure_packages() -> Tuple[str, ...]:
+    """
+    Return the extra secure packages currently allowed, excluding 'pyrosetta' which is
+    always implicitly allowed.
+    """
+    return SECURE_EXTRA_PACKAGES
+
+def remove_secure_package(package: str) -> None:
+    """
+    Remove a secure pacakge by top-level name if present in the unpickle allowed list.
+    """
+    if not package:
+        return None
+    top = _split_top_package(str(package))
+    current = [p for p in get_secure_packages() if p != top]
+    set_secure_packages(tuple(current))
+
+def set_secure_packages(packages: Iterable[str]) -> None:
+    """
+    Set the secure extra packages in the unpickle allowed list, excluding 'pyrosetta' which is
+    always implicitly allowed.
+
+    Example:
+        `set_secure_packages(('numpy', 'pandas'))`
+    """
+    global SECURE_EXTRA_PACKAGES
+
+    if not isinstance(packages, (list, tuple, set)):
+        raise TypeError(
+            "The 'packages' argument parameter must be a `list`, `tuple`, or `set` object. "
+            + "Received: %s" % type(packages)
+        )
+    seen = set()
+    out = []
+    for package in packages:
+        if not package:
+            continue
+        top = _split_top_package(str(package))
+        if top not in seen:
+            seen.add(top)
+            out.append(top)
+    SECURE_EXTRA_PACKAGES = tuple(out)
+
+def get_disallowed_packages() -> Tuple[str, ...]:
+    """
+    Return a `tuple` of packages and methods that are permanently disallowed
+    from being unpickled in PyRosetta.
+    """
+    disallowed = set()
+    for _package in BLOCKED_PACKAGES:
+        disallowed.add(_package)
+    for _package, _method in BLOCKED_GLOBALS:
+        disallowed.add("%s.%s" % (_package, _method,))
+    for _package, _methods in BLOCKED_PREFIXES.items():
+        for _method in _methods:
+            disallowed.add("%s.%s" % (_package, _method,))
+
+    return tuple(sorted(disallowed))
+
+def _split_top_package(module: str) -> str:
+    return module.split(".", 1)[0]
+
+
+# Unpickle methods:
+
+class ModuleCache(object):
+    """
+    Resolve modules and packages by path, and determine if they are allowed or blocked.
+    """
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _package_base_dir(package_name: str) -> Optional[Path]:
+        try:
+            package = importlib.import_module(package_name)
+        except Exception:
+            return None
+        f = getattr(package, "__file__", None)
+        return Path(f).resolve().parent if f else None
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _module_file(module: str) -> Optional[Path]:
+        try:
+            mod = importlib.import_module(module)
+        except Exception:
+            return None
+        f = getattr(mod, "__file__", None)
+        return Path(f).resolve() if f else None
+
+    @staticmethod
+    def _is_relative_to(p: Path, base: Path) -> bool:
+        try:
+            p.relative_to(base)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _is_under_package(module: str, package: str) -> bool:
+        base = ModuleCache._package_base_dir(package)
+        mf = ModuleCache._module_file(module)
+        return bool(base and mf and ModuleCache._is_relative_to(mf, base))
+
+    @staticmethod
+    def _is_allowed_module(module: str) -> bool:
+        # Always trust PyRosetta modules by path
+        if (module == "pyrosetta"):
+            return True
+        if module.startswith("pyrosetta."):
+            if (
+                (module == "pyrosetta.rosetta")
+                or module.startswith("pyrosetta.rosetta.")
+                or ModuleCache._is_under_package(module, "pyrosetta")
+            ):
+                return True
+            else:
+                raise ModuleNotFoundError(module)
+        else: # Maybe trust other modules
+            top = _split_top_package(module)
+            if top in SECURE_EXTRA_PACKAGES and ModuleCache._is_under_package(module, top):
+                return True
+            else:
+                return False
+
+
+class SecureUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module in BLOCKED_PACKAGES:
+            raise UnpickleSecurityError(module, name, get_secure_packages())
+        if (module, name) in BLOCKED_GLOBALS:
+            raise UnpickleSecurityError(module, name, get_secure_packages())
+        if module in BLOCKED_PREFIXES and any(name.startswith(prefix) for prefix in BLOCKED_PREFIXES[module]):
+            raise UnpickleSecurityError(module, name, get_secure_packages())
+        # Builtins:
+        if module == "builtins" and name in SECURE_PYTHON_BUILTINS:
+            return getattr(sys.modules["builtins"], name)
+        # For pickle protocols 0 and 1, include `copyreg` unpickle helper function:
+        # if module == "copyreg" and name == "_reconstructor":
+        #     __import__(module)
+        #     return getattr(sys.modules[module], name)
+        if ModuleCache._is_allowed_module(module):
+            __import__(module)
+            return getattr(sys.modules[module], name) 
+
+        raise UnpickleSecurityError(module, name, get_secure_packages())
+
+
+# Secure serialization for `PackedPose` and `Pose.cache` score objects:
+
+class SecureSerializerBase(object):
+    """
+    Base class for for `PackedPose`, `Pose`, and `Pose.cache` score
+    object secure serialization.
+    """
+    _encoder = "utf-8"
+
+    @staticmethod
+    def to_pickle(value: Any) -> Union[bytes, NoReturn]:
+        try:
+            return pickle.dumps(value, protocol=5)
+        except (TypeError, OverflowError, MemoryError, pickle.PicklingError) as ex:
+            raise Exception(
+                "%s: %s. Only pickle-serializable object types are " % (type(ex).__name__, ex,)
+                + "allowed to be dumped. Received: %r. %s" % (type(value), ex,)
+            )
+
+    @staticmethod
+    def from_base64(value: str) -> bytes:
+        return base64.b64decode(value, validate=True)
+
+    @staticmethod
+    def to_base64(value: bytes) -> str:
+        return base64.b64encode(value).decode(SecureSerializerBase._encoder)
+
+    @staticmethod
+    def secure_loads(value: bytes) -> Any:
+        """Secure replacement for `pickle.loads`."""
+        try:
+            return SecureUnpickler(io.BytesIO(value)).load()
+        except (TypeError, OverflowError, MemoryError, EOFError) as ex:
+            raise Exception(
+                "%s: %s. Could not deserialize value of type %r." % (type(ex).__name__, ex, type(value),)
+            )
+        except UnpickleSecurityError as ex:
+            raise UnpickleSecurityError(ex.module, ex.name, ex.allowed) from ex
+
+    @staticmethod
+    def secure_from_base64_pickle(string: str) -> Any:
+        raw = SecureSerializerBase.from_base64(
+            string.encode(SecureSerializerBase._encoder)
+        )
+        key = get_unpickle_hmac_key()
+        if key is not None:
+            raw = SecureSerializerBase._verify_and_remove_hmac_tag(key, raw)
+
+        return SecureSerializerBase.secure_loads(raw)
+
+    @staticmethod
+    def secure_to_base64_pickle(obj: Any) -> str:
+        obj = SecureSerializerBase.to_pickle(obj)
+        key = get_unpickle_hmac_key()
+        if key is not None:
+            obj = SecureSerializerBase._prepend_hmac_tag(key, obj)
+
+        return SecureSerializerBase.to_base64(obj)
+
+    @staticmethod
+    def _get_hmac_tag(key: bytes, data: bytes) -> bytes:
+        return hmac.digest(key, data, HASHMOD)
+
+    @staticmethod
+    def _prepend_hmac_tag(key: bytes, data: bytes) -> bytes:
+        return SecureSerializerBase._get_hmac_tag(key, data) + data
+
+    @staticmethod
+    def _verify_and_remove_hmac_tag(key: bytes, signed_data: bytes) -> Union[bytes, NoReturn]:
+        if len(signed_data) < HMAC_SIZE:
+            raise UnpickleIntegrityError("Signed object is too short.")
+        hmac_tag, data = signed_data[:HMAC_SIZE], signed_data[HMAC_SIZE:]
+        expected_hmac_tag = SecureSerializerBase._get_hmac_tag(key, data)
+        if not hmac.compare_digest(hmac_tag, expected_hmac_tag):
+            raise UnpickleIntegrityError(
+                "PyRosetta secure unpickler HMAC verification failed! The HMAC key may have "
+                + "changed or the data has been tampered with after the data was pickled."
+            )
+
+        return data

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -465,6 +465,12 @@ class SecureSerializerBase(object):
             raise Exception(
                 "%s: %s. Could not deserialize value of type %r." % (type(ex).__name__, ex, type(value),)
             ) from ex
+        except pickle.UnpicklingError as ex:
+            raise pickle.UnpicklingError(
+                f"{ex}. PyRosetta secure unpickle failed with stream protocol {stream_protocol}."
+            ) from ex
+        except (UnpickleSecurityError, UnpickleIntegrityError):
+            raise
 
     @staticmethod
     def secure_from_base64_pickle(string: str) -> Any:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -357,10 +357,6 @@ class ModuleCache(object):
             return False
         _rosetta_module = ModuleCache._rosetta_module()
         _rosetta_origin = ModuleCache._rosetta_origin()
-        _pyrosetta_base_dir = ModuleCache._package_base_dir("pyrosetta")
-        # Ensure that the `rosetta.so` binary is under the 'pyrosetta' package base directory
-        if _rosetta_origin and _pyrosetta_base_dir and not ModuleCache._is_relative_to(_rosetta_origin, _pyrosetta_base_dir):
-            raise PyRosettaModuleNotFoundError("pyrosetta.rosetta")
         # Check if submodule has an origin identical to the 'pyrosetta.rosetta' origin
         _module = sys.modules.get(module, None)
         if _module is not None:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -43,6 +43,7 @@ SECURE_PYTHON_BUILTINS: AbstractSet[str] = {
     "slice",
     "str",
     "tuple",
+    "type",
 }
 
 # Default secure packages, not including PyRosetta:

--- a/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/secure_unpickle.py
@@ -6,6 +6,13 @@
 # (c) For more information, see http://www.rosettacommons.org.
 # (c) Questions about this can be addressed to University of Washington CoMotion, email: license@uw.edu.
 # Secure unpickling in PyRosetta
+"""
+**Warning**: ONLY LOAD DATA YOU TRUST. 
+The pose.cache dictionary uses the pickle module to serialze and deserialize arbitrary scores in the Pose object. 
+When depickling (deserializing) is performed arbitrary code can be executed, learn more `here <https://docs.python.org/3/library/pickle.html>`_.
+The pose.cache object is only stored in memory, so this is only a risk if these objects are sent to a user in memory over a network
+such as a socket, queue, shared cache, etc. If you need to retrieve a pose.cache dictionary this way please make sure it is from a trusted source.
+"""
 
 
 __author__ = "Jason C. Klima"

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
@@ -1018,18 +1018,18 @@ class TestPoseSecureUnpickler(unittest.TestCase):
 
     def test_secure_unpickler(self):
         # Test secure packages
-        self.assertIn("numpy", pyrosetta.get_secure_packages())
-        pyrosetta.clear_secure_packages()
-        self.assertEqual(pyrosetta.get_secure_packages(), ())
-        pyrosetta.add_secure_package("pandas.core.frame")  # Normalizes to 'pandas'
-        self.assertEqual(pyrosetta.get_secure_packages(), ("pandas",))
-        pyrosetta.add_secure_package("pandas")  # Also normalizes to 'pandas'
-        self.assertEqual(pyrosetta.get_secure_packages(), ("pandas",))
-        pyrosetta.remove_secure_package("pandas.io.parquet")  # Also normalizes to 'pandas'
-        self.assertEqual(pyrosetta.get_secure_packages(), ())
-        pyrosetta.clear_secure_packages()
-        pyrosetta.set_secure_packages(("numpy",))
-        self.assertEqual(pyrosetta.get_secure_packages(), ("numpy",))
+        self.assertIn("numpy", pyrosetta.secure_unpickle.get_secure_packages())
+        pyrosetta.secure_unpickle.clear_secure_packages()
+        self.assertEqual(pyrosetta.secure_unpickle.get_secure_packages(), ())
+        pyrosetta.secure_unpickle.add_secure_package("pandas.core.frame")  # Normalizes to 'pandas'
+        self.assertEqual(pyrosetta.secure_unpickle.get_secure_packages(), ("pandas",))
+        pyrosetta.secure_unpickle.add_secure_package("pandas")  # Also normalizes to 'pandas'
+        self.assertEqual(pyrosetta.secure_unpickle.get_secure_packages(), ("pandas",))
+        pyrosetta.secure_unpickle.remove_secure_package("pandas.io.parquet")  # Also normalizes to 'pandas'
+        self.assertEqual(pyrosetta.secure_unpickle.get_secure_packages(), ())
+        pyrosetta.secure_unpickle.clear_secure_packages()
+        pyrosetta.secure_unpickle.set_secure_packages(("numpy",))
+        self.assertEqual(pyrosetta.secure_unpickle.get_secure_packages(), ("numpy",))
 
         # Test secure serialization round-trip
         data = {"foo": [1, 2, 3], "bar": ("String", b"Bytes"), "baz": complex(1, -2)}
@@ -1048,7 +1048,7 @@ class TestPoseSecureUnpickler(unittest.TestCase):
                 import os
                 return (os.system, ("echo 'Wreaking havoc...'",))
 
-        pyrosetta.clear_secure_packages()
+        pyrosetta.secure_unpickle.clear_secure_packages()
         _obj = pickle.dumps(_CauseHavoc(), protocol=pickle.DEFAULT_PROTOCOL)
         with self.assertRaises(UnpickleSecurityError) as ex:
             _ = SecureSerializerBase.secure_loads(_obj)
@@ -1087,7 +1087,7 @@ class TestPoseSecureUnpickler(unittest.TestCase):
             _ = SecureSerializerBase.secure_from_base64_pickle(string_data_tampered)
         set_unpickle_hmac_key(None)
 
-        pyrosetta.set_secure_packages(("numpy",))
+        pyrosetta.secure_unpickle.set_secure_packages(("numpy",))
         for hmac_key in (None,  b"", os.urandom(16), b"TestingMyKey", "String", {1, 2, 3}, {"foo": "bar"}):
             if not isinstance(hmac_key, (type(None), bytes)):
                 with self.assertRaises(TypeError):

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
@@ -1050,9 +1050,9 @@ class TestPoseSecureUnpickler(unittest.TestCase):
         _obj = pickle.dumps(_CauseHavoc(), protocol=5)
         with self.assertRaises(UnpickleSecurityError) as ex:
             _ = SecureSerializerBase.secure_loads(_obj)
-            _msg = str(ex.value)
-            self.assertIn(f"Disallowed unpickling of 'os.system' namespace!\n", _msg)
-            self.assertIn("`pyrosetta.add_secure_package('os')`", _msg)
+        _msg = str(ex.exception)
+        self.assertIn("Disallowed unpickling of the 'posix.system' namespace!", _msg)
+        self.assertIn("the 'posix.system' namespace cannot be added", _msg)
 
         # Test custom HMAC key
         data = {

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/bindings/core/test_pose.py
@@ -211,7 +211,7 @@ class TestPoseScoresAccessor(unittest.TestCase):
             # Round-trip set/get scoretype value
             if obj_type == pyrosetta.rosetta.core.scoring.ScoreFunction:
                 # `ScoreFunction` instances (and some other PyRosetta instances besides `Pose` instances) cannot be serialized
-                with self.assertRaises(TypeError):
+                with self.assertRaises(Exception):
                     test_pose.cache[str(obj_type)] = value_input
                 continue
             else:


### PR DESCRIPTION
Currently, `PackedPose` objects are serialized/deserialized using the `pickle` module (introduced in ~2019), and the `Pose.cache` dictionary (introduced in #430) supports caching arbitrary datatypes in the `Pose` object using the `pickle` module. Additionally, #462 enables saving compressed `PackedPose` objects to disk (i.e., as `*.b64_pose` and `*.pkl_pose` files) for sharing PyRosetta `Pose` objects with the scientific community. However, use of the `pickle` module is not secure (see warning [here](https://docs.python.org/3/library/pickle.html) as outlined in #519).

Herein this PR, a secure `pickle.loads` method is developed and slotted into the `PackedPose` and `Pose.cache` infrastructure to permanently disallow certain risky packages, modules, and namespaces from being unpickled/loaded (e.g., `exec`, `eval`, `os.system`, `subprocess.run`, etc., and will be updated over time as needed), thus significantly improving the security of handling `PackedPose` and `Pose` objects in memory if received from a second party (i.e., over a socket, queue, interprocess communication, etc.) or when reading a file received from a second party (i.e., using `pyrosetta.distributed.io.pose_from_file` with a `*.b64_pose` and `*.pkl_pose` file). By default, only `pyrosetta` and `numpy` packages, and certain `builtins` modules (like `dict`, `complex`, `tuple`, etc.), are considered secure and permitted to be unpickled/loaded. Other packages that the user may want to serialize/deserialize may be assigned as secure per-process by the user in-code (see methods below). It is worth noting that PyTorch developers have implemented a similar strategy with the [torch.serialization.add_safe_globals()](https://docs.pytorch.org/docs/stable/notes/serialization.html#torch.serialization.add_safe_globals) method.

Another aim of this PR is to implement an optional Hash-based Message Authentication Code (HMAC) key in the `Pose.cache` dictionary for data integrity verification. While not a security feature, this new API allows the user to set a HMAC key to be prepended to every score value in the `Pose.cache` dictionary that effectively says "this was saved by PyRosetta", so  that it intentionally raises an error when the HMAC key is missing or differs upon retrieval, indicating that the data appears to have been tampered with or modified. By default, the HMAC key is disabled (being set to `None`) in order to reduce memory overhead of the `Pose.cache` dictionary; e.g., if 32 bytes are prepended to each score value, with 1,000 score values that's 32,000 bytes or 32 KB of overhead, and with a million score values that's 32 MB of overhead.

The following are newly added functions:
- `pyrosetta.secure_unpickle.add_secure_package`: Add a package to the unpickle allowed list
- `pyrosetta.secure_unpickle.remove_secure_package`: Remove a package from the unpickle allowed list
- `pyrosetta.secure_unpickle.clear_secure_packages`: Remove all packages from the unpickle allowed list
- `pyrosetta.secure_unpickle.get_disallowed_packages`: Return all permanently disallowed packages/modules/prefixes
- `pyrosetta.secure_unpickle.get_secure_packages`: Return all packages in the unpickle allowed list
- `pyrosetta.secure_unpickle.set_secure_packages`: Set all packages in the unpickle allowed list
- `pyrosetta.secure_unpickle.set_unpickle_hmac_key`: Set the HMAC key for the `Pose.cache` dictionary
- `pyrosetta.secure_unpickle.get_unpickle_hmac_key`: Return the HMAC key for the `Pose.cache` dictionary