### PR TITLE
Refactor pimpl pointers in XMLSchemaComplexTypeGenerator and XMLValidator to unique_ptr

### DIFF
--- a/source/src/utility/tag/XMLSchemaGeneration.cc
+++ b/source/src/utility/tag/XMLSchemaGeneration.cc
@@ -2051,7 +2051,7 @@ XMLSchemaParticleOP XMLSchemaComplexTypeGeneratorImpl::create_subelement(
 }
 
 XMLSchemaComplexTypeGenerator::XMLSchemaComplexTypeGenerator() : pimpl_( new XMLSchemaComplexTypeGeneratorImpl ) {}
-XMLSchemaComplexTypeGenerator::~XMLSchemaComplexTypeGenerator() { delete pimpl_; }
+XMLSchemaComplexTypeGenerator::~XMLSchemaComplexTypeGenerator() = default;
 //XMLSchemaComplexTypeGenerator::XMLSchemaComplexTypeGenerator( XMLSchemaComplexTypeGenerator const & src ) :
 // pimpl_( new XMLSchemaComplexTypeGeneratorImpl( *src.pimpl_ ))
 //{

--- a/source/src/utility/tag/XMLSchemaGeneration.hh
+++ b/source/src/utility/tag/XMLSchemaGeneration.hh
@@ -117,6 +117,7 @@
 
 // Boost headers
 #include <functional>
+#include <memory>
 
 // LibXML includes
 
@@ -969,7 +970,7 @@ public:
 
 
 private:
-	class XMLSchemaComplexTypeGeneratorImpl * pimpl_;
+	std::unique_ptr< class XMLSchemaComplexTypeGeneratorImpl > pimpl_;
 
 };
 

--- a/source/src/utility/tag/XMLSchemaValidation.cc
+++ b/source/src/utility/tag/XMLSchemaValidation.cc
@@ -425,7 +425,7 @@ private:
 
 
 XMLValidator::XMLValidator() : pimpl_( new XMLValidatorImpl() ) {}
-XMLValidator::~XMLValidator() { delete pimpl_; }
+XMLValidator::~XMLValidator() = default;
 
 bool
 XMLValidator::schema_has_been_set() const

--- a/source/src/utility/tag/XMLSchemaValidation.hh
+++ b/source/src/utility/tag/XMLSchemaValidation.hh
@@ -28,6 +28,7 @@
 
 // C++ headers
 #include <list>
+#include <memory>
 #include <string>
 //#include <vector>
 //#include <map>
@@ -84,7 +85,7 @@ private:
 	XMLValidator( XMLValidator const & ) = delete;
 	XMLValidator & operator = ( XMLValidator const & rhs ) = delete;
 
-	class XMLValidatorImpl * pimpl_;
+	std::unique_ptr< class XMLValidatorImpl > pimpl_;
 };
 
 class XMLValidationOutput


### PR DESCRIPTION
## Summary

- Replace raw `class Impl*` pimpl members with `std::unique_ptr<class Impl>` in `XMLSchemaComplexTypeGenerator` and `XMLValidator`
- Destructors changed from `{ delete pimpl_; }` to `= default`, letting the compiler generate correct cleanup
- Added `#include <memory>` to both headers

## Motivation

Both classes already correctly suppressed copy/move with `= delete`, so there was no double-free risk. This refactor makes ownership explicit in the type system and eliminates manual `delete` calls, following the Rule of Zero pattern for pimpl idiom.

## Testing

Full debug build succeeds. No behavior change — pure ownership semantics refactor.