### PR TITLE
Default MetricValue special members

### DIFF
--- a/source/src/basic/MetricValue.hh
+++ b/source/src/basic/MetricValue.hh
@@ -33,7 +33,7 @@ class MetricValueBase : public utility::VirtualBase {
 public:
 	// note: MetricValueBase must have a virtual function so that it will be polymorphic
 	// (specifically to allow dynamic casting)
-	~MetricValueBase() override {};
+	~MetricValueBase() override = default;
 	virtual MetricValueBaseOP clone() const = 0;
 };
 
@@ -41,8 +41,8 @@ public:
 template <class T>
 class MetricValue : public MetricValueBase {
 public:
-	MetricValue() {};
-	MetricValue( MetricValue const & metric_value ) : MetricValueBase(), data_(metric_value.value()) {};
+	MetricValue() = default;
+	MetricValue( MetricValue const & metric_value ) = default;
 	MetricValue( T const & inp ) : data_(inp) {};
 	void set( T const & inp ) { data_ = inp; };
 	std::string print() const { std::ostringstream ostream; ostream << data_; return ostream.str(); };

--- a/source/src/basic/MetricValue.hh
+++ b/source/src/basic/MetricValue.hh
@@ -42,7 +42,7 @@ template <class T>
 class MetricValue : public MetricValueBase {
 public:
 	MetricValue() = default;
-	MetricValue( MetricValue const & metric_value ) = default;
+	MetricValue( MetricValue const & ) = default;
 	MetricValue( T const & inp ) : data_(inp) {};
 	void set( T const & inp ) { data_ = inp; };
 	std::string print() const { std::ostringstream ostream; ostream << data_; return ostream.str(); };


### PR DESCRIPTION
## Summary
- default no-op MetricValueBase destructor
- default MetricValue default and copy constructors

## Testing
- python3 ./scons.py -j16 mode=debug
- python3 test/run.py -j16 --mode=debug MetricValueIOTest
- python3 ./scons.py -j16 mode=release bin