### PR TITLE
Refactor ozstream raw pointers to unique_ptr; modernize orstream copy ops

### DIFF
--- a/source/src/utility/io/orstream.hh
+++ b/source/src/utility/io/orstream.hh
@@ -58,19 +58,10 @@ protected: // Creation
 	= default;
 
 
-private: // Creation
+public: // Creation (deleted)
 
-
-	/// @brief Copy constructor: Undefined
-	orstream( orstream const & );
-
-
-private: // Methods: assignment
-
-
-	/// @brief Copy assignment: Undefined
-	orstream &
-	operator =( orstream const & );
+	orstream( orstream const & ) = delete;
+	orstream & operator =( orstream const & ) = delete;
 
 
 public: // Methods: conversion

--- a/source/src/utility/io/ozstream.cc
+++ b/source/src/utility/io/ozstream.cc
@@ -40,8 +40,8 @@ ozstream::open_append_if_existed( std::string const& filename_a, std::stringstre
 #ifdef USEMPI
 		//		std::cout << "MPI_Reroute " << (bMPI_reroute_stream_ ? " active " : " not-active ") << std::endl;
 	if ( bMPI_reroute_stream_ ) { // this is switched via call to static function enable_MPI_reroute()
-		mpi_stream_p_ = new mpi_stream::mpi_ostream( filename_a, mpi_FileBuf_master_rank_, preprinted_header, true );
-		if ( ( !mpi_stream_p_ ) || ( !( *mpi_stream_p_ ) ) ) {
+		mpi_stream_p_.reset( new mpi_stream::mpi_ostream( filename_a, mpi_FileBuf_master_rank_, preprinted_header, true ) );
+		if ( !( *mpi_stream_p_ ) ) {
 			compression_ = NONE;
 		} else 	compression_ = UNCOMPRESSED;
 		return;
@@ -94,8 +94,8 @@ ozstream::open(
 		//		std::cout << "MPI_Reroute " << (bMPI_reroute_stream_ ? " active " : " not-active ") << std::endl;
 		if ( bMPI_reroute_stream_ ) {
 			std::stringstream no_header;
-			mpi_stream_p_ = new mpi_stream::mpi_ostream( filename_, mpi_FileBuf_master_rank_, no_header, open_mode & ios::app );
-			if ( ( !mpi_stream_p_ ) || ( !( *mpi_stream_p_ ) ) ) {
+			mpi_stream_p_.reset( new mpi_stream::mpi_ostream( filename_, mpi_FileBuf_master_rank_, no_header, open_mode & ios::app ) );
+			if ( !( *mpi_stream_p_ ) ) {
 				compression_ = NONE;
 			} else {
 				compression_ = UNCOMPRESSED;
@@ -139,12 +139,10 @@ ozstream::open(
 
 	// Attach zip_ostream to ofstream if gzip file
 	if ( compression_ == GZIP ) {
-		// zip_stream_p_ deleted by close() above so don't have to here
-		zip_stream_p_ = new zip_ostream( of_stream_, true, static_cast< size_t >( Z_DEFAULT_COMPRESSION ), zlib_stream::DefaultStrategy, 15, 8, buffer_size_ );
-		if ( ( !zip_stream_p_ ) || ( !( *zip_stream_p_ ) ) ||
-				( !zip_stream_p_->is_gzip() ) ) { // zip_stream not in good state
-			if ( zip_stream_p_ ) delete zip_stream_p_;
-			zip_stream_p_ = nullptr;
+		// zip_stream_p_ cleared by close() above so don't have to here
+		zip_stream_p_.reset( new zip_ostream( of_stream_, true, static_cast< size_t >( Z_DEFAULT_COMPRESSION ), zlib_stream::DefaultStrategy, 15, 8, buffer_size_ ) );
+		if ( !( *zip_stream_p_ ) || !zip_stream_p_->is_gzip() ) { // zip_stream not in good state
+			zip_stream_p_.reset();
 			of_stream_.close();
 			// Set failbit so failure can be detected
 			of_stream_.setstate( ios_base::failbit );
@@ -175,8 +173,8 @@ ozstream::open_append( std::string const & filename_a )
 		//		std::cout << "MPI_Reroute " << (bMPI_reroute_stream_ ? " active " : " not-active ") << std::endl;
 		if ( bMPI_reroute_stream_ ) {
 			std::stringstream no_header;
-			mpi_stream_p_ = new mpi_stream::mpi_ostream( filename_, mpi_FileBuf_master_rank_, no_header, true );
-			if ( ( !mpi_stream_p_ ) || ( !( *mpi_stream_p_ ) ) ) {
+			mpi_stream_p_.reset( new mpi_stream::mpi_ostream( filename_, mpi_FileBuf_master_rank_, no_header, true ) );
+			if ( !( *mpi_stream_p_ ) ) {
 				compression_ = NONE;
 			} else compression_ = UNCOMPRESSED;
 			return;
@@ -208,11 +206,10 @@ ozstream::open_append( std::string const & filename_a )
 
 	// Attach zip_ostream to ofstream if gzip file
 	if ( compression_ == GZIP ) {
-		// zip_stream_p_ deleted by close() above so don't have to here
-		zip_stream_p_ = new zip_ostream( of_stream_, true, static_cast< size_t >( Z_DEFAULT_COMPRESSION ), zlib_stream::DefaultStrategy, 15, 8, buffer_size_ );
-		if ( ( !zip_stream_p_ ) || ( !( *zip_stream_p_ ) ) ||
-				( !zip_stream_p_->is_gzip() ) ) { // zip_stream not in good state
-			delete zip_stream_p_; zip_stream_p_ = nullptr;
+		// zip_stream_p_ cleared by close() above so don't have to here
+		zip_stream_p_.reset( new zip_ostream( of_stream_, true, static_cast< size_t >( Z_DEFAULT_COMPRESSION ), zlib_stream::DefaultStrategy, 15, 8, buffer_size_ ) );
+		if ( !( *zip_stream_p_ ) || !zip_stream_p_->is_gzip() ) { // zip_stream not in good state
+			zip_stream_p_.reset();
 			of_stream_.close();
 			// Set failbit so failure can be detected
 			of_stream_.setstate( ios_base::failbit );

--- a/source/src/utility/io/ozstream.hh
+++ b/source/src/utility/io/ozstream.hh
@@ -41,6 +41,7 @@
 
 // C++ headers
 #include <fstream>
+#include <memory>
 
 namespace utility {
 namespace io {
@@ -438,15 +439,14 @@ public: // Methods: i/o
 #endif
 		if ( zip_stream_p_ ) {
 			zip_stream_p_->zflush_finalize();
-			delete zip_stream_p_; zip_stream_p_ = nullptr;
+			zip_stream_p_.reset();
 		}
 		of_stream_.close();
 		of_stream_.clear();
 		if ( mpi_stream_p_ ) {
 			mpi_stream_p_->close();
 			mpi_stream_p_->clear();
-			delete mpi_stream_p_;
-			mpi_stream_p_ = nullptr;
+			mpi_stream_p_.reset();
 		}
 		compression_ = NONE;
 		filename_.clear();
@@ -692,8 +692,8 @@ private: // buffer management
 	allocate_assign_char_buffer()
 	{
 		if ( !char_buffer_p_ && !of_stream_.is_open() ) {
-			char_buffer_p_ = new char[ buffer_size_ ];
-			of_stream_.rdbuf()->pubsetbuf( char_buffer_p_, buffer_size_ );
+			char_buffer_p_.reset( new char[ buffer_size_ ] );
+			of_stream_.rdbuf()->pubsetbuf( char_buffer_p_.get(), buffer_size_ );
 
 			return true;
 		}
@@ -710,8 +710,7 @@ private: // buffer management
 	destroy_char_buffer()
 	{
 		if ( char_buffer_p_ && !of_stream_.is_open() ) {
-			delete [] char_buffer_p_;
-			char_buffer_p_ = nullptr;
+			char_buffer_p_.reset();
 
 			return true;
 		}
@@ -750,13 +749,12 @@ private: // Fields
 	std::streamsize buffer_size_;
 
 	/// @brief character buffer pointer (owning)
-	char * char_buffer_p_;
+	std::unique_ptr<char[]> char_buffer_p_;
 
 	/// @brief Zip file stream pointer (owning)
-	zlib_stream::zip_ostream *zip_stream_p_;
+	std::unique_ptr<zlib_stream::zip_ostream> zip_stream_p_;
 
-
-	mpi_stream::mpi_ostream *mpi_stream_p_;
+	std::unique_ptr<mpi_stream::mpi_ostream> mpi_stream_p_;
 
 	static bool bMPI_reroute_stream_;
 	static int mpi_FileBuf_master_rank_;


### PR DESCRIPTION
## Summary

- Replace three raw owning pointers in `ozstream` (`char_buffer_p_`, `zip_stream_p_`, `mpi_stream_p_`) with `std::unique_ptr`, eliminating manual `delete`/`nullptr` pairs in `open()`, `open_append()`, `open_append_if_existed()`, `close()`, and the buffer helpers
- Modernize the private-undefined copy constructor/assignment in `orstream` to explicit `= delete`, consistent with the approach used in `irstream`/`izstream` (PR #664)

## Test plan

- [x] Full debug build passes (`python3 ./scons.py -j16 mode=debug`)
- [ ] No behavior change expected — ownership semantics are identical; `close()` still runs `zflush_finalize()` and `mpi_ostream::close()/clear()` before releasing the pointers