### PR TITLE
Apply Rule of Zero to BitSet and BitVector

### DIFF
--- a/source/src/utility/BitSet.hh
+++ b/source/src/utility/BitSet.hh
@@ -135,12 +135,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~BitSet()
-	{}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/BitVector.hh
+++ b/source/src/utility/BitVector.hh
@@ -147,12 +147,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~BitVector()
-	{}
-
-
 public: // Assignment
 
 


### PR DESCRIPTION
## Summary
- `utility::BitSet<B>` and `utility::BitVector<B>` each had only a single value-type member (`std::set<B>` and `std::vector<bool>` respectively), no user-declared copy/move/assignment operators, and an explicit empty destructor.
- The empty `~BitSet() {}` / `~BitVector() {}` did nothing the compiler-generated destructor wouldn't have done, and they suppressed the implicit move constructor and move assignment.
- Remove the empty destructors so both class templates follow the Rule of Zero and gain implicit move support.

## Test plan
- [x] `python3 ./scons.py -j16 mode=release bin` builds cleanly.
- [ ] CI: 90 standard tests.