### PR TITLE
Modernize copy prevention in KeyLookup to use = delete

### DIFF
--- a/source/src/utility/keys/KeyLookup.hh
+++ b/source/src/utility/keys/KeyLookup.hh
@@ -97,24 +97,13 @@ private: // Creation
 	= default;
 
 
-	/// @brief Copy constructor
-	inline
-	KeyLookup( KeyLookup const & a ); // Undefined
-
-
 	/// @brief Destructor
 	inline
 	~KeyLookup()
 	= default;
 
-
-private: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	KeyLookup &
-	operator =( KeyLookup const & a ); // Undefined
+	KeyLookup( KeyLookup const & ) = delete;
+	KeyLookup & operator =( KeyLookup const & ) = delete;
 
 
 public: // Methods


### PR DESCRIPTION
## Summary

- Replace old-style private-and-undefined copy constructor/assignment in `utility/keys/KeyLookup` with explicit `= delete`
- `KeyLookup` is a monostate singleton (all methods and data are static); copies are meaningless

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes (header-only template change; no behavioral difference)