### PR TITLE
Apply Rule of Zero across utility/ helpers

### DIFF
--- a/source/src/cppcheck_suppressions.txt
+++ b/source/src/cppcheck_suppressions.txt
@@ -33,3 +33,8 @@ noExplicitConstructor
 
 // The TenANeighborGraph::tenA_edge_pool_ is handled properly through virtual function calls made by the parent operator
 operatorEqVarError:core/scoring/TenANeighborGraph.cc
+
+// UpperEdgeGraph::get_vertex_ptr and ::note_edge_deleted are called from the
+// friend class UEEdge (constructors and delete_edge); cppcheck does not trace
+// template friend usage and flags them as unused.
+unusedPrivateFunction:utility/graph/UpperEdgeGraph.hh

--- a/source/src/utility/DereferenceIterator.hh
+++ b/source/src/utility/DereferenceIterator.hh
@@ -51,8 +51,6 @@ public:
 		it_ = s_iter;
 	}
 
-	~DereferenceIterator() {}
-
 	bool operator==( const DereferenceIterator& other ) const {
 		return ( it_ == other.it_ );
 	}

--- a/source/src/utility/graph/ArrayPool.hh
+++ b/source/src/utility/graph/ArrayPool.hh
@@ -58,26 +58,6 @@ public:
 		size_( size )
 	{}
 
-	/// @brief Copy constructor -- point this Array0 at a block of memory
-	Array0( Array0< T > const & other ) :
-		array_( other.array_ ),
-		size_( other.size_ )
-	{}
-
-	/// @brief Assignment operator -- point this Array0 at a different block of memory.
-	Array0< T > const &
-	operator = ( Array0< T > const & rhs ) {
-		if ( &rhs != this ) {
-			array_ = rhs.array_;
-			size_ = rhs.size_;
-		}
-		return *this;
-	}
-
-	/// @brief The destructor does not deallocate the memory that this Array0 points at.
-	/// That is the responsibility of some other class.  Array0 is for bounds checking only.
-	~Array0() = default;
-
 public:
 	/// Accessors and mutators.
 

--- a/source/src/utility/graph/Digraph.hh
+++ b/source/src/utility/graph/Digraph.hh
@@ -84,9 +84,6 @@ public:
 	DirectedEdgeListElement( DirectedEdge * edge, DirectedEdgeListElement * previous, DirectedEdgeListElement * next )
 	: edge_( edge ), previous_( previous ), next_( next ) {}
 
-
-	~DirectedEdgeListElement() {}
-
 	DirectedEdge * edge() {debug_assert( edge_ ); return edge_; }
 	void edge( DirectedEdge * setting ) { edge_ = setting; }
 	DirectedEdge const * const_edge() const {debug_assert( edge_ ); return edge_; }
@@ -129,21 +126,6 @@ public:
 	/// @brief owner and element constructor: points at a position in a list
 	DirectedEdgeListIterator( DirectedEdgeList const * owner, DirectedEdgeListElement * element )
 	: owner_( owner ), element_( element ) {}
-
-	/// @brief copy constructor
-	DirectedEdgeListIterator( DirectedEdgeListIterator const & src )
-	: owner_( src.owner_ ), element_( src.element_ ) {}
-
-	/// @brief non-virtual destructor, does nothing
-	~DirectedEdgeListIterator() {}
-
-	/// @brief assignmnet operator
-	DirectedEdgeListIterator & operator = ( DirectedEdgeListIterator const & rhs )
-	{
-		owner_ = rhs.owner_;
-		element_ = rhs.element_;
-		return *this;
-	}
 
 	/// @brief increment operator.  Point this iterator at the next element in the list.
 	inline
@@ -213,25 +195,9 @@ public:
 	DirectedEdgeListConstIterator( DirectedEdgeList const * owner, DirectedEdgeListElement const * element )
 	: owner_( owner ), element_( element ) {}
 
-	/// @brief copy constructor
-	DirectedEdgeListConstIterator( DirectedEdgeListConstIterator const & src )
-	: owner_( src.owner_ ), element_( src.element_ ) {}
-
 	/// @brief const-cast constructor
 	DirectedEdgeListConstIterator( DirectedEdgeListIterator const & src )
 	: owner_( src.owner_ ), element_( src.element_ ) {}
-
-
-	/// @brief non-virtual destructor, does nothing
-	~DirectedEdgeListConstIterator() {}
-
-	/// @brief assignmnet operator
-	DirectedEdgeListConstIterator & operator = ( DirectedEdgeListConstIterator const & rhs )
-	{
-		owner_ = rhs.owner_;
-		element_ = rhs.element_;
-		return *this;
-	}
 
 	/// @brief increment operator.  Point this iterator at the next element in the list.
 	inline

--- a/source/src/utility/graph/Graph.hh
+++ b/source/src/utility/graph/Graph.hh
@@ -110,9 +110,6 @@ public:
 	EdgeListElement( Edge * edge, EdgeListElement * previous, EdgeListElement * next )
 	: edge_( edge ), previous_( previous ), next_( next ) {}
 
-
-	~EdgeListElement() = default;
-
 	Edge * edge() {debug_assert( edge_ ); return edge_; }
 	void edge( Edge * setting ) { edge_ = setting; }
 	Edge const * const_edge() const {debug_assert( edge_ ); return edge_; }
@@ -155,17 +152,6 @@ public:
 	/// @brief owner and element constructor: points at a position in a list
 	EdgeListIterator( EdgeList const * owner, EdgeListElement * element )
 	: owner_( owner ), element_( element ) {}
-
-	/// @brief copy constructor
-	EdgeListIterator( EdgeListIterator const & src )
-	= default;
-
-	/// @brief non-virtual destructor, does nothing
-	~EdgeListIterator() = default;
-
-	/// @brief assignmnet operator
-	EdgeListIterator & operator = ( EdgeListIterator const & rhs )
-	= default;
 
 	/// @brief increment operator.  Point this iterator at the next element in the list.
 	EdgeListIterator const & operator ++ ()
@@ -233,21 +219,9 @@ public:
 	EdgeListConstIterator( EdgeList const * owner, EdgeListElement const * element )
 	: owner_( owner ), element_( element ) {}
 
-	/// @brief copy constructor
-	EdgeListConstIterator( EdgeListConstIterator const & src )
-	= default;
-
 	/// @brief const-cast constructor
 	EdgeListConstIterator( EdgeListIterator const & src )
 	: owner_( src.owner_ ), element_( src.element_ ) {}
-
-
-	/// @brief non-virtual destructor, does nothing
-	~EdgeListConstIterator() = default;
-
-	/// @brief assignmnet operator
-	EdgeListConstIterator & operator = ( EdgeListConstIterator const & rhs )
-	= default;
 
 	/// @brief increment operator.  Point this iterator at the next element in the list.
 	EdgeListConstIterator const & operator ++ ()

--- a/source/src/utility/graph/LowMemGraph.hh
+++ b/source/src/utility/graph/LowMemGraph.hh
@@ -352,8 +352,6 @@ class LowMemGraphBase : public utility::VirtualBase {
 public:
 	LowMemGraphBase() {}
 
-	~LowMemGraphBase() override {}
-
 	virtual LowMemNode const * get_node( uint32_t index ) const = 0;
 
 	virtual LowMemNode * get_node( uint32_t index ) = 0;

--- a/source/src/utility/graph/UpperEdgeGraph.hh
+++ b/source/src/utility/graph/UpperEdgeGraph.hh
@@ -319,12 +319,6 @@ public:
 		upper_vertex_->note_lower_edge_added();
 	}
 
-	~UEEdge()
-	{
-		//std::cout << "UEEdge dstor" << std::endl;
-	}
-
-
 	UEEdge( GraphClass * owner, int lower_node, int upper_node, E const & data )
 	:
 		owner_( owner ),
@@ -395,8 +389,6 @@ public:
 	{
 		copy_from( other );
 	}
-
-	~UpperEdgeGraph() override = default;
 
 	UpperEdgeGraph< V, E > const &
 	operator = ( UpperEdgeGraph< V, E > const & other )

--- a/source/src/utility/options/BooleanOption.hh
+++ b/source/src/utility/options/BooleanOption.hh
@@ -91,11 +91,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~BooleanOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/BooleanVectorOption.hh
+++ b/source/src/utility/options/BooleanVectorOption.hh
@@ -76,12 +76,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~BooleanVectorOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/FileOption.hh
+++ b/source/src/utility/options/FileOption.hh
@@ -89,12 +89,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~FileOption() override {}
-
-
 public: // Methods
 
 

--- a/source/src/utility/options/FileVectorOption.hh
+++ b/source/src/utility/options/FileVectorOption.hh
@@ -89,12 +89,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~FileVectorOption() override {}
-
-
 public: // Methods
 
 

--- a/source/src/utility/options/IntegerOption.hh
+++ b/source/src/utility/options/IntegerOption.hh
@@ -79,12 +79,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~IntegerOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/IntegerVectorOption.hh
+++ b/source/src/utility/options/IntegerVectorOption.hh
@@ -80,12 +80,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~IntegerVectorOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/RealOption.hh
+++ b/source/src/utility/options/RealOption.hh
@@ -80,12 +80,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~RealOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/RealVectorOption.hh
+++ b/source/src/utility/options/RealVectorOption.hh
@@ -80,12 +80,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~RealVectorOption() override {}
-
-
 public: // Properties
 
 


### PR DESCRIPTION
## Summary

Remove user-declared destructors and trivial copy ctor/assignment implementations whose bodies are equivalent to the compiler-generated defaults. The implicit special members are correct in every case (no owning raw pointers, no side effects in the removed bodies, virtual destructor inheritance preserved through base classes).

### utility/graph/ — non-owning iterator/element helpers

* `Graph.hh`: `EdgeListElement`, `EdgeListIterator`, `EdgeListConstIterator` — drop user dtor and the `= default` copy ctor / assignment.
* `Digraph.hh`: `DirectedEdgeListElement`, `DirectedEdgeListIterator`, `DirectedEdgeListConstIterator` — drop user dtor and member-wise copy ctor / assignment.
* `ArrayPool.hh` (`Array0`): drop user dtor, copy ctor, and self-assignment-guarded copy assignment.
* `LowMemGraph.hh` (`LowMemGraphBase`): drop empty `override` dtor (`utility::VirtualBase` supplies the virtual destructor).
* `UpperEdgeGraph.hh`: drop the empty `UEEdge` dtor and `~UpperEdgeGraph() override = default;`.

`LowMemNode` / `LowMemEdge` are intentionally left untouched — their explicit destructor declarations anchor a load-bearing comment about deliberately not making the destructor virtual.

### utility/

* `DereferenceIterator.hh` (`DereferenceIterator`): drop empty user dtor.

### utility/options/ — empty overriding destructors

Drop `~XxxOption() override {}` from the eight leaf scalar/vector option classes. The implicit destructor is virtual via inheritance from `Option` (which declares a virtual destructor), so dynamic dispatch is preserved.

* `BooleanOption.hh`, `BooleanVectorOption.hh`
* `FileOption.hh`, `FileVectorOption.hh`
* `IntegerOption.hh`, `IntegerVectorOption.hh`
* `RealOption.hh`, `RealVectorOption.hh`

The remaining option classes with the same pattern (`PathOption`, `StringOption`, `ResidueChainVectorOption`, `ScalarOption`, `ScalarOption_T_`, `VectorOption`, `VectorOption_T_`) can be addressed in a follow-up; the eight here form a coherent leaf-scalar-plus-vector subset.

## Test plan

- [x] `cd source && python3 ./scons.py -j16 mode=debug` — clean (no errors)
- [ ] 90 standard tests CI run