### PR TITLE
Modernize copy prevention in core factory singletons and non-copyable classes

### DIFF
--- a/source/src/core/import_pose/atom_tree_diffs/atom_tree_diff.hh
+++ b/source/src/core/import_pose/atom_tree_diffs/atom_tree_diff.hh
@@ -112,7 +112,8 @@ public:
 	}
 
 private:
-	AtomTreeDiff(AtomTreeDiff const &);
+	AtomTreeDiff( AtomTreeDiff const & ) = delete;
+	AtomTreeDiff & operator=( AtomTreeDiff const & ) = delete;
 
 	/// The list of (tag,scores) pairs for the diffed structures, for efficient selection of subsets.
 	/// (E.g. the top 5% by total score.) Memory cost is probably ~1 kb / structure.

--- a/source/src/core/io/silent/SilentStructFactory.hh
+++ b/source/src/core/io/silent/SilentStructFactory.hh
@@ -38,9 +38,6 @@ public:
 private:
 	SilentStructFactory();
 
-	SilentStructFactory(SilentStructFactory const &); // unimplemented
-	SilentStructFactory const & operator=( SilentStructFactory const & ); // unimplemented
-
 public:
 
 	void factory_register( SilentStructCreatorCOP creator );

--- a/source/src/core/scoring/constraints/ConstraintFactory.hh
+++ b/source/src/core/scoring/constraints/ConstraintFactory.hh
@@ -41,9 +41,6 @@ public:
 private:
 	ConstraintFactory();
 
-	ConstraintFactory(ConstraintFactory const &); // unimplemented
-	ConstraintFactory const & operator=( ConstraintFactory const & ); // unimplemented
-
 public:
 
 	void factory_register( ConstraintCreatorCOP creator );

--- a/source/src/core/scoring/orbitals/OrbitalsStatistics.hh
+++ b/source/src/core/scoring/orbitals/OrbitalsStatistics.hh
@@ -93,8 +93,8 @@ public:
 
 
 private:
-	OrbitalsStatistics(OrbitalsStatistics const & );  /// Non-copyable due to std::ofstream member, we need so PyRosetta builder
-	/// can figure out not to try to create copy constructor.
+	OrbitalsStatistics( OrbitalsStatistics const & ) = delete;
+	OrbitalsStatistics & operator=( OrbitalsStatistics const & ) = delete;
 
 	utility::vector1< numeric::histograms::TwoDHistogram<core::Size, core::SSize> > histogram_vector_;
 	numeric::histograms::TwoDHistogram<core::Size, core::SSize> twoD_histogram_;

--- a/source/src/core/sequence/SequenceFactory.hh
+++ b/source/src/core/sequence/SequenceFactory.hh
@@ -36,9 +36,6 @@ public:
 private:
 	SequenceFactory();
 
-	SequenceFactory(SequenceFactory const &); // unimplemented
-	SequenceFactory const & operator=( SequenceFactory const & ); // unimplemented
-
 public:
 	void factory_register( SequenceCreatorCOP creator );
 	SequenceOP get_sequence( std::string const & type_name );


### PR DESCRIPTION
## Summary

- **SilentStructFactory, ConstraintFactory, SequenceFactory**: all inherit from `utility::SingletonBase`, which already `= delete`s copy construction and copy assignment. Removes the now-redundant private-but-unimplemented declarations from each derived class (pre-C++11 idiom).
- **OrbitalsStatistics, AtomTreeDiff**: had private-but-undefined copy constructors (pre-C++11 idiom); replaced with explicit `= delete` on both copy constructor and copy assignment operator.

No behaviour change; build-only verification is sufficient for pure copy-prevention modernisation.

## Test plan
- [x] Debug build passes (`scons.py -j16 mode=debug`)