### PR TITLE
Add scorefile output convieniece function for PyRosetta

### DIFF
--- a/source/src/core/io/raw_data/ScoreFileData.cc
+++ b/source/src/core/io/raw_data/ScoreFileData.cc
@@ -26,8 +26,6 @@
 #include <core/io/raw_data/ScoreStructText.hh>
 #include <core/io/raw_data/ScoreStructJSON.hh>
 
-#include <core/pose/Pose.hh>
-
 #include <utility/file/file_sys_util.hh>
 
 ///Basic headers
@@ -66,36 +64,51 @@ bool ScoreFileData::write_struct(
 }
 
 
-/// @brief write the given pose to the supplied filename.
-bool ScoreFileData::write_pose(
-	core::pose::Pose const &,
+bool ScoreFileData::write_scorefile(
+	std::string tag,
 	std::map < std::string, core::Real > const & score_map,
-	std::string tag = "empty_tag",
-	std::map < std::string, std::string > const & string_map
+	std::map < std::string, std::string > const & string_map,
+	bool use_json
 ) {
 
-	using namespace basic::options;
-	using namespace basic::options::OptionKeys;
-
 	RawStructOP outputter(nullptr);
-	std::string format = option[ out::file::scorefile_format ].value();
 
-	if ( format == "text" ) {
-		// Old plain-text format
-		outputter = utility::pointer::make_shared< ScoreStructText >( tag );
-	} else if ( format == "json" || format == "JSON" ) {
+	if ( use_json ) {
 		// JSON
 		outputter = utility::pointer::make_shared< ScoreStructJSON >( tag );
+	} else {
+		// Old plain-text format
+		outputter = utility::pointer::make_shared< ScoreStructText >( tag );
 	}
 
 	if ( !outputter ) {
-		TR << "Invalid score file format specified: \"" << format << "\". No output generated!" << std::endl;
 		return false;
 	}
 
 	return write_struct( outputter, score_map, string_map );
 }
 
+bool
+ScoreFileData::write_scorefile(
+	std::string tag,
+	std::map < std::string, core::Real > const & score_map,
+	std::map < std::string, std::string > const & string_map
+) {
+	using namespace basic::options;
+	using namespace basic::options::OptionKeys;
+
+	bool use_json = false;
+	std::string format = option[ out::file::scorefile_format ].value();
+	if ( format == "text" ) {
+	} else if ( format == "json" || format == "JSON" ) {
+		use_json = true;
+	} else {
+		TR << "Invalid score file format specified: \"" << format << "\". No output generated!" << std::endl;
+		return false;
+	}
+
+	return write_scorefile(tag, score_map, string_map, use_json);
+}
 
 } // namespace silent
 } // namespace io

--- a/source/src/core/io/raw_data/ScoreFileData.hh
+++ b/source/src/core/io/raw_data/ScoreFileData.hh
@@ -17,7 +17,6 @@
 
 // mini headers
 #include <core/types.hh>
-#include <core/pose/Pose.fwd.hh>
 #include <core/io/raw_data/Raw.fwd.hh>
 #include <core/io/raw_data/RawFileData.hh>
 
@@ -42,11 +41,19 @@ public:
 		std::map < std::string, std::string > const & string_map = ( std::map < std::string, std::string > () )
 	);
 
-	bool write_pose(
-		const core::pose::Pose & pose,
-		std::map < std::string, core::Real > const & score_map,
+	/// @brief write the given data to a scorefile
+	bool write_scorefile(
 		std::string tag,
-		std::map < std::string, std::string > const & string_map = ( std::map < std::string, std::string > () )
+		std::map < std::string, core::Real > const & score_map,
+		std::map < std::string, std::string > const & string_map,
+		bool use_json
+	);
+
+	/// @brief write the given data to a scorefile, autodetecting the format.
+	bool write_scorefile(
+		std::string tag,
+		std::map < std::string, core::Real > const & score_map,
+		std::map < std::string, std::string > const & string_map
 	);
 
 private:

--- a/source/src/protocols/jd2/FileJobOutputter.cc
+++ b/source/src/protocols/jd2/FileJobOutputter.cc
@@ -148,7 +148,7 @@ void FileJobOutputter::scorefile(
 	}
 	*/
 
-	sfd.write_pose( pose, score_map, (prefix_tag + output_name(job) + suffix_tag), string_map );
+	sfd.write_scorefile( (prefix_tag + output_name(job) + suffix_tag), score_map, string_map );
 }
 
 

--- a/source/src/protocols/jd3/pose_outputters/ScoreFileOutputter.cc
+++ b/source/src/protocols/jd3/pose_outputters/ScoreFileOutputter.cc
@@ -131,7 +131,7 @@ ScoreFileOutputter::write_output(
 	// buffer the score file output and then write out the contents
 	// in "flush," which is called only sporadically
 
-	sfd.write_pose( pose, score_map, sfspec.pose_tag(), string_map );
+	sfd.write_scorefile( sfspec.pose_tag(), score_map, string_map );
 }
 
 void

--- a/source/src/protocols/jobdist/JobDistributors.cc
+++ b/source/src/protocols/jobdist/JobDistributors.cc
@@ -709,7 +709,9 @@ void PlainPdbJobDistributor::dump_pose_and_map(
 			name = scorefile_name_.base()+"score."+scorefile_name_.ext();
 		}
 		core::io::raw_data::ScoreFileData sfd(name);
-		sfd.write_pose( pose, score_map_, outfile_name );
+
+		std::map < std::string, std::string > string_map; //empty
+		sfd.write_scorefile( outfile_name, score_map_, string_map );
 	}
 	this->end_critical_section();
 }

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -58,6 +58,7 @@ from pyrosetta.io import (
     poses_from_silent,
     poses_from_multimodel_pdb,
     poses_to_silent,
+    poses_to_scorefile,
     dump_file,
     dump_scored_pdb,
     dump_pdb,

--- a/source/src/python/PyRosetta/src/pyrosetta/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/__init__.py
@@ -68,6 +68,7 @@ from pyrosetta.io import (
     create_score_function,
     get_fa_scorefxn,
     get_score_function,
+    get_scorefile_info,
     Pose,
 )
 

--- a/source/src/python/PyRosetta/src/pyrosetta/io/__init__.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/io/__init__.py
@@ -244,6 +244,57 @@ def poses_to_silent(poses, output_filename):
     else:
         output_silent(pose=poses)
 
+def poses_to_scorefile(poses, scorefile_name, use_json=False, use_job=False):
+    """Takes a Pose or list of poses and outputs the scoring information
+    as a standard Rosetta score file.
+
+    This method requires a Pose object.
+
+    Inputs:
+    poses: Pose or list of poses. This function automatically detects which one.
+    scorefile_name: The desired name of the output score file
+    use_json: If true, use the json-formatting of output.
+        Note this is a concatenation of JSON objects for each pose (one per line), rather than a full JSON object
+    use_job: If true, also include information in the JD2 Job object (normally not relevant for PyRosetta)
+
+    Example:
+    poses_to_scorefile(poses, "mydesigns.sc")
+
+    The decoy name written to your score file is take from pose.pdb_info().name()
+    To set a different decoy name, change it in your pose before calling this function.
+    Example:
+    pose.pdb_info().name("my_tag.pdb")
+    """
+
+    sfd = rosetta.core.io.raw_data.ScoreFileData(scorefile_name)
+
+    def output_scorefile(pose):
+        decoy_tag = pose.pdb_info().name()
+        # Most of this is cribbed from FileJobOutputter::scorefile() in src/protocols/jd2/FileJobOutputter.cc
+        score_map = rosetta.std.map_std_string_double()
+        string_map = rosetta.std.map_std_string_std_string()
+
+        rosetta.core.io.raw_data.ScoreMap.add_energies_data_from_scored_pose( pose, score_map )
+
+        if use_job:
+            # We do this first, in case the pose-specific data will overwrite it.
+            job_string_real = rosetta.protocols.jd2.get_string_real_pairs_from_current_job()
+            job_string_string = rosetta.protocols.jd2.get_string_string_pairs_from_current_job()
+            for key in job_string_real:
+                score_map[ key ] = job_string_real[ key ]
+            for key in job_string_string:
+                string_map[ key ] = job_string_string[ key ]
+
+        rosetta.core.io.raw_data.ScoreMap.add_arbitrary_score_data_from_pose( pose, score_map )
+        rosetta.core.io.raw_data.ScoreMap.add_arbitrary_string_data_from_pose( pose, string_map )
+
+        sfd.write_scorefile( decoy_tab, score_map, string_map, use_json )
+
+    if isinstance(poses, (list, tuple, set)):
+        for pose in poses:
+            output_scorefile(pose=pose)
+    else:
+        output_scorefile(pose=poses)
 
 def to_pdbstring(pose):
     """Convert to pdb-formatted string with score and energy data.

--- a/source/src/python/PyRosetta/src/test/T011_SaveIO.py
+++ b/source/src/python/PyRosetta/src/test/T011_SaveIO.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# :noTabs=true:
+# -*- coding: utf-8 -*-
+
+# (c) Copyright Rosetta Commons Member Institutions.
+# (c) This file is part of the Rosetta software suite and is made available under license.
+# (c) The Rosetta software is developed by the contributing members of the Rosetta Commons.
+# (c) For more information, see http://www.rosettacommons.org. Questions about this can be
+# (c) addressed to University of Washington CoMotion, email: license@uw.edu.
+
+## @file   T011_SavePDB.py
+## @brief  Tests for the saving functionality of PyRosetta
+## @author Rocco Moretti
+
+from __future__ import print_function
+
+import os
+import pyrosetta
+import pyrosetta.rosetta as rosetta
+import tempfile
+import unittest
+import json
+
+try:
+    import lzma as xz
+    _skip_xz = False
+except ImportError:
+    _skip_xz = True
+
+
+class SavePDBTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pyrosetta.init(extra_options = "-constant_seed")  # WARNING: option '-constant_seed' is for testing only! MAKE SURE TO REMOVE IT IN PRODUCTION RUNS!!!!!
+        print( pyrosetta.version() )
+        cls.pose1 = rosetta.core.import_pose.pose_from_file("../test/data/test_in.pdb")
+        cls.pose2 = pyrosetta.pose_from_sequence("ARNDCEQGHILKMFPSTWYV", 'fa_standard')
+        cls.scorefxn = rosetta.core.scoring.get_score_function()
+        cls.scorefxn(cls.pose1)
+        cls.scorefxn(cls.pose2)
+        cls.workdir = tempfile.TemporaryDirectory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.workdir.cleanup()
+
+    def test_save_silent(self):
+
+        silent_filename = os.path.join(self.workdir.name,"output.silent")
+
+        pyrosetta.poses_to_silent( [self.pose1, self.pose2], silent_filename )
+
+        self.assertTrue( os.path.exists(silent_filename) )
+
+        num_score = 0
+        num_annotated = 0
+        with open(silent_filename) as f:
+            for line in f:
+                if line.startswith("SCORE:"):
+                    num_score += 1
+                elif line.startswith("ANNOTATED_SEQUENCE"):
+                    num_annotated += 1
+                # Other checks?
+
+        self.assertEqual(num_score, 3) # plus the header
+        self.assertEqual(num_annotated, 2)
+
+    def test_rountrip_silent(self):
+        silent_filename = os.path.join(self.workdir.name,"roundtrip.silent")
+
+        pyrosetta.poses_to_silent( [self.pose1, self.pose2], silent_filename )
+
+        self.assertTrue( os.path.exists(silent_filename) )
+
+        poses = list( pyrosetta.poses_from_silent(silent_filename) )
+
+        self.assertEquals(len(poses), 2 )
+        self.assertEquals(poses[0].size(), self.pose1.size())
+        self.assertEquals(poses[1].size(), self.pose2.size())
+        self.assertEquals(poses[0].annotated_sequence(), self.pose1.annotated_sequence())
+        self.assertEquals(poses[1].annotated_sequence(), self.pose2.annotated_sequence())
+
+    def test_scorefile(self):
+        scorefile_name = os.path.join(self.workdir.name,"scorefile.sc")
+
+        pyrosetta.poses_to_scorefile( [self.pose2, self.pose1], scorefile_name ) )
+
+        self.assertTrue( os.path.exists(scorefile_name) )
+
+        lengths = []
+        n_score = 0
+        with open(scorefile_name) as f:
+            for line in f:
+                lengths.append( len(line.split()) )
+                if line.startswith("SCORE:"):
+                    n_score += 1
+
+        self.assertEqual(n_score, 3) # plus the header
+        self.assertTrue( len(lengths) <= n_score+1 ) # Allow for spurious "SEQUENCE" line
+        lenghts = lengths[-n_score:]
+        self.assertEqual( min(lenghts), max(lengths) )
+
+    def test_json_scorefile(self):
+        scorefile_name = os.path.join(self.workdir.name,"scorefile.sc")
+
+        pose_clone = self.pose1.clone()
+        pyrosetta.rosetta.core.pose.setPoseExraScore(pose_clone, "extra_real", 3.14159 )
+        pyrosetta.rosetta.core.pose.setPoseExraScore(pose_clone, "extra_string", "TAG_VALUE" )
+
+        pyrosetta.poses_to_scorefile( pose_clone, scorefile_name )
+        pyrosetta.poses_to_scorefile( [self.pose2, self.pose1], scorefile_name ), use_json=True )
+
+        self.assertTrue( os.path.exists(scorefile_name) )
+
+        with open(scorefile_name) as f:
+            lines = f.readlines()
+
+        self.assertEqual(len(lines),3)
+
+        has_extra_real = 0
+        has_extra_string = 0
+        for line in lines:
+            try:
+                scores = json.loads(line)
+            except:
+                self.assertTrue(False)
+                continue
+
+            self.assertTrue( scores.has("total_score") )
+            if scores.has("extra_real"):
+                has_extra_real += 1
+            if scores.has("extra_string"):
+                has_extra_string += 1
+
+        self.assertEqual(has_extra_real,1)
+        self.assertEqual(has_extra_string,1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/src/python/PyRosetta/src/test/T011_SaveIO.py
+++ b/source/src/python/PyRosetta/src/test/T011_SaveIO.py
@@ -135,5 +135,16 @@ class SavePDBTest(unittest.TestCase):
         self.assertEqual(has_extra_real,1)
         self.assertEqual(has_extra_string,1)
 
+    def test_get_scorefile_info(self):
+        pose_clone = self.pose1.clone()
+        pyrosetta.rosetta.core.pose.setPoseExraScore(pose_clone, "extra_real", 3.14159 )
+        pyrosetta.rosetta.core.pose.setPoseExraScore(pose_clone, "extra_string", "TAG_VALUE" )
+
+        info = pyrosetta.io.get_scorefile_info(pose_clone)
+
+        self.assertTrue( info.has("total_score") )
+        self.assertAlmoseEqual( info["extra_real"], 3.14159 )
+        self.assertEqual( info["extra_string"], "TAG_VALUE" )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
At the recent Bootcamp, several people (namely @LouisaMe09 and @zyajahuggan) expressed interest in the ability to create scorefile info from PyRosetta. Add a convenience function which allows easy creation of JD2-like scorefiles through the PyRosetta interface. (`pyrosetta.poses_to_scorefile()`)

I've also added a function (`pyrosetta.io.get_scorefile_info()`) which gets what would be reported to the scorefile as a Python dictionary.

Additionally, this PR also cleans up some of the scorefile writing interface at the C++ level.