### PR TITLE
Modernize copy prevention in utility/graph EdgeList/Node/Edge to use = delete

### DIFF
--- a/source/src/utility/graph/Digraph.hh
+++ b/source/src/utility/graph/Digraph.hh
@@ -357,12 +357,10 @@ public:
 	/// O(N)
 	platform::Size size() const;
 
-private:
+	DirectedEdgeList( DirectedEdgeList const & ) = delete;
+	DirectedEdgeList & operator =( DirectedEdgeList const & ) = delete;
 
-	/// @brief Uncopyable -- private and unimplemented copy ctor
-	DirectedEdgeList( DirectedEdgeList const & );
-	/// @brief Uncopyable -- private and unimplemented assignment operator
-	DirectedEdgeList const & operator = ( DirectedEdgeList const & );
+private:
 
 	/// @brief this edge-list-element-pool reference is handed to the list
 	/// to draw from.  This pool must outlive the edge-list itself.
@@ -518,10 +516,9 @@ private:
 	DirectedEdgeListIter first_outgoing_edge_;
 	Digraph* owner_;
 
-	//no default constructor, uncopyable
-	DirectedNode();
-	DirectedNode( DirectedNode const & );
-	DirectedNode & operator = ( DirectedNode & );
+	DirectedNode() = delete;
+	DirectedNode( DirectedNode const & ) = delete;
+	DirectedNode & operator =( DirectedNode const & ) = delete;
 };
 
 class DirectedEdge
@@ -667,10 +664,9 @@ private:
 	DirectedEdgeListIter pos_in_owners_edge_list_;
 	Digraph* owner_;
 
-	//no default constructor, uncopyable
-	DirectedEdge();
-	DirectedEdge( DirectedEdge const & );
-	DirectedEdge & operator = ( DirectedEdge & );
+	DirectedEdge() = delete;
+	DirectedEdge( DirectedEdge const & ) = delete;
+	DirectedEdge & operator =( DirectedEdge const & ) = delete;
 
 };
 

--- a/source/src/utility/graph/Graph.hh
+++ b/source/src/utility/graph/Graph.hh
@@ -366,12 +366,10 @@ public:
 	/// O(N)
 	platform::Size size() const;
 
-private:
+	EdgeList( EdgeList const & ) = delete;
+	EdgeList & operator =( EdgeList const & ) = delete;
 
-	/// @brief Uncopyable -- private and unimplemented copy ctor
-	EdgeList( EdgeList const & );
-	/// @brief Uncopyable -- private and unimplemented assignment operator
-	EdgeList const & operator = ( EdgeList const & );
+private:
 
 	/// @brief this edge-list-element-pool reference is handed to the list
 	/// to draw from.  This pool must outlive the edge-list itself.
@@ -522,10 +520,9 @@ private:
 	EdgeListIter first_upper_edge_;
 	Graph* owner_;
 
-	//no default constructor, uncopyable
-	Node();
-	Node( Node const & );
-	Node & operator = ( Node & );
+	Node() = delete;
+	Node( Node const & ) = delete;
+	Node & operator =( Node const & ) = delete;
 };
 
 class Edge
@@ -634,10 +631,9 @@ private:
 	EdgeListIter pos_in_owners_edge_list_;
 	Graph* owner_;
 
-	//no default constructor, uncopyable
-	Edge();
-	Edge( Edge const & );
-	Edge & operator = ( Edge & );
+	Edge() = delete;
+	Edge( Edge const & ) = delete;
+	Edge & operator =( Edge const & ) = delete;
 
 };
 


### PR DESCRIPTION
## Summary

Replace old-style private-and-undefined copy constructor/assignment with explicit `= delete` in six internal classes across `Graph.hh` and `Digraph.hh`:

- `Graph.hh`: `EdgeList`, `Node`, `Edge`
- `Digraph.hh`: `DirectedEdgeList`, `DirectedNode`, `DirectedEdge`

Also corrects the copy assignment signatures from the non-standard `T&` argument to the correct `T const &` form. The `Graph` class itself (which has a real, implemented copy constructor and assignment) is unchanged.

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes