### PR TITLE
Fix off-by-one bugs in 1-indexed loops over pose residues

### DIFF
--- a/source/src/core/pack/task/PackerTask_.cc
+++ b/source/src/core/pack/task/PackerTask_.cc
@@ -676,7 +676,7 @@ PackerTask_::show( std::ostream & out ) const {
 
 	//sml pymol-style selection, great for debugging
 	if ( basic::options::option[ basic::options::OptionKeys::packing::print_pymol_selection ].value() ) {
-		for ( Size i=1, it_end = total_residue(); i != it_end; ++i ) if ( pack_residue(i) ) out << i << "+";
+		for ( Size i=1, it_end = total_residue(); i <= it_end; ++i ) if ( pack_residue(i) ) out << i << "+";
 		out << std::endl;
 	}
 }

--- a/source/src/protocols/denovo_design/components/StructureData.cc
+++ b/source/src/protocols/denovo_design/components/StructureData.cc
@@ -2115,7 +2115,7 @@ utility::vector1< core::Size >
 compute_cutpoints( core::pose::Pose const & pose )
 {
 	utility::vector1< core::Size > cutpoints;
-	for ( core::Size resid=1; resid!=pose.size(); ++resid ) {
+	for ( core::Size resid=1; resid<=pose.size(); ++resid ) {
 		if ( pose.residue( resid ).has_variant_type( core::chemical::CUTPOINT_LOWER ) ) {
 			cutpoints.push_back( resid );
 			if ( ( resid < pose.size() ) && !pose.residue( resid + 1 ).has_variant_type( core::chemical::CUTPOINT_UPPER ) ) {

--- a/source/src/protocols/enzdes/BackboneSampler.cc
+++ b/source/src/protocols/enzdes/BackboneSampler.cc
@@ -153,7 +153,7 @@ BackboneSampler::apply( Pose & pose )
 	mc.reset( pose );
 
 	TR << "Running " << bb_moves_ << " trials..." << std::endl;
-	for ( core::Size ii =1; ii != bb_moves_; ++ii ) {
+	for ( core::Size ii =1; ii <= bb_moves_; ++ii ) {
 		bbg8t3amover.apply( pose );
 		mc.boltzmann( pose, bbg8t3amover.type() );
 	}

--- a/source/src/protocols/fldsgn/BluePrintBDR.cc
+++ b/source/src/protocols/fldsgn/BluePrintBDR.cc
@@ -519,7 +519,7 @@ bool BluePrintBDR::centroid_build(
 	// ensure modified_archive_pose is completely full-atom, otherwise mismatch
 	// will occur when restoring sidechains at the end of the procedure
 	bool mod_ap_is_full_atom = true;
-	for ( core::Size i = 1, ie = modified_archive_pose.size(); mod_ap_is_full_atom && i != ie; ++i ) {
+	for ( core::Size i = 1, ie = modified_archive_pose.size(); mod_ap_is_full_atom && i <= ie; ++i ) {
 		mod_ap_is_full_atom &= ( modified_archive_pose.residue( i ).type().mode() == core::chemical::FULL_ATOM_t );
 	}
 

--- a/source/src/protocols/forge/components/BDR.cc
+++ b/source/src/protocols/forge/components/BDR.cc
@@ -281,7 +281,7 @@ bool BDR::centroid_build(
 	// ensure modified_archive_pose is completely full-atom, otherwise mismatch
 	// will occur when restoring sidechains at the end of the procedure
 	bool mod_ap_is_full_atom = true;
-	for ( core::Size i = 1, ie = modified_archive_pose.size(); mod_ap_is_full_atom && i != ie; ++i ) {
+	for ( core::Size i = 1, ie = modified_archive_pose.size(); mod_ap_is_full_atom && i <= ie; ++i ) {
 		mod_ap_is_full_atom &= ( modified_archive_pose.residue( i ).type().mode() == core::chemical::FULL_ATOM_t );
 	}
 
@@ -399,7 +399,7 @@ bool BDR::design_refine(
 		RestrictResidueToRepackingOP repack_op( new RestrictResidueToRepacking() );
 
 		Positions new_positions = manager_.new_positions();
-		for ( core::Size i = 1, ie = pose.size(); i != ie; ++i ) {
+		for ( core::Size i = 1, ie = pose.size(); i <= ie; ++i ) {
 			if ( new_positions.find( i ) == new_positions.end() ) {
 				repack_op->include_residue( i );
 			}


### PR DESCRIPTION
## Summary

Replace \`i != end\` with \`i <= end\` (or \`i != size()\` with \`i <= size()\`) in several loops that iterate over 1-indexed residue ranges. With the old condition, the last residue (index == end) was silently skipped.

* \`core/pack/task/PackerTask_.cc\`: pymol-style debug selection output omitted the last residue.
* \`protocols/forge/components/BDR.cc\`:
  - the full-atom check used to gate \`switch_to_residue_type_set\` skipped the last residue, so a non-full-atom last residue could bypass conversion and later cause sidechain-restore mismatch (the precise failure the surrounding comment warns about).
  - the loop building the \`RestrictResidueToRepacking\` operation skipped the last residue, so a C-terminal residue outside \`new_positions\` was designed instead of repack-only.
* \`protocols/fldsgn/BluePrintBDR.cc\`: same full-atom check bug as in \`BDR.cc\`.
* \`protocols/denovo_design/components/StructureData.cc\`: \`compute_cutpoints\` skipped the last residue, dropping a \`CUTPOINT_LOWER\` variant on the C-terminal residue.
* \`protocols/enzdes/BackboneSampler.cc\`: the user-requested number of backbone-Monte-Carlo trials was off by one (e.g. \`bb_moves_=1000\` actually ran 999 trials, in contradiction with the \"Running N trials...\" log line printed just above).

These are all instances of the same pattern: a 1-indexed loop using \`!=\` against a one-past-the-last bound that was actually meant to be the last valid index. Each loop body uses the index directly to access pose data, so the fix is to switch the comparison to \`<=\`.