### PR TITLE
Apply Rule of Zero across utility/options/ empty destructors

### DIFF
--- a/source/src/utility/options/AnyOption.hh
+++ b/source/src/utility/options/AnyOption.hh
@@ -93,12 +93,6 @@ public: // Creation
 	clone() const = 0;
 
 
-	/// @brief Destructor
-	inline
-	virtual
-	~AnyOption() {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/AnyVectorOption.hh
+++ b/source/src/utility/options/AnyVectorOption.hh
@@ -87,12 +87,6 @@ public: // Creation
 	clone() const = 0;
 
 
-	/// @brief Destructor
-	inline
-	virtual
-	~AnyVectorOption() {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/PathOption.hh
+++ b/source/src/utility/options/PathOption.hh
@@ -89,12 +89,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~PathOption() override {}
-
-
 public: // Methods
 
 

--- a/source/src/utility/options/PathVectorOption.hh
+++ b/source/src/utility/options/PathVectorOption.hh
@@ -89,12 +89,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~PathVectorOption() override {}
-
-
 public: // Methods
 
 

--- a/source/src/utility/options/ResidueChainVectorOption.hh
+++ b/source/src/utility/options/ResidueChainVectorOption.hh
@@ -83,12 +83,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~ResidueChainVectorOption() override {}
-
-
 public: // copying
 
 

--- a/source/src/utility/options/ScalarOption.hh
+++ b/source/src/utility/options/ScalarOption.hh
@@ -68,12 +68,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-
-	~ScalarOption() override {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/ScalarOption_T_.hh
+++ b/source/src/utility/options/ScalarOption_T_.hh
@@ -139,12 +139,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-
-	~ScalarOption_T_() override {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/StringOption.hh
+++ b/source/src/utility/options/StringOption.hh
@@ -76,12 +76,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~StringOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/StringVectorOption.hh
+++ b/source/src/utility/options/StringVectorOption.hh
@@ -76,12 +76,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-
-	~StringVectorOption() override {}
-
-
 public: // Properties
 
 

--- a/source/src/utility/options/VectorOption.hh
+++ b/source/src/utility/options/VectorOption.hh
@@ -68,12 +68,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-
-	~VectorOption() override {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/VectorOption_T_.hh
+++ b/source/src/utility/options/VectorOption_T_.hh
@@ -147,12 +147,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-
-	~VectorOption_T_() override {}
-
-
 protected: // Assignment
 
 

--- a/source/src/utility/options/keys/AnyOptionKey.hh
+++ b/source/src/utility/options/keys/AnyOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~AnyOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/AnyVectorOptionKey.hh
+++ b/source/src/utility/options/keys/AnyVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~AnyVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/BooleanOptionKey.hh
+++ b/source/src/utility/options/keys/BooleanOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~BooleanOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/BooleanVectorOptionKey.hh
+++ b/source/src/utility/options/keys/BooleanVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~BooleanVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/FileOptionKey.hh
+++ b/source/src/utility/options/keys/FileOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~FileOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/FileVectorOptionKey.hh
+++ b/source/src/utility/options/keys/FileVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~FileVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/IntegerOptionKey.hh
+++ b/source/src/utility/options/keys/IntegerOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~IntegerOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/IntegerVectorOptionKey.hh
+++ b/source/src/utility/options/keys/IntegerVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~IntegerVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/OptionKey.hh
+++ b/source/src/utility/options/keys/OptionKey.hh
@@ -129,11 +129,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-	~OptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/PathOptionKey.hh
+++ b/source/src/utility/options/keys/PathOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~PathOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/PathVectorOptionKey.hh
+++ b/source/src/utility/options/keys/PathVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~PathVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/RealOptionKey.hh
+++ b/source/src/utility/options/keys/RealOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~RealOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/RealVectorOptionKey.hh
+++ b/source/src/utility/options/keys/RealVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~RealVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/ResidueChainVectorOptionKey.hh
+++ b/source/src/utility/options/keys/ResidueChainVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~ResidueChainVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/ScalarOptionKey.hh
+++ b/source/src/utility/options/keys/ScalarOptionKey.hh
@@ -106,11 +106,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-	~ScalarOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/StringOptionKey.hh
+++ b/source/src/utility/options/keys/StringOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~StringOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/StringVectorOptionKey.hh
+++ b/source/src/utility/options/keys/StringVectorOptionKey.hh
@@ -121,11 +121,6 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~StringVectorOptionKey() override {}
-
-
 public: // Assignment
 
 

--- a/source/src/utility/options/keys/VectorOptionKey.hh
+++ b/source/src/utility/options/keys/VectorOptionKey.hh
@@ -106,11 +106,6 @@ public: // Creation
 	clone() const override = 0;
 
 
-	/// @brief Destructor
-	inline
-	~VectorOptionKey() override {}
-
-
 public: // Assignment
 
 


### PR DESCRIPTION
## Summary

Drop user-declared empty destructors from the `utility/options/` and `utility/options/keys/` class hierarchies. The implicit destructor preserves virtual dispatch in every case via inherited virtual destructors:

- All option classes inherit (transitively) from `utility::options::Option`, which declares `virtual ~Option()`.
- All option-key classes inherit (transitively) from `utility::keys::Key`, which declares `virtual ~Key()`.

No class touched here owns a raw resource, declares a non-trivial destructor body, or has a user-declared copy/move that would suppress the implicit destructor.

### `utility/options/` — abstract bases and remaining leaf option classes

* Abstract / templated bases: `ScalarOption`, `ScalarOption_T_`, `VectorOption`, `VectorOption_T_`, `AnyOption`, `AnyVectorOption`.
* Leaf options: `PathOption`, `PathVectorOption`, `StringOption`, `StringVectorOption`, `ResidueChainVectorOption`.

`AnyOption` / `AnyVectorOption` used the `virtual` keyword on the empty body; the rest used `override {}`. Both forms are equivalent to the implicit virtual destructor here.

### `utility/options/keys/` — base + 16 leaf key types

* Base: `OptionKey`.
* Leaves: `AnyOptionKey`, `AnyVectorOptionKey`, `BooleanOptionKey`, `BooleanVectorOptionKey`, `FileOptionKey`, `FileVectorOptionKey`, `IntegerOptionKey`, `IntegerVectorOptionKey`, `PathOptionKey`, `PathVectorOptionKey`, `RealOptionKey`, `RealVectorOptionKey`, `ResidueChainVectorOptionKey`, `ScalarOptionKey`, `StringOptionKey`, `StringVectorOptionKey`, `VectorOptionKey`.

This is the natural follow-up to #692, which intentionally deferred this batch. With this PR, the entire `utility/options*` empty-virtual-destructor pattern is cleaned up.

29 files, 156 deletions, 0 additions. Debug build clean.