### PR TITLE
Fix incorrect comparison logic in operator< / difference_from

### DIFF
--- a/source/src/core/chemical/gasteiger/GasteigerAtomTypeData.cc
+++ b/source/src/core/chemical/gasteiger/GasteigerAtomTypeData.cc
@@ -751,6 +751,10 @@ GasteigerAtomTypeData::TypeDifference GasteigerAtomTypeData::difference_from( co
 		return None;
 	}
 
+	// Two atom types are "fundamentally different" (TypeDifference::Other) if any
+	// of charge / element / hybridization differ. The lone-pair / s-orbital /
+	// p-orbital classification below assumes these three are equal and uses
+	// `charge_` as a shared reference value, so this early-out is required.
 	if ( charge_ != OTHER.charge_ || element_type_ != OTHER.element_type_ || hybridization_ != OTHER.hybridization_ ) {
 		return Other;
 	}

--- a/source/src/core/chemical/gasteiger/GasteigerAtomTypeData.cc
+++ b/source/src/core/chemical/gasteiger/GasteigerAtomTypeData.cc
@@ -751,7 +751,7 @@ GasteigerAtomTypeData::TypeDifference GasteigerAtomTypeData::difference_from( co
 		return None;
 	}
 
-	if ( charge_ == OTHER.charge_ || element_type_ != OTHER.element_type_ || hybridization_ != OTHER.hybridization_ ) {
+	if ( charge_ != OTHER.charge_ || element_type_ != OTHER.element_type_ || hybridization_ != OTHER.hybridization_ ) {
 		return Other;
 	}
 

--- a/source/src/core/chemical/sdf/mol_util.cc
+++ b/source/src/core/chemical/sdf/mol_util.cc
@@ -15,6 +15,7 @@
 #include <utility/string_util.hh>
 #include <map>
 #include <set>
+#include <tuple>
 #include <core/types.hh>
 
 namespace core {
@@ -35,7 +36,7 @@ BondData::BondData(core::Size index1, core::Size index2, core::Size type)
 
 bool BondData::operator <(const core::chemical::sdf::BondData & other) const
 {
-	return (this->lower < other.lower) || (this->upper < other.upper);
+	return std::tie( lower, upper ) < std::tie( other.lower, other.upper );
 }
 
 bool BondData::operator ==(const core::chemical::sdf::BondData& other) const

--- a/source/src/core/chemical/sdf/mol_util.cc
+++ b/source/src/core/chemical/sdf/mol_util.cc
@@ -36,6 +36,9 @@ BondData::BondData(core::Size index1, core::Size index2, core::Size type)
 
 bool BondData::operator <(const core::chemical::sdf::BondData & other) const
 {
+	// Lexicographic compare. Do NOT replace with `(lower<o.lower) || (upper<o.upper)`:
+	// that form violates strict weak ordering (e.g. (5,1) and (3,7) each compare less
+	// than the other), which breaks std::set<BondData> in parse_bond_type_data().
 	return std::tie( lower, upper ) < std::tie( other.lower, other.upper );
 }
 

--- a/source/src/core/io/StructFileReaderOptions.cc
+++ b/source/src/core/io/StructFileReaderOptions.cc
@@ -136,20 +136,20 @@ StructFileReaderOptions::operator == ( StructFileReaderOptions const & other ) c
 bool
 StructFileReaderOptions::operator < ( StructFileReaderOptions const & other ) const
 {
-	if ( StructFileRepOptions::operator< ( other ) ) return true;
-	if ( StructFileRepOptions::operator== ( other ) ) return false;
+	if (   StructFileRepOptions::operator<  ( other ) ) return true;
+	if ( ! StructFileRepOptions::operator== ( other ) ) return false;
 
-	if ( new_chain_order_ <  other.new_chain_order_ ) return true;
-	if ( new_chain_order_ == other.new_chain_order_ ) return false;
-	if ( obey_ENDMDL_ <  other.obey_ENDMDL_  ) return true;
-	if ( obey_ENDMDL_ == other.obey_ENDMDL_  ) return false;
-	if ( read_pdb_header_ <  other.read_pdb_header_  ) return true;
-	if ( read_pdb_header_ == other.read_pdb_header_  ) return false;
-	if ( glycam_pdb_format_ <  other.glycam_pdb_format_  ) return true;
-	if ( mmtf_extra_data_io_ < other.mmtf_extra_data_io_ ) return true;
-	if ( mmtf_extra_data_io_ == other.mmtf_extra_data_io_ ) return false;
+	if ( new_chain_order_      <  other.new_chain_order_      ) return true;
+	if ( new_chain_order_      != other.new_chain_order_      ) return false;
+	if ( obey_ENDMDL_          <  other.obey_ENDMDL_          ) return true;
+	if ( obey_ENDMDL_          != other.obey_ENDMDL_          ) return false;
+	if ( read_pdb_header_      <  other.read_pdb_header_      ) return true;
+	if ( read_pdb_header_      != other.read_pdb_header_      ) return false;
+	if ( glycam_pdb_format_    <  other.glycam_pdb_format_    ) return true;
+	if ( glycam_pdb_format_    != other.glycam_pdb_format_    ) return false;
+	if ( mmtf_extra_data_io_   <  other.mmtf_extra_data_io_   ) return true;
+	if ( mmtf_extra_data_io_   != other.mmtf_extra_data_io_   ) return false;
 
-	//if ( glycam_pdb_format_ == other.glycam_pdb_format_  ) return false;
 	return false;
 
 }

--- a/source/src/core/io/StructFileReaderOptions.cc
+++ b/source/src/core/io/StructFileReaderOptions.cc
@@ -136,6 +136,10 @@ StructFileReaderOptions::operator == ( StructFileReaderOptions const & other ) c
 bool
 StructFileReaderOptions::operator < ( StructFileReaderOptions const & other ) const
 {
+	// Lexicographic compare. The pattern is: for each tier, return true on `<`,
+	// return false on `!=` (i.e. on `>`), otherwise fall through to the next tier.
+	// Using `==` for the second check (the original form) returns false on equality
+	// and short-circuits before later tiers are ever consulted -- breaks ordering.
 	if (   StructFileRepOptions::operator<  ( other ) ) return true;
 	if ( ! StructFileRepOptions::operator== ( other ) ) return false;
 

--- a/source/src/core/scoring/motif/motif_hash_stuff.cc
+++ b/source/src/core/scoring/motif/motif_hash_stuff.cc
@@ -259,6 +259,8 @@ char ResPairMotif::ss2  () const { if ( ss2_=='H'||ss2_=='I'||ss2_=='G' ) return
 char ResPairMotif::dssp1() const { return ss1_; }
 char ResPairMotif::dssp2() const { return ss2_; }
 bool ResPairMotif::operator < (ResPairMotif const & other) const {
+	// memcmp returns negative when *this is byte-wise less than other; the
+	// original form `0 < memcmp(...)` was the inverted predicate (greater-than).
 	return memcmp(this,&other,sizeof(ResPairMotif)) < 0;
 }
 bool ResPairMotif::operator ==(ResPairMotif const & other) const {

--- a/source/src/core/scoring/motif/motif_hash_stuff.cc
+++ b/source/src/core/scoring/motif/motif_hash_stuff.cc
@@ -259,7 +259,7 @@ char ResPairMotif::ss2  () const { if ( ss2_=='H'||ss2_=='I'||ss2_=='G' ) return
 char ResPairMotif::dssp1() const { return ss1_; }
 char ResPairMotif::dssp2() const { return ss2_; }
 bool ResPairMotif::operator < (ResPairMotif const & other) const {
-	return 0 <  memcmp(this,&other,sizeof(ResPairMotif));
+	return memcmp(this,&other,sizeof(ResPairMotif)) < 0;
 }
 bool ResPairMotif::operator ==(ResPairMotif const & other) const {
 	return 0 == memcmp(this,&other,sizeof(ResPairMotif));


### PR DESCRIPTION
## Summary

Four independent classes had broken comparison logic that violated either the contract of \`operator<\` (strict weak ordering) or the intended semantics of \`difference_from\`. Each is a separate, surgical fix bundled into a single PR because they all share the same \"comparison-operator misuse\" theme.

* **\`core/chemical/sdf/mol_util.cc\`** — \`BondData::operator<\` was \`(lower < other.lower) || (upper < other.upper)\`. This is not a strict weak ordering: for example, \`(5, 1)\` and \`(3, 7)\` each compare less than the other, breaking antisymmetry. \`BondData\` is held in \`std::set<BondData>\` (see \`parse_bond_type_data\`), so the broken ordering directly affects the set. Replaced with a proper lexicographic compare via \`std::tie\`.

* **\`core/scoring/motif/motif_hash_stuff.cc\`** — \`ResPairMotif::operator<\` returned \`0 < memcmp(...)\`, which is true exactly when \`memcmp\` says *this > other*; the comparison was inverted. Switched to \`memcmp(...) < 0\` (matches \`MotifHit::operator<\` in the same file).

* **\`core/io/StructFileReaderOptions.cc\`** — \`operator<\` used \`==\` instead of \`!=\` for the short-circuit \`return false\` lines. The intended pattern (used correctly by the parent \`StructFileRepOptions::operator<\` and by \`ImportPoseOptions::operator<\`) is \`if a < b return true; if a != b return false; // fall through\`. The \`==\` form returns false when members are equal, short-circuiting before the rest of the members are compared, *and* falls through when one member is greater. Fixed every \`==\` to \`!=\` and added the missing \`!=\` follow-up after \`glycam_pdb_format_\`.

* **\`core/chemical/gasteiger/GasteigerAtomTypeData.cc\`** — \`difference_from\` short-circuited \`return Other\` when \`charge_ == OTHER.charge_ || element_type_ != ... || ...\`. The first clause is inverted: the function should return \`Other\` when fundamental properties *differ*, not when they match. The bug also made the lone-pair / s-orbital / p-orbital classification logic below this check unreachable for any two types with equal charge. Fixed \`==\` to \`!=\`.