### PR TITLE
Explicitly delete copy constructor and assignment in Timer

### DIFF
--- a/source/src/basic/gpu/Timer.hh
+++ b/source/src/basic/gpu/Timer.hh
@@ -39,6 +39,8 @@ public:
 	Timer();
 	~Timer();
 
+	// ~Timer() calls Report(), so a copy would fire a second Report() on its
+	// own destruction, silently logging a duplicate timing entry.
 	Timer(Timer const &) = delete;
 	Timer & operator=(Timer const &) = delete;
 	void Report(const char *tag =nullptr);

--- a/source/src/basic/gpu/Timer.hh
+++ b/source/src/basic/gpu/Timer.hh
@@ -38,6 +38,9 @@ public:
 	Timer(basic::Tracer::TracerProxy& t, const char *tag =nullptr);
 	Timer();
 	~Timer();
+
+	Timer(Timer const &) = delete;
+	Timer & operator=(Timer const &) = delete;
 	void Report(const char *tag =nullptr);
 	void Reset();
 	double GetTime();


### PR DESCRIPTION
## Summary
`Timer::~Timer()` calls `Report()`, logging the elapsed time to a tracer or stdout. With no explicit copy policy, a copied `Timer` would produce a second `Report()` on its own destruction — silently logging a duplicate timing entry for the same measured interval.

`tag_` and `t_` are non-owning pointers (no `delete` in the destructor), so there is no memory-safety risk. The issue is purely semantic, but it is a real hazard for callers who pass or store `Timer` by value.

Explicitly `= delete` the copy constructor and copy assignment to make the non-copyable intent clear.

## Test plan
- [x] `basic/gpu` builds cleanly in debug mode
- [x] Full debug build passes with no errors