### PR TITLE
Refactor VariantKey and VariantOption raw pointers to unique_ptr

### DIFF
--- a/source/src/utility/keys/VariantKey.hh
+++ b/source/src/utility/keys/VariantKey.hh
@@ -64,11 +64,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Move constructor
-	inline
-	VariantKey( VariantKey && ) = default;
-
-
 	/// @brief Key constructor
 	inline
 	VariantKey( Key const & key_a ) :
@@ -89,12 +84,6 @@ public: // Assignment
 		}
 		return *this;
 	}
-
-
-	/// @brief Move assignment
-	inline
-	VariantKey &
-	operator =( VariantKey && ) = default;
 
 
 public: // Conversion

--- a/source/src/utility/keys/VariantKey.hh
+++ b/source/src/utility/keys/VariantKey.hh
@@ -21,6 +21,7 @@
 
 // C++ headers
 #include <utility/assert.hh>
+#include <memory>
 #include <string>
 
 
@@ -52,7 +53,7 @@ public: // Creation
 	/// @brief Default constructor
 	inline
 	VariantKey() :
-		key_p_( 0 )
+		key_p_()
 	{}
 
 
@@ -63,19 +64,16 @@ public: // Creation
 	{}
 
 
+	/// @brief Move constructor
+	inline
+	VariantKey( VariantKey && ) = default;
+
+
 	/// @brief Key constructor
 	inline
 	VariantKey( Key const & key_a ) :
 		key_p_( key_a.clone() )
 	{}
-
-
-	/// @brief Destructor
-	inline
-	~VariantKey() throw() // throw() needed for ICC
-	{
-		delete key_p_;
-	}
 
 
 public: // Assignment
@@ -87,10 +85,16 @@ public: // Assignment
 	operator =( VariantKey const & var )
 	{
 		if ( this != &var ) {
-			delete key_p_; key_p_ = ( var.key_p_ ? var.key_p_->clone() : 0 );
+			key_p_.reset( var.key_p_ ? var.key_p_->clone() : nullptr );
 		}
 		return *this;
 	}
+
+
+	/// @brief Move assignment
+	inline
+	VariantKey &
+	operator =( VariantKey && ) = default;
 
 
 public: // Conversion
@@ -292,7 +296,7 @@ private: // Fields
 
 
 	/// @brief Pointer to key
-	Key * key_p_;
+	std::unique_ptr< Key > key_p_;
 
 
 }; // VariantKey

--- a/source/src/utility/options/VariantOption.hh
+++ b/source/src/utility/options/VariantOption.hh
@@ -67,11 +67,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Move constructor
-	inline
-	VariantOption( VariantOption && ) = default;
-
-
 	/// @brief Option constructor
 	inline
 	VariantOption( Option const & option_a ) :
@@ -92,12 +87,6 @@ public: // Assignment
 		}
 		return *this;
 	}
-
-
-	/// @brief Move assignment
-	inline
-	VariantOption &
-	operator =( VariantOption && ) = default;
 
 
 public: // Conversion

--- a/source/src/utility/options/VariantOption.hh
+++ b/source/src/utility/options/VariantOption.hh
@@ -22,6 +22,7 @@
 
 // C++ headers
 #include <cstddef>
+#include <memory>
 #include <string>
 
 
@@ -55,7 +56,7 @@ public: // Creation
 	/// @brief Default constructor
 	inline
 	VariantOption() :
-		option_p_( 0 )
+		option_p_()
 	{}
 
 
@@ -66,19 +67,16 @@ public: // Creation
 	{}
 
 
+	/// @brief Move constructor
+	inline
+	VariantOption( VariantOption && ) = default;
+
+
 	/// @brief Option constructor
 	inline
 	VariantOption( Option const & option_a ) :
 		option_p_( option_a.clone() )
 	{}
-
-
-	/// @brief Destructor
-	inline
-	~VariantOption() throw() // throw() is needed for ICC
-	{
-		delete option_p_;
-	}
 
 
 public: // Assignment
@@ -90,10 +88,16 @@ public: // Assignment
 	operator =( VariantOption const & var )
 	{
 		if ( this != &var ) {
-			delete option_p_; option_p_ = ( var.option_p_ ? var.option_p_->clone() : nullptr );
+			option_p_.reset( var.option_p_ ? var.option_p_->clone() : nullptr );
 		}
 		return *this;
 	}
+
+
+	/// @brief Move assignment
+	inline
+	VariantOption &
+	operator =( VariantOption && ) = default;
 
 
 public: // Conversion
@@ -121,7 +125,7 @@ public: // Conversion
 	operator Option const *() const
 	{
 		runtime_assert( option_p_ );
-		return option_p_;
+		return option_p_.get();
 	}
 
 
@@ -130,7 +134,7 @@ public: // Conversion
 	operator Option *()
 	{
 		runtime_assert( option_p_ );
-		return option_p_;
+		return option_p_.get();
 	}
 
 
@@ -343,7 +347,7 @@ private: // Fields
 
 
 	/// @brief Pointer to option
-	Option * option_p_;
+	std::unique_ptr< Option > option_p_;
 
 
 }; // VariantOption


### PR DESCRIPTION
## Summary
- `VariantKey<K>` and `VariantOption<O>` each held a raw owning pointer with a manually-defined copy-constructor, copy-assignment, and destructor, but were missing move-constructor and move-assignment (Rule of Five violation)
- Replace `K* key_p_` / `O* option_p_` with `std::unique_ptr<K>` / `std::unique_ptr<O>`
- Add `= default` move-constructor and move-assignment, giving correct move semantics for free
- Remove the manual destructors; `unique_ptr` handles cleanup
- Preserve deep-copy semantics in copy-constructor and copy-assignment using `unique_ptr::reset()` with the existing `clone()` pattern
- Update pointer-conversion operators in `VariantOption` to use `.get()`

## Test plan
- [x] `utility/options/keys/OptionKeyList.cc` and `protocols/jd3/standard/StandardJobQueen.cc` compile cleanly (syntax check)
- [x] Full debug build passes with no errors