### PR TITLE
Apply Rule of Zero to disulfide energy neighbor iterators

### DIFF
--- a/source/src/core/scoring/disulfides/CentroidDisulfideEnergyContainer.cc
+++ b/source/src/core/scoring/disulfides/CentroidDisulfideEnergyContainer.cc
@@ -74,8 +74,6 @@ CentroidDisulfideNeighborIterator::CentroidDisulfideNeighborIterator(
 	disulfide_index_( CentroidDisulfideEnergyContainer::NO_DISULFIDE )
 {}
 
-CentroidDisulfideNeighborIterator::~CentroidDisulfideNeighborIterator() = default;
-
 /// @brief Assignment
 ResidueNeighborIterator &
 CentroidDisulfideNeighborIterator::operator = ( ResidueNeighborIterator const & rhs)
@@ -218,8 +216,6 @@ CentroidDisulfideNeighborConstIterator::CentroidDisulfideNeighborConstIterator(
 	focused_residue_( CentroidDisulfideEnergyContainer::NO_DISULFIDE ),
 	disulfide_index_( CentroidDisulfideEnergyContainer::NO_DISULFIDE )
 {}
-
-CentroidDisulfideNeighborConstIterator::~CentroidDisulfideNeighborConstIterator() = default;
 
 ResidueNeighborConstIterator &
 CentroidDisulfideNeighborConstIterator::operator = ( ResidueNeighborConstIterator const & rhs )

--- a/source/src/core/scoring/disulfides/CentroidDisulfideEnergyContainer.hh
+++ b/source/src/core/scoring/disulfides/CentroidDisulfideEnergyContainer.hh
@@ -60,7 +60,6 @@ namespace disulfides {
 * could form a bond, not just the best one. Maybe even include non-cysteines!
 */
 class CentroidDisulfideNeighborIterator : public ResidueNeighborIterator {
-	CentroidDisulfideNeighborIterator & operator = (CentroidDisulfideNeighborIterator const & );
 public:
 
 	CentroidDisulfideNeighborIterator(
@@ -73,7 +72,10 @@ public:
 		CentroidDisulfideEnergyContainer * owner
 	);
 
-	~CentroidDisulfideNeighborIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	CentroidDisulfideNeighborIterator & operator = (CentroidDisulfideNeighborIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & ) override;
 	ResidueNeighborIterator const & operator ++ () override;
@@ -113,7 +115,6 @@ public:
 
 /// @brief Just a const version of CentroidDisulfideNeighborIterator
 class CentroidDisulfideNeighborConstIterator : public ResidueNeighborConstIterator {
-	CentroidDisulfideNeighborConstIterator & operator = (CentroidDisulfideNeighborConstIterator const & );
 public:
 	CentroidDisulfideNeighborConstIterator(
 		CentroidDisulfideEnergyContainer const * owner,
@@ -123,7 +124,10 @@ public:
 
 	CentroidDisulfideNeighborConstIterator( CentroidDisulfideEnergyContainer const * owner );
 
-	~CentroidDisulfideNeighborConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	CentroidDisulfideNeighborConstIterator & operator = (CentroidDisulfideNeighborConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & ) override;
 	ResidueNeighborConstIterator const & operator ++ () override;

--- a/source/src/core/scoring/disulfides/DisulfideMatchingEnergyContainer.cc
+++ b/source/src/core/scoring/disulfides/DisulfideMatchingEnergyContainer.cc
@@ -71,8 +71,6 @@ DisulfideMatchingNeighborIterator::DisulfideMatchingNeighborIterator(
 	disulfide_index_( DisulfideMatchingEnergyContainer::NO_DISULFIDE )
 {}
 
-DisulfideMatchingNeighborIterator::~DisulfideMatchingNeighborIterator() = default;
-
 /// @brief Assignment
 ResidueNeighborIterator &
 DisulfideMatchingNeighborIterator::operator = ( ResidueNeighborIterator const & rhs)
@@ -215,8 +213,6 @@ DisulfideMatchingNeighborConstIterator::DisulfideMatchingNeighborConstIterator(
 	focused_residue_( DisulfideMatchingEnergyContainer::NO_DISULFIDE ),
 	disulfide_index_( DisulfideMatchingEnergyContainer::NO_DISULFIDE )
 {}
-
-DisulfideMatchingNeighborConstIterator::~DisulfideMatchingNeighborConstIterator() = default;
 
 ResidueNeighborConstIterator &
 DisulfideMatchingNeighborConstIterator::operator = ( ResidueNeighborConstIterator const & rhs )

--- a/source/src/core/scoring/disulfides/DisulfideMatchingEnergyContainer.hh
+++ b/source/src/core/scoring/disulfides/DisulfideMatchingEnergyContainer.hh
@@ -59,7 +59,6 @@ namespace disulfides {
 */
 class DisulfideMatchingNeighborIterator : public ResidueNeighborIterator
 {
-	DisulfideMatchingNeighborIterator & operator = (DisulfideMatchingNeighborIterator const & src );
 public:
 
 	DisulfideMatchingNeighborIterator(
@@ -72,7 +71,10 @@ public:
 		DisulfideMatchingEnergyContainer * owner
 	);
 
-	~DisulfideMatchingNeighborIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DisulfideMatchingNeighborIterator & operator = (DisulfideMatchingNeighborIterator const & src ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & ) override;
 	ResidueNeighborIterator const & operator ++ () override;
@@ -102,7 +104,6 @@ private:
 
 /// @brief Just a const version of DisulfideMatchingNeighborIterator
 class DisulfideMatchingNeighborConstIterator : public ResidueNeighborConstIterator {
-	DisulfideMatchingNeighborConstIterator & operator = (DisulfideMatchingNeighborConstIterator const & src );
 public:
 	DisulfideMatchingNeighborConstIterator(
 		DisulfideMatchingEnergyContainer const * owner,
@@ -112,7 +113,10 @@ public:
 
 	DisulfideMatchingNeighborConstIterator( DisulfideMatchingEnergyContainer const * owner );
 
-	~DisulfideMatchingNeighborConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DisulfideMatchingNeighborConstIterator & operator = (DisulfideMatchingNeighborConstIterator const & src ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & ) override;
 	ResidueNeighborConstIterator const & operator ++ () override;

--- a/source/src/core/scoring/disulfides/FullatomDisulfideEnergyContainer.cc
+++ b/source/src/core/scoring/disulfides/FullatomDisulfideEnergyContainer.cc
@@ -69,8 +69,6 @@ DisulfResNeighbIterator::DisulfResNeighbIterator(
 	disulfide_index_( FullatomDisulfideEnergyContainer::NO_DISULFIDE )
 {}
 
-DisulfResNeighbIterator::~DisulfResNeighbIterator() = default;
-
 ResidueNeighborIterator &
 DisulfResNeighbIterator::operator = ( ResidueNeighborIterator const & rhs)
 {
@@ -207,8 +205,6 @@ DisulfResNeighbConstIterator::DisulfResNeighbConstIterator(
 	focused_residue_( FullatomDisulfideEnergyContainer::NO_DISULFIDE ),
 	disulfide_index_( FullatomDisulfideEnergyContainer::NO_DISULFIDE )
 {}
-
-DisulfResNeighbConstIterator::~DisulfResNeighbConstIterator() = default;
 
 ResidueNeighborConstIterator &
 DisulfResNeighbConstIterator::operator = ( ResidueNeighborConstIterator const & rhs )

--- a/source/src/core/scoring/disulfides/FullatomDisulfideEnergyContainer.hh
+++ b/source/src/core/scoring/disulfides/FullatomDisulfideEnergyContainer.hh
@@ -44,7 +44,6 @@ namespace scoring {
 namespace disulfides {
 
 class DisulfResNeighbIterator : public ResidueNeighborIterator {
-	DisulfResNeighbIterator & operator = (DisulfResNeighbIterator const & );
 public:
 
 	DisulfResNeighbIterator(
@@ -57,7 +56,10 @@ public:
 		FullatomDisulfideEnergyContainer * owner
 	);
 
-	~DisulfResNeighbIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DisulfResNeighbIterator & operator = (DisulfResNeighbIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & ) override;
 	ResidueNeighborIterator const & operator ++ () override;
@@ -87,7 +89,6 @@ private:
 };
 
 class DisulfResNeighbConstIterator : public ResidueNeighborConstIterator {
-	DisulfResNeighbConstIterator & operator = (DisulfResNeighbConstIterator const & );
 public:
 	DisulfResNeighbConstIterator(
 		FullatomDisulfideEnergyContainer const * owner,
@@ -97,7 +98,10 @@ public:
 
 	DisulfResNeighbConstIterator( FullatomDisulfideEnergyContainer const * owner );
 
-	~DisulfResNeighbConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DisulfResNeighbConstIterator & operator = (DisulfResNeighbConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & ) override;
 	ResidueNeighborConstIterator const & operator ++ () override;


### PR DESCRIPTION
## Summary

- Remove user-declared trivial (defaulted) destructors from the six disulfide neighbor iterator classes; the implicit virtual destructor inherited from `ResidueNeighborIterator` / `ResidueNeighborConstIterator` does the same job.
- Modernize the old-style C++03 copy-assignment prevention (private undefined declaration) to a public `= delete` for the derived-type `operator=`. Behavior is unchanged: derived-derived assignment is still forbidden so all assignments flow through the polymorphic `operator=(BaseType const &)` override that downcasts and copies all members.

Touched: `CentroidDisulfideNeighborIterator`/`ConstIterator`, `DisulfideMatchingNeighborIterator`/`ConstIterator`, `DisulfResNeighbIterator`/`ConstIterator`.

## Test plan

- [x] Full release build (`scons mode=release bin`) passes with no errors
- [x] No external call sites reference the removed destructors or the deleted operator=