### PR TITLE
Fix memory leak in SimulateMPI: use unique_ptr for simulation_ ownership

### DIFF
--- a/source/src/utility/SimulateMPI.cc
+++ b/source/src/utility/SimulateMPI.cc
@@ -112,7 +112,7 @@ void SimulateMPIMessage::set_doubles_msg( utility::vector1< double > const & set
 }
 
 // initialize private static data
-SimulateMPIData * SimulateMPI::simulation_( nullptr );
+std::unique_ptr< SimulateMPIData > SimulateMPI::simulation_;
 int SimulateMPI::rank_( 0 );
 
 SimulateMPIData::SimulateMPIData( platform::Size nprocs ) :
@@ -236,13 +236,13 @@ void SimulateMPIData::clear_processed_msgs( MsgQueue & message_queue )
 
 void
 SimulateMPI::initialize_simulation( int nprocs ) {
-	simulation_ = new SimulateMPIData( nprocs );
+	simulation_.reset( new SimulateMPIData( nprocs ) );
 	rank_ = 0;
 }
 
 bool
 SimulateMPI::simulate_mpi() {
-	return simulation_;
+	return simulation_ != nullptr;
 }
 
 

--- a/source/src/utility/SimulateMPI.hh
+++ b/source/src/utility/SimulateMPI.hh
@@ -30,6 +30,7 @@
 
 // C++ headers
 #include <list>
+#include <memory>
 #include <string>
 
 namespace utility {
@@ -277,7 +278,7 @@ public:
 
 private:
 
-	static SimulateMPIData * simulation_;
+	static std::unique_ptr< SimulateMPIData > simulation_;
 	static int rank_;
 
 };


### PR DESCRIPTION
## Summary

- `initialize_simulation()` unconditionally assigned `new SimulateMPIData*` without deleting any previous allocation, leaking memory on re-initialization
- `simulation_` was a raw owning static pointer with no cleanup path
- Fixed by switching `simulation_` from `SimulateMPIData*` to `std::unique_ptr<SimulateMPIData>`, so `reset()` frees the old object on re-initialization and the static is properly cleaned up at program exit

## Test plan

- [ ] Build `utility` library in debug mode: `cd source && ./scons.py -j16 mode=debug utility`
- [ ] Run utility unit tests: `cd source && python test/run.py -j16 --mode=debug`