### PR TITLE
Modernize copy prevention in basic/ComparingTracer and MessageListenerFactory

### DIFF
--- a/source/src/basic/ComparingTracer.hh
+++ b/source/src/basic/ComparingTracer.hh
@@ -31,8 +31,8 @@ protected:
 	/// @brief overload member function.
 	void t_flush(std::string const & s) override;
 
-private:
-	ComparingTracer(ComparingTracer const & );
+	ComparingTracer( ComparingTracer const & ) = delete;
+	ComparingTracer & operator=( ComparingTracer const & ) = delete;
 
 	//std::string  file_name_;
 	std::fstream file_;

--- a/source/src/basic/mpi/MessageListenerFactory.hh
+++ b/source/src/basic/mpi/MessageListenerFactory.hh
@@ -37,8 +37,6 @@ public:
 private:
 
 	MessageListenerFactory();
-	MessageListenerFactory(MessageListenerFactory const &);
-	MessageListenerFactory const & operator = (MessageListenerFactory const &);
 
 private:
 


### PR DESCRIPTION
## Summary

Two related cleanups in `basic/`:

**`ComparingTracer.hh`**: Replace private-and-undefined copy constructor with public `= delete`; also explicitly delete copy assignment. The `std::fstream` member already makes copies impossible, but `= delete` documents the intent at the class level.

**`mpi/MessageListenerFactory.hh`**: Remove the redundant private-undefined copy constructor and copy assignment. `MessageListenerFactory` inherits from `utility::SingletonBase<MessageListenerFactory>`, which already deletes both copy operations — the manual declarations were dead code.

## Test plan

- [x] `python3 ./scons.py -j16 mode=debug` passes