### PR TITLE
Refactor Svm_rosetta raw pointer to unique_ptr with custom deleter

### DIFF
--- a/source/src/utility/libsvm/Svm_rosetta.cc
+++ b/source/src/utility/libsvm/Svm_rosetta.cc
@@ -30,21 +30,19 @@ Svm_node_rosetta::Svm_node_rosetta(platform::Size index, platform::Real value){
 	value_ = value;
 }
 
-Svm_node_rosetta::~Svm_node_rosetta()= default;
+void SvmModelDeleter::operator()(svm_model* model) const {
+	svm_free_model_content( model );
+	free( model );
+}
 
-
-Svm_rosetta::Svm_rosetta(string const & model_filename){
-	svm_model_ = svm_load_model(model_filename.c_str());
+Svm_rosetta::Svm_rosetta(string const & model_filename) :
+	svm_model_( svm_load_model(model_filename.c_str()) )
+{
 	runtime_assert_string_msg( svm_model_, "Error in constructor for Svm_rosetta class: Could not read file \"" + model_filename + "\"." );
 }
 
-Svm_rosetta::~Svm_rosetta(){
-	svm_free_model_content( svm_model_ );
-	free( svm_model_ );
-}
-
 platform::Size Svm_rosetta::get_nr_class() const {
-	return((platform::Size)svm_get_nr_class(svm_model_));
+	return((platform::Size)svm_get_nr_class(svm_model_.get()));
 }
 
 vector1 < platform::Real > Svm_rosetta::predict_probability(vector1 <Svm_node_rosettaOP> const & features) const {
@@ -56,10 +54,10 @@ vector1 < platform::Real > Svm_rosetta::predict_probability(vector1 <Svm_node_ro
 		x[ii-1].value = (double)features[ii]->value();
 	}
 	x[features.size()].index = -1;
-	int nr_class = svm_get_nr_class(svm_model_);
+	int nr_class = svm_get_nr_class(svm_model_.get());
 	//double *prob_estimates = (double *) malloc(nr_class*sizeof(double));
 	auto *prob_estimates = new double[nr_class];
-	/*double predict_label =*/ svm_predict_probability(svm_model_,x,prob_estimates);
+	/*double predict_label =*/ svm_predict_probability(svm_model_.get(),x,prob_estimates);
 	vector1 <platform::Real> probs_to_return;
 	for ( int ii=0; ii<nr_class; ++ii ) {
 		probs_to_return.push_back(prob_estimates[ii]);
@@ -79,7 +77,7 @@ platform::Real Svm_rosetta::predict( vector1 <Svm_node_rosettaOP> const & featur
 		x[ii-1].value = (double)features[ii]->value();
 	}
 	x[features.size()].index = -1;
-	platform::Real predict_value( svm_predict(svm_model_,x) );
+	platform::Real predict_value( svm_predict(svm_model_.get(),x) );
 	delete[] x;
 	return(predict_value);
 }

--- a/source/src/utility/libsvm/Svm_rosetta.hh
+++ b/source/src/utility/libsvm/Svm_rosetta.hh
@@ -22,6 +22,7 @@
 // type headers
 #include <platform/types.hh>
 // aaaa WinPyRosetta
+#include <memory>
 #include <string>
 
 struct svm_model; // Forward declaration
@@ -29,10 +30,13 @@ struct svm_model; // Forward declaration
 namespace utility {
 namespace libsvm {
 
+struct SvmModelDeleter {
+	void operator()(svm_model* model) const;
+};
+
 class Svm_node_rosetta: public utility::VirtualBase {
 public:
 	Svm_node_rosetta(platform::Size index, platform::Real value);
-	~Svm_node_rosetta() override;
 	void set_index(platform::Size index){
 		index_ = index;
 	};
@@ -54,12 +58,13 @@ private:
 class Svm_rosetta: public utility::VirtualBase {
 public:
 	Svm_rosetta(std::string const & model_filename);
-	~Svm_rosetta() override;
+	Svm_rosetta(Svm_rosetta const &) = delete;
+	Svm_rosetta & operator=(Svm_rosetta const &) = delete;
 	platform::Size get_nr_class() const;
 	utility::vector1< platform::Real > predict_probability(utility::vector1< Svm_node_rosettaOP > const  & features) const;
 	platform::Real predict( utility::vector1< Svm_node_rosettaOP > const & features) const;
 private:
-	svm_model *svm_model_;
+	std::unique_ptr<svm_model, SvmModelDeleter> svm_model_;
 };
 }//libsvm
 }//utility


### PR DESCRIPTION
## Summary
- `Svm_rosetta` held a raw `svm_model*` and defined a custom destructor but no copy constructor/assignment, making the compiler-generated copies unsafe (double-free on destruction)
- Replace `svm_model*` with `std::unique_ptr<svm_model, SvmModelDeleter>` where `SvmModelDeleter` calls `svm_free_model_content` + `free`
- Explicitly delete copy constructor and copy assignment on `Svm_rosetta`
- Remove the unnecessary `= default` destructor from `Svm_node_rosetta` (no resources to manage)

## Test plan
- [x] `utility/libsvm` compiles cleanly in debug mode
- [x] Full debug build passes with no errors or warnings