### PR TITLE
Modernize copy prevention in irstream to use = delete

### DIFF
--- a/source/src/utility/io/irstream.hh
+++ b/source/src/utility/io/irstream.hh
@@ -48,6 +48,9 @@ public: // Creation
 	virtual
 	~irstream() {}
 
+	irstream( irstream const & ) = delete;
+	irstream & operator =( irstream const & ) = delete;
+
 
 protected: // Creation
 
@@ -56,21 +59,6 @@ protected: // Creation
 	inline
 	irstream()
 	= default;
-
-
-private: // Creation
-
-
-	/// @brief Copy constructor: Undefined
-	irstream( irstream const & );
-
-
-private: // Methods: assignment
-
-
-	/// @brief Copy assignment: Undefined
-	irstream &
-	operator =( irstream const & );
 
 
 public: // Methods: conversion


### PR DESCRIPTION
## Summary

- Replace old-style private-and-undefined copy constructor/assignment in `utility/io/irstream` with explicit `= delete`
- Mirrors the same treatment already applied to the sibling `orstream` class (PR #667)

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes (header-only change; no behavioral difference)