### PR TITLE
Apply Rule of Zero to utility/keys container family

### DIFF
--- a/source/src/utility/keys/ClassKeyMap.hh
+++ b/source/src/utility/keys/ClassKeyMap.hh
@@ -108,19 +108,6 @@ public: // Types
 public: // Creation
 
 
-	/// @brief Default constructor
-	inline
-	ClassKeyMap()
-	= default;
-
-
-	/// @brief Copy constructor
-	inline
-	ClassKeyMap( ClassKeyMap const & a ) :
-		v_( a.v_ )
-	{}
-
-
 	/// @brief Iterator range constructor
 	template< typename InputIterator >
 	inline
@@ -136,24 +123,7 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~ClassKeyMap() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	ClassKeyMap &
-	operator =( ClassKeyMap const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements

--- a/source/src/utility/keys/ClassKeyVector.hh
+++ b/source/src/utility/keys/ClassKeyVector.hh
@@ -98,19 +98,6 @@ public: // Types
 public: // Creation
 
 
-	/// @brief Default constructor
-	inline
-	ClassKeyVector()
-	= default;
-
-
-	/// @brief Copy constructor
-	inline
-	ClassKeyVector( ClassKeyVector const & a ) :
-		v_( a.v_ )
-	{}
-
-
 	/// @brief Size constructor
 	inline
 	explicit
@@ -140,24 +127,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~ClassKeyVector() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	ClassKeyVector &
-	operator =( ClassKeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements

--- a/source/src/utility/keys/KeyVector.hh
+++ b/source/src/utility/keys/KeyVector.hh
@@ -89,12 +89,6 @@ public: // Types
 public: // Creation
 
 
-	/// @brief Default constructor
-	inline
-	KeyVector()
-	= default;
-
-
 	/// @brief Size constructor
 	inline
 	explicit
@@ -124,25 +118,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~KeyVector()
-	= default;
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	KeyVector &
-	operator =( KeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to elements

--- a/source/src/utility/keys/SmallKeyMap.hh
+++ b/source/src/utility/keys/SmallKeyMap.hh
@@ -111,15 +111,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Copy constructor
-	inline
-	SmallKeyMap( SmallKeyMap const & a ) :
-		v_( a.v_ ),
-		m_( a.m_ ),
-		u_( a.u_ )
-	{}
-
-
 	/// @brief Iterator range constructor
 	template< typename InputIterator >
 	inline
@@ -136,26 +127,7 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~SmallKeyMap() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	SmallKeyMap &
-	operator =( SmallKeyMap const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-			m_ = a.m_;
-			u_ = a.u_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform mapped value assignment to current elements

--- a/source/src/utility/keys/SmallKeyVector.hh
+++ b/source/src/utility/keys/SmallKeyVector.hh
@@ -105,15 +105,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Copy constructor
-	inline
-	SmallKeyVector( SmallKeyVector const & a ) :
-		v_( a.v_ ),
-		m_( a.m_ ),
-		u_( a.u_ )
-	{}
-
-
 	/// @brief Size constructor
 	inline
 	explicit
@@ -146,26 +137,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~SmallKeyVector() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	SmallKeyVector &
-	operator =( SmallKeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-			m_ = a.m_;
-			u_ = a.u_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements


### PR DESCRIPTION
## Summary

Applies Rule of Zero to five sibling key-container templates in `source/src/utility/keys/`:

- `ClassKeyMap`
- `ClassKeyVector`
- `KeyVector`
- `SmallKeyMap`
- `SmallKeyVector`

Each held only standard-container value-type members (a `Vector`, plus an `IndexMap` and a scalar `Index u_` in the `Small*` variants). Their user-declared destructors (empty body or `= default`), copy constructors, and copy-assignment operators were byte-for-byte equivalent to the implicit defaults the compiler would synthesize, so they were redundant.

Removing them lets the implicitly defaulted special-member-functions take over and, as a side effect, restores the implicit move constructor and move assignment that were previously suppressed by the user-declared copy operations. The explicit default constructors on `SmallKeyMap` and `SmallKeyVector` are kept because they value-initialize the scalar `Index u_`, which an implicit default would leave indeterminate. `ClassKeyMap` / `ClassKeyVector` / `KeyVector` previously had `= default` default constructors that are now also implicit.

Net: 5 files changed, 140 lines removed, 0 added.

## Test plan

- [x] Debug build: `cd source && python3 ./scons.py -j16 mode=debug` — completed with exit 0, no errors.
- [ ] Standard test suite (label `90 standard tests` requested).