### PR TITLE
Apply Rule of Zero to core signal event hierarchies

### DIFF
--- a/source/src/core/conformation/signals/ConnectionEvent.hh
+++ b/source/src/core/conformation/signals/ConnectionEvent.hh
@@ -86,30 +86,7 @@ struct ConnectionEvent { // do not derive from GeneralEvent
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	ConnectionEvent( ConnectionEvent const & rval ) :
-		conformation( rval.conformation ),
-		tag( rval.tag )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	virtual
-	~ConnectionEvent() {}
-
-
-	/// @brief copy assignment
-	inline
-	ConnectionEvent &
-	operator =( ConnectionEvent const & rval ) {
-		if ( this != &rval ) {
-			conformation = rval.conformation;
-			tag = rval.tag;
-		}
-		return *this;
-	}
+	virtual ~ConnectionEvent() = default;
 
 
 	/// @brief the Conformation firing the signal

--- a/source/src/core/conformation/signals/GeneralEvent.hh
+++ b/source/src/core/conformation/signals/GeneralEvent.hh
@@ -59,28 +59,7 @@ struct GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	GeneralEvent( GeneralEvent const & rval ) :
-		conformation( rval.conformation )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	virtual
-	~GeneralEvent() {}
-
-
-	/// @brief copy assignment
-	inline
-	GeneralEvent &
-	operator =( GeneralEvent const & rval ) {
-		if ( this != &rval ) {
-			conformation = rval.conformation;
-		}
-		return *this;
-	}
+	virtual ~GeneralEvent() = default;
 
 
 	/// @brief the Conformation firing the signal

--- a/source/src/core/conformation/signals/IdentityEvent.hh
+++ b/source/src/core/conformation/signals/IdentityEvent.hh
@@ -84,35 +84,6 @@ struct IdentityEvent : public GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	IdentityEvent( IdentityEvent const & rval ) :
-		Super( rval ),
-		tag( rval.tag ),
-		position( rval.position ),
-		residue( rval.residue )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	~IdentityEvent() override {}
-
-
-	/// @brief copy assignment
-	inline
-	IdentityEvent &
-	operator =( IdentityEvent const & rval ) {
-		if ( this != &rval ) {
-			Super::operator =( rval );
-			tag = rval.tag;
-			position = rval.position;
-			residue = rval.residue;
-		}
-		return *this;
-	}
-
-
 	/// @brief tag indicating type of identity change
 	Tag tag;
 

--- a/source/src/core/conformation/signals/XYZEvent.hh
+++ b/source/src/core/conformation/signals/XYZEvent.hh
@@ -59,29 +59,6 @@ struct XYZEvent : public GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	XYZEvent( XYZEvent const & rval ) :
-		Super( rval )
-	{}
-
-
-	/// @brief copy assignment
-	inline
-	XYZEvent &
-	operator =( XYZEvent const & rval ) {
-		if ( this != &rval ) {
-			Super::operator =( rval );
-		}
-		return *this;
-	}
-
-
-	/// @brief default destructor
-	inline
-	~XYZEvent() override {}
-
-
 };
 
 

--- a/source/src/core/pose/signals/ConformationEvent.hh
+++ b/source/src/core/pose/signals/ConformationEvent.hh
@@ -57,29 +57,6 @@ struct ConformationEvent : public GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	ConformationEvent( ConformationEvent const & rval ) :
-		Super( rval )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	~ConformationEvent() override {}
-
-
-	/// @brief copy assignment
-	inline
-	ConformationEvent &
-	operator =( ConformationEvent const & rval ) {
-		if ( this != &rval ) {
-			Super::operator =( rval );
-		}
-		return *this;
-	}
-
-
 };
 
 

--- a/source/src/core/pose/signals/DestructionEvent.hh
+++ b/source/src/core/pose/signals/DestructionEvent.hh
@@ -49,28 +49,7 @@ struct DestructionEvent { // do not derive from GeneralEvent
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	DestructionEvent( DestructionEvent const & rval ) :
-		pose( rval.pose )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	virtual
-	~DestructionEvent() {}
-
-
-	/// @brief copy assignment
-	inline
-	DestructionEvent &
-	operator =( DestructionEvent const & rval ) {
-		if ( this != &rval ) {
-			pose = rval.pose;
-		}
-		return *this;
-	}
+	virtual ~DestructionEvent() = default;
 
 
 	/// @brief the Pose firing the signal

--- a/source/src/core/pose/signals/EnergyEvent.hh
+++ b/source/src/core/pose/signals/EnergyEvent.hh
@@ -56,29 +56,6 @@ struct EnergyEvent : public GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	EnergyEvent( EnergyEvent const & rval ) :
-		Super( rval )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	~EnergyEvent() override {}
-
-
-	/// @brief copy assignment
-	inline
-	EnergyEvent &
-	operator =( EnergyEvent const & rval ) {
-		if ( this != &rval ) {
-			Super::operator =( rval );
-		}
-		return *this;
-	}
-
-
 };
 
 

--- a/source/src/core/pose/signals/GeneralEvent.hh
+++ b/source/src/core/pose/signals/GeneralEvent.hh
@@ -61,28 +61,7 @@ struct GeneralEvent {
 	{}
 
 
-	/// @brief copy constructor
-	inline
-	GeneralEvent( GeneralEvent const & rval ) :
-		pose( rval.pose )
-	{}
-
-
-	/// @brief default destructor
-	inline
-	virtual
-	~GeneralEvent() {}
-
-
-	/// @brief copy assignment
-	inline
-	GeneralEvent &
-	operator =( GeneralEvent const & rval ) {
-		if ( this != &rval ) {
-			pose = rval.pose;
-		}
-		return *this;
-	}
+	virtual ~GeneralEvent() = default;
 
 
 	/// @brief the Pose firing the signal


### PR DESCRIPTION
## Summary

Each of the simple polymorphic signal-event classes in `core/conformation/signals/` and `core/pose/signals/` had a hand-written copy constructor, copy assignment, and empty destructor that all just did what the compiler-generated versions would do. Removing the boilerplate brings them in line with the Rule of Zero while preserving the polymorphic base destructors as `= default`.

Touched:

- `core/conformation/signals/`: `GeneralEvent`, `ConnectionEvent`, `IdentityEvent`, `XYZEvent`
- `core/pose/signals/`: `GeneralEvent`, `DestructionEvent`, `ConformationEvent`, `EnergyEvent`

`LengthEvent` is intentionally left alone — its copy constructor and copy assignment invoke `check_consistency()` in debug builds, so they have real semantic content beyond member-wise copy.

Net diff: 8 files changed, 4 insertions(+), 188 deletions(-).

## Test plan

- [x] `mode=debug` build passes (clean, `-Werror`)
- [x] `mode=release bin` build passes
- [ ] CI green