### PR TITLE
Modernize copy prevention in factory/Registrant to use = delete

### DIFF
--- a/source/src/utility/factory/Registrant.hh
+++ b/source/src/utility/factory/Registrant.hh
@@ -48,13 +48,6 @@ public: // Types
 	typedef  typename ProductFactory::Create  Create; // Product creation function
 
 
-private: // Creation
-
-
-	/// @brief Copy constructor
-	Registrant( Registrant const & ); // Undefined
-
-
 public: // Creation
 
 
@@ -175,12 +168,9 @@ public: // Creation
 	}
 
 
-private: // Assignment
-
-
-	/// @brief Copy assignment
-	Registrant &
-	operator =( Registrant const & ); // Undefined
+	// Each constructor calls ProductFactory::add(); a copy would silently re-register the same key.
+	Registrant( Registrant const & ) = delete;
+	Registrant & operator =( Registrant const & ) = delete;
 
 
 }; // Registrant


### PR DESCRIPTION
## Summary

- Replace old-style private-and-undefined copy constructor/assignment in `utility/factory/Registrant` with explicit `= delete`
- Added a one-line comment explaining the non-obvious reason: each constructor calls `ProductFactory::add()`, so a copy would silently re-register the same key

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes (header-only template change; no behavioral difference)