### PR TITLE
Hotfix of T919 and T920 tests for ubuntu.clang.cxx11thread.serialization.python38.PyRosetta.unit test

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
@@ -105,7 +105,7 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
     def get_random_options():
         return TestReproducibilityRemodelTaskUpdates.get_remodel_options()
 
-    def reproduce_remodel_task_updates(self, norm_task_options=False, with_init_file=False, verbose=True):
+    def reproduce_remodel_task_updates(self, norm_task_options=False, with_init_file=False, verbose=False):
         """
         Test for PyRosettaCluster decoy reproducibility with updated task dictionaries
         using RosettaRemodel per user-provided PyRosetta protocol.
@@ -270,30 +270,6 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
                 protocol_seeds=protocol_seeds,
                 protocol_random_states=protocol_random_states,
             )
-
-            hash_data = []
-            pose = packed_pose.pose
-            for res in range(1, pose.size() + 1):
-                residue = pose.residue(res)
-                # Add residue number
-                hash_data.append(res)
-                # Add residue name
-                hash_data.append(residue.name())
-                for atom in range(1, residue.natoms() + 1):
-                    # Add atom number
-                    hash_data.append(atom)
-                    # Add atom name
-                    hash_data.append(residue.atom_name(atom))
-                    # Add atom coordinate components
-                    xyz = residue.atom(atom).xyz()
-                    for axis in "xyz":
-                        hash_data.append(getattr(xyz, axis))
-            if verbose:
-                print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
-                digest = packed_pose.pose.cache["protocol_pose_hash"][protocol_number]
-                print(f"Protocol number {protocol_number} Pose digest:\n{digest}\n")
-                print(f"Protocol number {protocol_number} Pose hash:\n{hash(digest)}\n")
-
             # Maybe print
             if verbose:
                 print(f"PyRosetta protocol number {protocol_number} Pose.cache:", packed_pose.pose.cache, flush=True)

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
@@ -104,7 +104,7 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
     def get_random_options():
         return TestReproducibilityRemodelTaskUpdates.get_remodel_options()
 
-    def reproduce_remodel_task_updates(self, norm_task_options=False, with_init_file=False, verbose=False):
+    def reproduce_remodel_task_updates(self, norm_task_options=False, with_init_file=False, verbose=True):
         """
         Test for PyRosettaCluster decoy reproducibility with updated task dictionaries
         using RosettaRemodel per user-provided PyRosetta protocol.
@@ -269,6 +269,28 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
                 protocol_seeds=protocol_seeds,
                 protocol_random_states=protocol_random_states,
             )
+
+            hash_data = []
+            pose = packed_pose.pose
+            for res in range(1, pose.size() + 1):
+                residue = pose.residue(res)
+                # Add residue number
+                hash_data.append(res)
+                # Add residue name
+                hash_data.append(residue.name())
+                for atom in range(1, residue.natoms() + 1):
+                    # Add atom number
+                    hash_data.append(atom)
+                    # Add atom name
+                    hash_data.append(residue.atom_name(atom))
+                    # Add atom coordinate components
+                    xyz = residue.atom(atom).xyz()
+                    for axis in "xyz":
+                        hash_data.append(getattr(xyz, axis))
+            if verbose:
+                print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
+                print(f"Protocol number {protocol_number} PDB string:\n{io.to_pdbstring(pose)}\n")
+
             # Maybe print
             if verbose:
                 print(f"PyRosetta protocol number {protocol_number} Pose.cache:", packed_pose.pose.cache, flush=True)

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_remodel_task_updates.py
@@ -11,6 +11,7 @@ PyRosettaCluster reproducibility unit test suite using the `unittest` framework.
 __author__ = "Jason C. Klima"
 
 import glob
+import hashlib
 import itertools
 import os
 import pyrosetta
@@ -252,11 +253,11 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
             protocol_total_scores[protocol_number] = scorefxn(packed_pose.pose)
             protocol_n_res[protocol_number] = packed_pose.pose.size()
             protocol_sequence[protocol_number] = packed_pose.pose.sequence()
-            protocol_pose_hash[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=False, include_comments=False).digest())
-            protocol_pose_hash_cache[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=True, include_comments=False).digest())
-            protocol_pose_hash_cache_comments[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=True, include_comments=True).digest())
+            protocol_pose_hash[protocol_number] = PackedPoseHasher(packed_pose, include_cache=False, include_comments=False).digest()
+            protocol_pose_hash_cache[protocol_number] = PackedPoseHasher(packed_pose, include_cache=True, include_comments=False).digest()
+            protocol_pose_hash_cache_comments[protocol_number] = PackedPoseHasher(packed_pose, include_cache=True, include_comments=True).digest()
             protocol_seeds[protocol_number] = pyrosetta.rosetta.numeric.random.rg().get_seed()
-            protocol_random_states[protocol_number] = hash(str(random.getstate()))
+            protocol_random_states[protocol_number] = hashlib.sha256(str(random.getstate()).encode("utf-8")).hexdigest()
             # Update scores
             packed_pose = packed_pose.update_scores(
                 protocol_scorefxn_names=protocol_scorefxn_names,
@@ -289,7 +290,9 @@ class TestReproducibilityRemodelTaskUpdates(unittest.TestCase):
                         hash_data.append(getattr(xyz, axis))
             if verbose:
                 print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
-                print(f"Protocol number {protocol_number} PDB string:\n{io.to_pdbstring(pose)}\n")
+                digest = packed_pose.pose.cache["protocol_pose_hash"][protocol_number]
+                print(f"Protocol number {protocol_number} Pose digest:\n{digest}\n")
+                print(f"Protocol number {protocol_number} Pose hash:\n{hash(digest)}\n")
 
             # Maybe print
             if verbose:

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
@@ -11,6 +11,7 @@ PyRosettaCluster reproducibility unit test suite using the `unittest` framework.
 __author__ = "Jason C. Klima"
 
 import glob
+import hashlib
 import itertools
 import os
 import pyrosetta
@@ -134,11 +135,11 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
             protocol_total_scores[protocol_number] = scorefxn(packed_pose.pose)
             protocol_n_res[protocol_number] = packed_pose.pose.size()
             protocol_sequence[protocol_number] = packed_pose.pose.sequence()
-            protocol_pose_hash[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=False, include_comments=False).digest())
-            protocol_pose_hash_cache[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=True, include_comments=False).digest())
-            protocol_pose_hash_cache_comments[protocol_number] = hash(PackedPoseHasher(packed_pose, include_cache=True, include_comments=True).digest())
+            protocol_pose_hash[protocol_number] = PackedPoseHasher(packed_pose, include_cache=False, include_comments=False).digest()
+            protocol_pose_hash_cache[protocol_number] = PackedPoseHasher(packed_pose, include_cache=True, include_comments=False).digest()
+            protocol_pose_hash_cache_comments[protocol_number] = PackedPoseHasher(packed_pose, include_cache=True, include_comments=True).digest()
             protocol_seeds[protocol_number] = pyrosetta.rosetta.numeric.random.rg().get_seed()
-            protocol_random_states[protocol_number] = hash(str(random.getstate()))
+            protocol_random_states[protocol_number] = hashlib.sha256(str(random.getstate()).encode("utf-8")).hexdigest()
             # Update scores
             packed_pose = packed_pose.update_scores(
                 protocol_scorefxn_names=protocol_scorefxn_names,
@@ -171,7 +172,9 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
                         hash_data.append(getattr(xyz, axis))
             if verbose:
                 print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
-                print(f"Protocol number {protocol_number} PDB string:\n{io.to_pdbstring(pose)}\n")
+                digest = packed_pose.pose.cache["protocol_pose_hash"][protocol_number]
+                print(f"Protocol number {protocol_number} Pose digest:\n{digest}\n")
+                print(f"Protocol number {protocol_number} Pose hash:\n{hash(digest)}\n")
 
             # Maybe update task dictionary for next PyRosetta protocol, which gets validated and kept
             if protocol_number + 1 < len(kwargs["protocol_options"]):

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
@@ -54,7 +54,7 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
         self.tmpdir.cleanup()
         sys.stdout.flush()
 
-    def reproduce_task_updates(self, norm_task_options=False, with_init_file=False, verbose=False):
+    def reproduce_task_updates(self, norm_task_options=False, with_init_file=False, verbose=True):
         """
         Test for PyRosettaCluster decoy reproducibility with updated task dictionaries
         per user-provided PyRosetta protocol.
@@ -151,6 +151,28 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
                 protocol_seeds=protocol_seeds,
                 protocol_random_states=protocol_random_states,
             )
+
+            hash_data = []
+            pose = packed_pose.pose
+            for res in range(1, pose.size() + 1):
+                residue = pose.residue(res)
+                # Add residue number
+                hash_data.append(res)
+                # Add residue name
+                hash_data.append(residue.name())
+                for atom in range(1, residue.natoms() + 1):
+                    # Add atom number
+                    hash_data.append(atom)
+                    # Add atom name
+                    hash_data.append(residue.atom_name(atom))
+                    # Add atom coordinate components
+                    xyz = residue.atom(atom).xyz()
+                    for axis in "xyz":
+                        hash_data.append(getattr(xyz, axis))
+            if verbose:
+                print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
+                print(f"Protocol number {protocol_number} PDB string:\n{io.to_pdbstring(pose)}\n")
+
             # Maybe update task dictionary for next PyRosetta protocol, which gets validated and kept
             if protocol_number + 1 < len(kwargs["protocol_options"]):
                 kwargs["options"] = ""

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_reproducibility_task_updates.py
@@ -55,7 +55,7 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
         self.tmpdir.cleanup()
         sys.stdout.flush()
 
-    def reproduce_task_updates(self, norm_task_options=False, with_init_file=False, verbose=True):
+    def reproduce_task_updates(self, norm_task_options=False, with_init_file=False, verbose=False):
         """
         Test for PyRosettaCluster decoy reproducibility with updated task dictionaries
         per user-provided PyRosetta protocol.
@@ -152,30 +152,6 @@ class TestReproducibilityTaskUpdates(unittest.TestCase):
                 protocol_seeds=protocol_seeds,
                 protocol_random_states=protocol_random_states,
             )
-
-            hash_data = []
-            pose = packed_pose.pose
-            for res in range(1, pose.size() + 1):
-                residue = pose.residue(res)
-                # Add residue number
-                hash_data.append(res)
-                # Add residue name
-                hash_data.append(residue.name())
-                for atom in range(1, residue.natoms() + 1):
-                    # Add atom number
-                    hash_data.append(atom)
-                    # Add atom name
-                    hash_data.append(residue.atom_name(atom))
-                    # Add atom coordinate components
-                    xyz = residue.atom(atom).xyz()
-                    for axis in "xyz":
-                        hash_data.append(getattr(xyz, axis))
-            if verbose:
-                print(f"Protocol number {protocol_number} Pose hash data:\n{hash_data}\n")
-                digest = packed_pose.pose.cache["protocol_pose_hash"][protocol_number]
-                print(f"Protocol number {protocol_number} Pose digest:\n{digest}\n")
-                print(f"Protocol number {protocol_number} Pose hash:\n{hash(digest)}\n")
-
             # Maybe update task dictionary for next PyRosetta protocol, which gets validated and kept
             if protocol_number + 1 < len(kwargs["protocol_options"]):
                 kwargs["options"] = ""


### PR DESCRIPTION
This PR removes a few built-in `hash()` function calls from the `T919` and `T920` unit tests, which are non-deterministic in Python-3.8.