### PR TITLE
Restrict perturbation_type XSD attribute to gaussian/uniform

### DIFF
--- a/source/src/core/conformation/parametric/RealValuedParameter.cc
+++ b/source/src/core/conformation/parametric/RealValuedParameter.cc
@@ -351,8 +351,7 @@ RealValuedParameter::provide_xsd_perturbation_information(
 ) const {
 	using namespace utility::tag;
 	xsd + XMLSchemaAttribute::attribute_w_default( parameter_name() + "_perturbation" , xsct_real, "Perturbation magnitude for perturbing " + parameter_name() + ".", "0.0" );
-	xsd + XMLSchemaAttribute::attribute_w_default( parameter_name() + "_perturbation_type" , xs_string, "Perturbation type for perturbing " + parameter_name() + ".  Can be \"gaussian\" or \"uniform\".", "gaussian" );
-	//TODO: FIGURE OUT HOW TO ADD RESTRICTION THAT THE PERTURBATION TYPE CAN ONLY BE "gaussian" OR "uniform"
+	xsd + XMLSchemaAttribute::attribute_w_default( parameter_name() + "_perturbation_type" , xsct_perturbation_type, "Perturbation type for perturbing " + parameter_name() + ".  Can be \"gaussian\" or \"uniform\".", "gaussian" );
 }
 
 /// @brief Return the XSD information for setting this parameter.

--- a/source/src/utility/tag/XMLSchemaGeneration.cc
+++ b/source/src/utility/tag/XMLSchemaGeneration.cc
@@ -78,6 +78,7 @@ std::string name_for_common_type( XMLSchemaCommonType common_type )
 	case xsct_task_operation_comma_separated_list : return "task_operation_comma_separated_list";
 	case xsct_pose_cached_task_operation : return "pose_cached_task_operation";
 	case xsct_string_cslist : return "string_cslist";
+	case xsct_perturbation_type : return "perturbation_type";
 	case xsct_none :
 		throw CREATE_EXCEPTION(utility::excn::Exception, "Error in requesting name for xsct_none;" );
 		break;
@@ -513,6 +514,13 @@ activate_common_simple_type(
 		string_cslist.base_type( xs_string );
 		string_cslist.add_restriction( xsr_pattern, "[+]?.+(,[-+]?[0-9]+)*" );
 		xsd.add_top_level_element( string_cslist );
+	} else if ( common_type == xsct_perturbation_type ) {
+		XMLSchemaRestriction perturbation_type;
+		perturbation_type.name( name_for_common_type( common_type ) );
+		perturbation_type.base_type( xs_string );
+		perturbation_type.add_restriction( xsr_enumeration, "gaussian" );
+		perturbation_type.add_restriction( xsr_enumeration, "uniform" );
+		xsd.add_top_level_element( perturbation_type );
 	}
 
 	/* else if ( common_type == xsct_zero_or_one ) {

--- a/source/src/utility/tag/XMLSchemaGeneration.hh
+++ b/source/src/utility/tag/XMLSchemaGeneration.hh
@@ -166,7 +166,8 @@ enum XMLSchemaCommonType {
 	xsct_packer_palette, //A single packer palette, previously defined in XML
 	xsct_task_operation, //A single task operation, previously defined in XML
 	xsct_task_operation_comma_separated_list, //A comma-separated list of task operations, all of which are previously defined in XML
-	xsct_pose_cached_task_operation //The identifier of a task operation stored in the datacache of a Pose object.
+	xsct_pose_cached_task_operation, //The identifier of a task operation stored in the datacache of a Pose object.
+	xsct_perturbation_type //A perturbation type: "gaussian" or "uniform"
 };
 std::string residue_number_string();
 std::string real_regex_pattern();


### PR DESCRIPTION
We create a `xsct_perturbation_type` enum. This ultimately closes a TODO that has stood for.... nine and a half years? @aleaverfay did you know we were in florida a decade ago