### PR TITLE
Fix key map range indexing

### DIFF
--- a/source/src/utility/keys/ClassKeyMap.hh
+++ b/source/src/utility/keys/ClassKeyMap.hh
@@ -130,7 +130,7 @@ public: // Creation
 	) :
 		v_( beg, end )
 	{
-		for ( Index i = 1, e = v_.size(); i != e; ++i ) {
+		for ( Index i = 1, e = v_.size(); i <= e; ++i ) {
 			add_key( v_[ i ].first );
 		}
 	}
@@ -206,7 +206,7 @@ public: // Assignment
 	{
 		clear();
 		v_.assign( beg, end );
-		for ( Index i = 1, e = v_.size(); i != e; ++i ) {
+		for ( Index i = 1, e = v_.size(); i <= e; ++i ) {
 			add_key( v_[ i ].first );
 		}
 	}

--- a/source/src/utility/keys/SmallKeyMap.hh
+++ b/source/src/utility/keys/SmallKeyMap.hh
@@ -130,7 +130,7 @@ public: // Creation
 		v_( beg, end ),
 		u_( 0 )
 	{
-		for ( Index i = 1, e = v_.size(); i != e; ++i ) {
+		for ( Index i = 1, e = v_.size(); i <= e; ++i ) {
 			add_key( v_[ i ].first );
 		}
 	}
@@ -208,7 +208,7 @@ public: // Assignment
 	{
 		clear();
 		v_.assign( beg, end );
-		for ( Index i = 1, e = v_.size(); i != e; ++i ) {
+		for ( Index i = 1, e = v_.size(); i <= e; ++i ) {
 			add_key( v_[ i ].first );
 		}
 	}

--- a/source/test/utility/keys/ClassKeyMap.cxxtest.hh
+++ b/source/test/utility/keys/ClassKeyMap.cxxtest.hh
@@ -17,6 +17,9 @@
 #include <cxxtest/TestSuite.h>
 #include <utility/keys/ClassKeyMap.hh>
 
+// C++ headers
+#include <vector>
+
 
 // --- set up the individual test cases
 class KeyMapTests : public CxxTest::TestSuite {
@@ -89,6 +92,24 @@ class KeyMapTests : public CxxTest::TestSuite {
 		TS_ASSERT( m[ 9 ] == 33 );
 	}
 
-};
+	void test_ClassKeyMap_range_operations_activate_last_key() {
 
+		typedef  utility::keys::ClassKeyMap< int, int, char >  Map;
+		typedef  std::vector< Map::Value >  Values;
+
+		Values values;
+		values.push_back( Map::Value( 4, 44 ) );
+		values.push_back( Map::Value( 8, 88 ) );
+
+		Map constructed( values.begin(), values.end() );
+		TS_ASSERT( constructed.has( 8 ) );
+		TS_ASSERT_EQUALS( constructed[ 8 ], 88 );
+
+		Map assigned;
+		assigned.assign( values.begin(), values.end() );
+		TS_ASSERT( assigned.has( 8 ) );
+		TS_ASSERT_EQUALS( assigned[ 8 ], 88 );
+	}
+
+};
 

--- a/source/test/utility/keys/SmallKeyMap.cxxtest.hh
+++ b/source/test/utility/keys/SmallKeyMap.cxxtest.hh
@@ -18,6 +18,9 @@
 #include <cxxtest/TestSuite.h>
 #include <utility/keys/SmallKeyMap.hh>
 
+// C++ headers
+#include <vector>
+
 
 class SmallKeyMapTests : public CxxTest::TestSuite {
 
@@ -88,6 +91,24 @@ class SmallKeyMapTests : public CxxTest::TestSuite {
 		TS_ASSERT( m[ 9 ] == 33 );
 	}
 
-};
+	void test_SmallKeyMap_range_operations_activate_last_key() {
 
+		typedef  utility::keys::SmallKeyMap< int, int >  Map;
+		typedef  std::vector< Map::Value >  Values;
+
+		Values values;
+		values.push_back( Map::Value( 4, 44 ) );
+		values.push_back( Map::Value( 8, 88 ) );
+
+		Map constructed( values.begin(), values.end() );
+		TS_ASSERT( constructed.has( 8 ) );
+		TS_ASSERT_EQUALS( constructed[ 8 ], 88 );
+
+		Map assigned;
+		assigned.assign( values.begin(), values.end() );
+		TS_ASSERT( assigned.has( 8 ) );
+		TS_ASSERT_EQUALS( assigned[ 8 ], 88 );
+	}
+
+};
 


### PR DESCRIPTION
## Summary
- fix ClassKeyMap and SmallKeyMap range constructor/assignment loops to visit the final 1-indexed element
- add regression coverage for range construction and assignment preserving the final key

## Testing
- python3 ./scons.py -j16 mode=debug cat=test
- python3 test/run.py -j16 --mode=debug KeyMapTests SmallKeyMapTests
- python3 ./scons.py -j16 mode=release bin