### PR TITLE
Modernize copy prevention in utility/signals classes to use = delete

### DIFF
--- a/source/src/utility/signals/BufferedSignalHub.hh
+++ b/source/src/utility/signals/BufferedSignalHub.hh
@@ -87,16 +87,8 @@ public: // construct/destruct
 	inline
 	~BufferedSignalHub() override = default;
 
-
-private: // disallow copy construction and assignment
-
-
-	/// @brief disallow copy constructor
-	BufferedSignalHub( BufferedSignalHub const & rval );
-
-
-	/// @brief disallow copy assignment
-	BufferedSignalHub & operator =( BufferedSignalHub const & rval );
+	BufferedSignalHub( BufferedSignalHub const & ) = delete;
+	BufferedSignalHub & operator =( BufferedSignalHub const & ) = delete;
 
 
 public: // signal management

--- a/source/src/utility/signals/LinkUnit.hh
+++ b/source/src/utility/signals/LinkUnit.hh
@@ -43,18 +43,6 @@ private:
 	typedef utility::VirtualBase Super;
 
 
-	/// @brief disallow default constructor
-	LinkUnit();
-
-
-	/// @brief disallow copy constructor
-	LinkUnit( LinkUnit const & rval );
-
-
-	/// @brief disallow copy assignment
-	LinkUnit & operator =( LinkUnit const & rval );
-
-
 public:
 
 
@@ -72,6 +60,10 @@ public:
 	/// @brief default destructor
 	inline
 	~LinkUnit() override = default;
+
+	LinkUnit() = delete;
+	LinkUnit( LinkUnit const & ) = delete;
+	LinkUnit & operator =( LinkUnit const & ) = delete;
 
 
 	/// @brief return a reference to the function object with requested cast

--- a/source/src/utility/signals/PausableSignalHub.hh
+++ b/source/src/utility/signals/PausableSignalHub.hh
@@ -74,16 +74,8 @@ public: // construct/destruct
 	inline
 	~PausableSignalHub() override = default;
 
-
-private: // disallow copy construction and assignment
-
-
-	/// @brief disallow copy constructor
-	PausableSignalHub( PausableSignalHub const & rval );
-
-
-	/// @brief disallow copy assignment
-	PausableSignalHub & operator =( PausableSignalHub const & rval );
+	PausableSignalHub( PausableSignalHub const & ) = delete;
+	PausableSignalHub & operator =( PausableSignalHub const & ) = delete;
 
 
 public: // signal management

--- a/source/src/utility/signals/SignalHub.hh
+++ b/source/src/utility/signals/SignalHub.hh
@@ -95,16 +95,8 @@ public: // construct/destruct
 		invalidate_all( links_ );
 	}
 
-
-private: // disallow copy construction and assignment
-
-
-	/// @brief disallow copy constructor
-	SignalHub( SignalHub const & rval );
-
-
-	/// @brief disallow copy assignment
-	SignalHub & operator =( SignalHub const & rval );
+	SignalHub( SignalHub const & ) = delete;
+	SignalHub & operator =( SignalHub const & ) = delete;
 
 
 public: // operators

--- a/source/src/utility/signals/TokenHub.hh
+++ b/source/src/utility/signals/TokenHub.hh
@@ -89,16 +89,8 @@ public: // construct/destruct
 		this->invalidate_all( tokens_ );
 	}
 
-
-private: // disallow copy construction and assignment
-
-
-	/// @brief disallow copy constructor
-	TokenHub( TokenHub const & rval );
-
-
-	/// @brief disallow copy assignment
-	TokenHub & operator =( TokenHub const & rval );
+	TokenHub( TokenHub const & ) = delete;
+	TokenHub & operator =( TokenHub const & ) = delete;
 
 
 public: // token copy


### PR DESCRIPTION
## Summary

- Replace old-style private-and-undefined copy constructor/assignment in five `utility/signals` classes with explicit `= delete`
- Affected classes: `SignalHub`, `BufferedSignalHub`, `PausableSignalHub`, `TokenHub`, `LinkUnit`
- Also explicitly deletes the `LinkUnit` default constructor (was previously also private-undefined)
- Pure mechanical modernization — no behavioral change

## Motivation

The pre-C++11 idiom of declaring copy ops private with no definition produces a linker error on misuse rather than a clear compile-time diagnostic. `= delete` gives an immediate, descriptive compiler error at the call site and is the modern idiomatic approach.

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes (headers-only change; no behavioral difference)