### PR TITLE
Defining a PyRosetta build signature specifying extras

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -213,7 +213,7 @@ def _version_string():
     return rosetta.utility.Version.package() + " " + ".".join(version)
 
 
-def _pyrosetta_build_signature():
+def _build_signature():
     extras = "+".join(sorted(rosetta.utility.Version.extras()))
     extras_string = f"[extras:{extras}]"
     version_list = _version_string().split()

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -191,9 +191,9 @@ def init(options='-ex1 -ex2aro', extra_options='', set_logging_handler=None, not
 
     if not silent:
         print( version() )
-        logger.info( version() )
+        logger.info( "\n" + version() )
     else:
-        logger.debug( version() )
+        logger.debug( "\n" + version() )
     rosetta.protocols.init.init(v)
     pyrosetta.protocols.h5_fragment_store_provider.init_H5FragmentStoreProvider()
     pyrosetta.protocols.h5_structure_store_provider.init_H5StructureStoreProvider()

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -213,6 +213,14 @@ def _version_string():
     return rosetta.utility.Version.package() + " " + ".".join(version)
 
 
+def _pyrosetta_build_signature():
+    extras = "+".join(sorted(rosetta.utility.Version.extras()))
+    extras_string = f"[extras:{extras}]"
+    version_list = _version_string().split()
+    version_list.insert(1, extras_string)
+    return "".join(version_list)
+
+
 def version():
     return (
         '┌───────────────────────────────────────────────────────────────────────────────┐\n'

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/__init__.py
@@ -49,7 +49,7 @@ __all__: List[str] = [
     "run",
     "update_scores",
 ]
-__version__: str = "2.2.0"
+__version__: str = "2.2.1"
 
 _print_conda_warnings()
 

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
@@ -230,7 +230,7 @@ def _parse_yield_results(yield_results: Any) -> bool:
 def _parse_pyrosetta_build(obj: Any) -> str:
     """Parse the PyRosetta build string."""
 
-    _pyrosetta_version_string = pyrosetta._pyrosetta_build_signature()
+    _pyrosetta_version_string = pyrosetta._build_signature()
 
     @singledispatch
     def converter(obj: Any) -> NoReturn:

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
@@ -230,7 +230,7 @@ def _parse_yield_results(yield_results: Any) -> bool:
 def _parse_pyrosetta_build(obj: Any) -> str:
     """Parse the PyRosetta build string."""
 
-    _pyrosetta_version_string = pyrosetta._version_string()
+    _pyrosetta_version_string = pyrosetta._pyrosetta_build_signature()
 
     @singledispatch
     def converter(obj: Any) -> NoReturn:

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/converters.py
@@ -244,7 +244,7 @@ def _parse_pyrosetta_build(obj: Any) -> str:
     def _validate_pyrosetta_version_string(obj: str) -> Union[str, NoReturn]:
         if obj == "":
             logging.warning(
-                "The input 'pyrosetta_build' parameter argument is an empty string, "
+                "The input 'pyrosetta_build' keyword argument parameter is an empty string, "
                 + "which is not a valid PyRosetta build string capturing the original PyRosetta "
                 + "version! Reproduction simulations may not necessarily reproduce "
                 + "the original decoy(s)! Please verify that your PyRosetta build "
@@ -261,12 +261,12 @@ def _parse_pyrosetta_build(obj: Any) -> str:
                     + "Therefore, the original decoy may not necessarily be reproduced! "
                     + "Using different PyRosetta builds can lead to different outputs. "
                     + "Please consider running this simulation using the PyRosetta build that "
-                    + "was used with the original simulation run. Please set the 'pyrosetta_build' parameter "
-                    + "argument to an empty string ('') to bypass PyRosetta build validation."
+                    + "was used with the original simulation run. Please set the 'pyrosetta_build' keyword "
+                    + "argument parameter to an empty string ('') to bypass PyRosetta build validation."
                 )
             else:
                 logging.debug(
-                    "The 'pyrosetta_build' parameter argument correctly validated against the original PyRosetta build!"
+                    "The 'pyrosetta_build' keyword argument parameter correctly validated against the original PyRosetta build!"
                 )
                 return obj
 

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
@@ -117,7 +117,7 @@ Args:
         accounting.
         Default: None
     pyrosetta_build: A `str` or `NoneType` object specifying the PyRosetta build as
-        output by `pyrosetta._version_string()`. If `None` is provided, then PyRosettaCluster
+        output by `pyrosetta._build_signature()`. If `None` is provided, then PyRosettaCluster
         automatically detects the PyRosetta build and sets this attribute as the `str`.
         If a non-empty `str` is provided, then validate that the input PyRosetta build is
         equal to the active PyRosetta build, and raise an error if not. This ensures that

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_smoke.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_smoke.py
@@ -975,7 +975,7 @@ class SaveAllTest(unittest.TestCase):
             self.assertEqual(init_data["author"], author)
             self.assertEqual(init_data["email"], email)
             self.assertEqual(init_data["license"], license)
-            self.assertEqual(init_data["pyrosetta_build"], pyrosetta._version_string())
+            self.assertEqual(init_data["pyrosetta_build"], pyrosetta._build_signature())
             self.assertListEqual(init_data["options"]["run:constant_seed"], ["true"])
 
             # Verify metadata in output PyRosetta initialization file
@@ -1024,7 +1024,7 @@ class SaveAllTest(unittest.TestCase):
                 self.assertEqual(decoy_init_data["author"], author)
                 self.assertEqual(decoy_init_data["email"], email)
                 self.assertEqual(decoy_init_data["license"], license)
-                self.assertEqual(decoy_init_data["pyrosetta_build"], pyrosetta._version_string())
+                self.assertEqual(decoy_init_data["pyrosetta_build"], pyrosetta._build_signature())
                 self.assertListEqual(decoy_init_data["options"]["run:constant_seed"], ["true"])
 
                 # Verify metadata in decoy output PyRosetta initialization file
@@ -1111,7 +1111,7 @@ class SaveAllTest(unittest.TestCase):
             self.assertEqual(exported_init_data["author"], author)
             self.assertEqual(exported_init_data["email"], email)
             self.assertEqual(exported_init_data["license"], license)
-            self.assertEqual(exported_init_data["pyrosetta_build"], pyrosetta._version_string())
+            self.assertEqual(exported_init_data["pyrosetta_build"], pyrosetta._build_signature())
             self.assertListEqual(exported_init_data["options"]["run:constant_seed"], ["true"])
 
             # Verify metadata in exported PyRosetta initialization file

--- a/source/src/python/PyRosetta/src/pyrosetta/utility/initialization.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/utility/initialization.py
@@ -56,7 +56,7 @@ class PyRosettaInitFileParserBase(object):
     )
 
     def get_pyrosetta_build(self):
-        return pyrosetta._version_string()
+        return pyrosetta._build_signature()
 
     def pyrosetta_build_warning(self, original_pyrosetta_build, current_pyrosetta_build):
         _msg = os.linesep.join(


### PR DESCRIPTION
This quick PR defines a unique PyRosetta build signature that differs from the existing PyRosetta version string in that it contains build extras as given by `rosetta.utility.Version.extras()`. The aim is to capture build differences in the official PyRosetta `ml` images from non-`ml` images. The `PyRosettaCluster(pyrosetta_build=...)` default keyword argument parameter, and the PyRosetta `.init` file `pyrosetta_build` key value, are updated herein accordingly.

Here is an example of the new `pyrosetta._build_signature()` function's output:
```
PyRosetta4.Release.python311.mac.cxx11thread.serialization[extras:cxx11thread+serialization]2025.19+release.1354d05daa4c339d591afeecef3c94ca2d38680e
```