### PR TITLE
Apply Rule of Zero to old-style uncopyable classes in core/ and protocols/

### DIFF
--- a/source/src/core/chemical/rotamers/RotamerLibrarySpecificationFactory.hh
+++ b/source/src/core/chemical/rotamers/RotamerLibrarySpecificationFactory.hh
@@ -57,8 +57,6 @@ private:
 
 private:
 	RotamerLibrarySpecificationFactory();
-	RotamerLibrarySpecificationFactory( RotamerLibrarySpecificationFactory const & ); // unimplemented
-	RotamerLibrarySpecificationFactory const & operator = ( RotamerLibrarySpecificationFactory const & ); // unimplemented
 
 private:
 	typedef std::map< std::string, RotamerLibrarySpecificationCreatorOP > CreatorMap;

--- a/source/src/core/pack/dunbrack/RotamerLibrary.hh
+++ b/source/src/core/pack/dunbrack/RotamerLibrary.hh
@@ -366,9 +366,6 @@ private:
 	void
 	initialize_from_options( utility::options::OptionCollection const & options );
 
-	RotamerLibrary( RotamerLibrary const & ); // unimplemented
-	RotamerLibrary const & operator = ( RotamerLibrary const & ); // unimplemented
-
 private:
 
 	//////////////////////////

--- a/source/src/core/pack/dunbrack/cenrot/CenrotLibrary.hh
+++ b/source/src/core/pack/dunbrack/cenrot/CenrotLibrary.hh
@@ -79,8 +79,6 @@ private:
 private:
 
 	CenrotLibrary();
-	CenrotLibrary( CenrotLibrary const & ); // unimplemented
-	CenrotLibrary const & operator = ( CenrotLibrary const & ); // unimplemented
 
 private:
 

--- a/source/src/core/pack/interaction_graph/DensePDInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/DensePDInteractionGraph.hh
@@ -174,10 +174,10 @@ private:
 
 	bool alternate_state_is_being_considered_;
 
-	//no default constructor, uncopyable
-	DensePDNode();
-	DensePDNode( DensePDNode const & );
-	DensePDNode & operator = ( DensePDNode const & );
+public:
+	DensePDNode() = delete;
+	DensePDNode( DensePDNode const & ) = delete;
+	DensePDNode & operator = ( DensePDNode const & ) = delete;
 };
 
 class DensePDEdge : public PrecomputedPairEnergiesEdge
@@ -261,10 +261,10 @@ private:
 	core::PackerEnergy curr_state_energy_;
 	bool energies_updated_since_last_prep_for_simA_;
 
-	//no default constructor, uncopyable
-	DensePDEdge();
-	DensePDEdge( DensePDEdge const & );
-	DensePDEdge & operator = ( DensePDEdge const & );
+public:
+	DensePDEdge() = delete;
+	DensePDEdge( DensePDEdge const & ) = delete;
+	DensePDEdge & operator = ( DensePDEdge const & ) = delete;
 };
 
 class DensePDInteractionGraph : public PrecomputedPairEnergiesInteractionGraph
@@ -372,10 +372,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	DensePDInteractionGraph();
-	DensePDInteractionGraph( DensePDInteractionGraph const & );
-	DensePDInteractionGraph & operator = ( DensePDInteractionGraph const & );
+public:
+	DensePDInteractionGraph() = delete;
+	DensePDInteractionGraph( DensePDInteractionGraph const & ) = delete;
+	DensePDInteractionGraph & operator = ( DensePDInteractionGraph const & ) = delete;
 };
 
 inline

--- a/source/src/core/pack/interaction_graph/DoubleDensePDInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/DoubleDensePDInteractionGraph.hh
@@ -125,10 +125,10 @@ private:
 
 	bool alternate_state_is_being_considered_;
 
-	//no default constructor, uncopyable
-	DoubleDensePDNode();
-	DoubleDensePDNode( DoubleDensePDNode const & );
-	DoubleDensePDNode & operator = ( DoubleDensePDNode const & );
+public:
+	DoubleDensePDNode() = delete;
+	DoubleDensePDNode( DoubleDensePDNode const & ) = delete;
+	DoubleDensePDNode & operator = ( DoubleDensePDNode const & ) = delete;
 };
 
 class DoubleDensePDEdge : public PrecomputedPairEnergiesEdge
@@ -200,10 +200,10 @@ private:
 	core::PackerEnergy curr_state_energy_;
 	bool energies_updated_since_last_prep_for_simA_;
 
-	//no default constructor, uncopyable
-	DoubleDensePDEdge();
-	DoubleDensePDEdge( DoubleDensePDEdge const & );
-	DoubleDensePDEdge & operator = ( DoubleDensePDEdge const & );
+public:
+	DoubleDensePDEdge() = delete;
+	DoubleDensePDEdge( DoubleDensePDEdge const & ) = delete;
+	DoubleDensePDEdge & operator = ( DoubleDensePDEdge const & ) = delete;
 };
 
 class DoubleDensePDInteractionGraph : public PrecomputedPairEnergiesInteractionGraph
@@ -273,10 +273,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	DoubleDensePDInteractionGraph();
-	DoubleDensePDInteractionGraph( DoubleDensePDInteractionGraph const & );
-	DoubleDensePDInteractionGraph & operator = ( DoubleDensePDInteractionGraph const & );
+public:
+	DoubleDensePDInteractionGraph() = delete;
+	DoubleDensePDInteractionGraph( DoubleDensePDInteractionGraph const & ) = delete;
+	DoubleDensePDInteractionGraph & operator = ( DoubleDensePDInteractionGraph const & ) = delete;
 };
 
 /// @brief returns the change in energy that would be induced by switching this node

--- a/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.cc
+++ b/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.cc
@@ -62,8 +62,7 @@ DoubleLazyNode::DoubleLazyNode(
 	alternate_state_( 0 ),
 	alternate_state_one_body_energy_( 0 ),
 	alternate_state_total_energy_( 0 ),
-	alternate_state_is_being_considered_( false ),
-	procrastinated_( false )
+	alternate_state_is_being_considered_( false )
 {
 }
 

--- a/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.hh
@@ -178,10 +178,10 @@ private:
 	bool alternate_state_is_being_considered_;
 	bool procrastinated_;
 
-	//no default constructor, uncopyable
-	DoubleLazyNode();
-	DoubleLazyNode( DoubleLazyNode const & );
-	DoubleLazyNode & operator = ( DoubleLazyNode const & );
+public:
+	DoubleLazyNode() = delete;
+	DoubleLazyNode( DoubleLazyNode const & ) = delete;
+	DoubleLazyNode & operator = ( DoubleLazyNode const & ) = delete;
 
 };
 
@@ -380,10 +380,10 @@ private:
 	// prepare_for_simulated_annealing
 	int edge_index_;
 
-	//no default constructor, uncopyable
-	DoubleLazyEdge();
-	DoubleLazyEdge( DoubleLazyEdge const & );
-	DoubleLazyEdge & operator = ( DoubleLazyEdge const & );
+public:
+	DoubleLazyEdge() = delete;
+	DoubleLazyEdge( DoubleLazyEdge const & ) = delete;
+	DoubleLazyEdge & operator = ( DoubleLazyEdge const & ) = delete;
 
 };
 
@@ -527,10 +527,10 @@ private:
 	utility::vector0< DoubleLazyEdge * > dlazy_edge_vector_;
 	mutable InPlaceIntListOP aa_submatrix_history_list_;
 
-	//no default constructor, uncopyable
-	DoubleLazyInteractionGraph();
-	DoubleLazyInteractionGraph( DoubleLazyInteractionGraph const & );
-	DoubleLazyInteractionGraph & operator = ( DoubleLazyInteractionGraph const & );
+public:
+	DoubleLazyInteractionGraph() = delete;
+	DoubleLazyInteractionGraph( DoubleLazyInteractionGraph const & ) = delete;
+	DoubleLazyInteractionGraph & operator = ( DoubleLazyInteractionGraph const & ) = delete;
 
 };
 

--- a/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/DoubleLazyInteractionGraph.hh
@@ -176,7 +176,6 @@ private:
 	std::vector< core::PackerEnergy > alternate_state_two_body_energies_;
 
 	bool alternate_state_is_being_considered_;
-	bool procrastinated_;
 
 public:
 	DoubleLazyNode() = delete;

--- a/source/src/core/pack/interaction_graph/FASTERInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/FASTERInteractionGraph.hh
@@ -189,10 +189,10 @@ private:
 	std::vector< bool > neighbor_relaxed_in_sBR_;
 	std::vector< core::PackerEnergy > perturbed_two_body_energies_;
 
-	//no default constructor, uncopyable
-	FASTERNode();
-	FASTERNode( FASTERNode const & );
-	FASTERNode & operator = ( FASTERNode const & );
+public:
+	FASTERNode() = delete;
+	FASTERNode( FASTERNode const & ) = delete;
+	FASTERNode & operator = ( FASTERNode const & ) = delete;
 };
 
 class FASTEREdge : public PrecomputedPairEnergiesEdge
@@ -313,10 +313,10 @@ private:
 
 private:
 	// Unimplemented functions
-	//no default constructor, uncopyable
-	FASTEREdge();
-	FASTEREdge( FASTEREdge const & );
-	FASTEREdge & operator = ( FASTEREdge const & );
+public:
+	FASTEREdge() = delete;
+	FASTEREdge( FASTEREdge const & ) = delete;
+	FASTEREdge & operator = ( FASTEREdge const & ) = delete;
 };
 
 class FASTERInteractionGraph : public PrecomputedPairEnergiesInteractionGraph
@@ -432,10 +432,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	FASTERInteractionGraph();
-	FASTERInteractionGraph( FASTERInteractionGraph const & );
-	FASTERInteractionGraph & operator = ( FASTERInteractionGraph const & );
+public:
+	FASTERInteractionGraph() = delete;
+	FASTERInteractionGraph( FASTERInteractionGraph const & ) = delete;
+	FASTERInteractionGraph & operator = ( FASTERInteractionGraph const & ) = delete;
 };
 
 inline

--- a/source/src/core/pack/interaction_graph/InteractionGraphBase.hh
+++ b/source/src/core/pack/interaction_graph/InteractionGraphBase.hh
@@ -182,10 +182,10 @@ private:
 	bool edge_vector_up_to_date_;
 	InteractionGraphBase* owner_;
 
-	//no default constructor, uncopyable
-	NodeBase();
-	NodeBase( NodeBase const & );
-	NodeBase & operator = ( NodeBase & );
+public:
+	NodeBase() = delete;
+	NodeBase( NodeBase const & ) = delete;
+	NodeBase & operator = ( NodeBase const & ) = delete;
 };
 
 class EdgeBase
@@ -311,10 +311,10 @@ private:
 	bool marked_for_deletion_ = false;
 
 
-	//no default constructor, uncopyable
-	EdgeBase();
-	EdgeBase( EdgeBase const & );
-	EdgeBase & operator = ( EdgeBase & );
+public:
+	EdgeBase() = delete;
+	EdgeBase( EdgeBase const & ) = delete;
+	EdgeBase & operator = ( EdgeBase const & ) = delete;
 
 };
 
@@ -550,10 +550,10 @@ private:
 	ObjexxFCL::FArray2D_bool energy_sum_group_membership_;
 	ObjexxFCL::FArray1D_int component_membership_;
 
-	//no default constructor, uncopyable
-	InteractionGraphBase();
-	InteractionGraphBase( InteractionGraphBase const &);
-	InteractionGraphBase & operator = (InteractionGraphBase const & );
+public:
+	InteractionGraphBase() = delete;
+	InteractionGraphBase( InteractionGraphBase const & ) = delete;
+	InteractionGraphBase & operator = ( InteractionGraphBase const & ) = delete;
 };
 
 } //end namespace interaction_graph

--- a/source/src/core/pack/interaction_graph/LazyInteractionGraph.cc
+++ b/source/src/core/pack/interaction_graph/LazyInteractionGraph.cc
@@ -57,8 +57,7 @@ LazyNode::LazyNode(
 	alternate_state_( 0 ),
 	alternate_state_one_body_energy_( 0 ),
 	alternate_state_total_energy_( 0 ),
-	alternate_state_is_being_considered_( false ),
-	procrastinated_( false )
+	alternate_state_is_being_considered_( false )
 {
 }
 

--- a/source/src/core/pack/interaction_graph/LazyInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/LazyInteractionGraph.hh
@@ -169,10 +169,10 @@ private:
 	bool alternate_state_is_being_considered_;
 	bool procrastinated_;
 
-	//no default constructor, uncopyable
-	LazyNode();
-	LazyNode( LazyNode const & );
-	LazyNode & operator = ( LazyNode const & );
+public:
+	LazyNode() = delete;
+	LazyNode( LazyNode const & ) = delete;
+	LazyNode & operator = ( LazyNode const & ) = delete;
 
 };
 
@@ -333,10 +333,10 @@ private:
 	bool partial_state_assignment_;
 	bool ran_annealing_since_pair_energy_table_cleared_;
 
-	//no default constructor, uncopyable
-	LazyEdge();
-	LazyEdge( LazyEdge const & );
-	LazyEdge & operator = ( LazyEdge const & );
+public:
+	LazyEdge() = delete;
+	LazyEdge( LazyEdge const & ) = delete;
+	LazyEdge & operator = ( LazyEdge const & ) = delete;
 
 };
 
@@ -426,10 +426,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	LazyInteractionGraph();
-	LazyInteractionGraph( LazyInteractionGraph const & );
-	LazyInteractionGraph & operator = ( LazyInteractionGraph const & );
+public:
+	LazyInteractionGraph() = delete;
+	LazyInteractionGraph( LazyInteractionGraph const & ) = delete;
+	LazyInteractionGraph & operator = ( LazyInteractionGraph const & ) = delete;
 
 };
 

--- a/source/src/core/pack/interaction_graph/LazyInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/LazyInteractionGraph.hh
@@ -167,7 +167,6 @@ private:
 	std::vector< core::PackerEnergy > alternate_state_two_body_energies_;
 
 	bool alternate_state_is_being_considered_;
-	bool procrastinated_;
 
 public:
 	LazyNode() = delete;
@@ -418,7 +417,6 @@ protected:
 	}
 
 private:
-	int num_aa_types_;
 	int num_commits_since_last_update_;
 	core::PackerEnergy total_energy_current_state_assignment_;
 	core::PackerEnergy total_energy_alternate_state_assignment_;

--- a/source/src/core/pack/interaction_graph/LinearMemoryInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/LinearMemoryInteractionGraph.hh
@@ -360,10 +360,10 @@ private:
 	bool partial_state_assignment_;
 	bool preped_for_sim_annealing_;
 
-	//no default constructor, uncopyable
-	LinearMemEdge();
-	LinearMemEdge( LinearMemEdge const & );
-	LinearMemEdge & operator = ( LinearMemEdge const & );
+public:
+	LinearMemEdge() = delete;
+	LinearMemEdge( LinearMemEdge const & ) = delete;
+	LinearMemEdge & operator = ( LinearMemEdge const & ) = delete;
 
 };
 
@@ -435,10 +435,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	LinearMemoryInteractionGraph();
-	LinearMemoryInteractionGraph( LinearMemoryInteractionGraph const & );
-	LinearMemoryInteractionGraph & operator = ( LinearMemoryInteractionGraph const & );
+public:
+	LinearMemoryInteractionGraph() = delete;
+	LinearMemoryInteractionGraph( LinearMemoryInteractionGraph const & ) = delete;
+	LinearMemoryInteractionGraph & operator = ( LinearMemoryInteractionGraph const & ) = delete;
 };
 
 

--- a/source/src/core/pack/interaction_graph/PDInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/PDInteractionGraph.hh
@@ -222,10 +222,10 @@ private:
 	*/
 	bool alternate_state_is_being_considered_;
 
-	//no default constructor, uncopyable
-	PDNode();
-	PDNode( PDNode const & );
-	PDNode & operator = ( PDNode const & );
+public:
+	PDNode() = delete;
+	PDNode( PDNode const & ) = delete;
+	PDNode & operator = ( PDNode const & ) = delete;
 };
 
 class PDEdge : public PrecomputedPairEnergiesEdge
@@ -344,10 +344,10 @@ private: // Data
 	core::PackerEnergy curr_state_energy_;
 	bool energies_updated_since_last_prep_for_simA_;
 
-	//no default constructor, uncopyable
-	PDEdge();
-	PDEdge( PDEdge const & );
-	PDEdge & operator = ( PDEdge const & );
+public:
+	PDEdge() = delete;
+	PDEdge( PDEdge const & ) = delete;
+	PDEdge & operator = ( PDEdge const & ) = delete;
 };
 
 class PDInteractionGraph : public PrecomputedPairEnergiesInteractionGraph
@@ -497,10 +497,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	PDInteractionGraph();
-	PDInteractionGraph( PDInteractionGraph const & );
-	PDInteractionGraph & operator = ( PDInteractionGraph const & );
+public:
+	PDInteractionGraph() = delete;
+	PDInteractionGraph( PDInteractionGraph const & ) = delete;
+	PDInteractionGraph & operator = ( PDInteractionGraph const & ) = delete;
 };
 
 inline

--- a/source/src/core/pack/interaction_graph/PDInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/PDInteractionGraph.hh
@@ -488,8 +488,6 @@ private:
 
 
 	//variables for I/O
-	int num_nodes_in_file_;
-	int num_file_aa_types_;
 	ObjexxFCL::FArray1D_int file_node_2_instance_node_;
 	ObjexxFCL::FArray1D_int instance_node_2_file_node_;
 	ObjexxFCL::FArray1D< ObjexxFCL::FArray1D_int > aa_types_for_states_on_file_nodes_;

--- a/source/src/core/pack/interaction_graph/SymmLinMemInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/SymmLinMemInteractionGraph.hh
@@ -291,10 +291,10 @@ private:
 	bool partial_state_assignment_;
 	bool preped_for_sim_annealing_;
 
-	//no default constructor, uncopyable
-	SymmLinearMemEdge();
-	SymmLinearMemEdge( SymmLinearMemEdge const & );
-	SymmLinearMemEdge & operator = ( SymmLinearMemEdge const & );
+public:
+	SymmLinearMemEdge() = delete;
+	SymmLinearMemEdge( SymmLinearMemEdge const & ) = delete;
+	SymmLinearMemEdge & operator = ( SymmLinearMemEdge const & ) = delete;
 
 };
 
@@ -366,10 +366,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	SymmLinearMemoryInteractionGraph();
-	SymmLinearMemoryInteractionGraph( SymmLinearMemoryInteractionGraph const & );
-	SymmLinearMemoryInteractionGraph & operator = ( SymmLinearMemoryInteractionGraph const & );
+public:
+	SymmLinearMemoryInteractionGraph() = delete;
+	SymmLinearMemoryInteractionGraph( SymmLinearMemoryInteractionGraph const & ) = delete;
+	SymmLinearMemoryInteractionGraph & operator = ( SymmLinearMemoryInteractionGraph const & ) = delete;
 };
 
 

--- a/source/src/core/pack/interaction_graph/SymmMinimalistInteractionGraph.hh
+++ b/source/src/core/pack/interaction_graph/SymmMinimalistInteractionGraph.hh
@@ -249,10 +249,10 @@ private:
 	bool partial_state_assignment_;
 	bool preped_for_sim_annealing_;
 
-	//no default constructor, uncopyable
-	SymmMinimalistEdge();
-	SymmMinimalistEdge( SymmMinimalistEdge const & );
-	SymmMinimalistEdge & operator = ( SymmMinimalistEdge const & );
+public:
+	SymmMinimalistEdge() = delete;
+	SymmMinimalistEdge( SymmMinimalistEdge const & ) = delete;
+	SymmMinimalistEdge & operator = ( SymmMinimalistEdge const & ) = delete;
 
 };
 
@@ -318,10 +318,10 @@ private:
 
 	static const int COMMIT_LIMIT_BETWEEN_UPDATES = 1024; // 2^10
 
-	//no default constructor, uncopyable
-	SymmMinimalistInteractionGraph();
-	SymmMinimalistInteractionGraph( SymmMinimalistInteractionGraph const & );
-	SymmMinimalistInteractionGraph & operator = ( SymmMinimalistInteractionGraph const & );
+public:
+	SymmMinimalistInteractionGraph() = delete;
+	SymmMinimalistInteractionGraph( SymmMinimalistInteractionGraph const & ) = delete;
+	SymmMinimalistInteractionGraph & operator = ( SymmMinimalistInteractionGraph const & ) = delete;
 };
 
 

--- a/source/src/core/pack/rotamers/SingleResidueRotamerLibraryFactory.hh
+++ b/source/src/core/pack/rotamers/SingleResidueRotamerLibraryFactory.hh
@@ -71,8 +71,6 @@ private:
 
 private:
 	SingleResidueRotamerLibraryFactory();
-	SingleResidueRotamerLibraryFactory( SingleResidueRotamerLibraryFactory const & ); // unimplemented
-	SingleResidueRotamerLibraryFactory const & operator = ( SingleResidueRotamerLibraryFactory const & ); // unimplemented
 
 private:
 	typedef std::map< std::string, SingleResidueRotamerLibraryCreatorOP > CreatorMap;

--- a/source/src/core/pack/scmin/AtomTreeCollection.hh
+++ b/source/src/core/pack/scmin/AtomTreeCollection.hh
@@ -171,12 +171,9 @@ public:
 	void save_momento( ResidueAtomTreeCollectionMomento & momento ) const;
 	void update_from_momento( ResidueAtomTreeCollectionMomento const & momento );
 
-private:
-
-	//uncopyable -- unimplemented
-	ResidueAtomTreeCollection( ResidueAtomTreeCollection const & );
-	ResidueAtomTreeCollection & operator = ( ResidueAtomTreeCollection const & );
-
+public:
+	ResidueAtomTreeCollection( ResidueAtomTreeCollection const & ) = delete;
+	ResidueAtomTreeCollection & operator = ( ResidueAtomTreeCollection const & ) = delete;
 
 private:
 

--- a/source/src/protocols/docking/DockingHighResFactory.hh
+++ b/source/src/protocols/docking/DockingHighResFactory.hh
@@ -44,10 +44,6 @@ public:
 private:
 	// Private constructor to make it singleton managed
 	DockingHighResFactory();
-	DockingHighResFactory(const DockingHighResFactory & src); // unimplemented
-
-	DockingHighResFactory const &
-	operator=( DockingHighResFactory const & ); // unimplemented
 
 public:
 	// Warning this is not called because of the singleton pattern

--- a/source/src/protocols/evaluation/EvaluatorFactory.hh
+++ b/source/src/protocols/evaluation/EvaluatorFactory.hh
@@ -47,13 +47,6 @@ private:
 	/// @brief Private constructor to make it singleton managed
 	EvaluatorFactory();
 
-	/// @brief Private unimplemented copy constructor -- uncopyable.
-	EvaluatorFactory(const EvaluatorFactory & src);
-
-	/// @brief Private unimplemented assignment operator -- uncopyable.
-	EvaluatorFactory const &
-	operator = ( EvaluatorFactory const & );
-
 public:
 
 	// Warning this is not called because of the singleton pattern

--- a/source/src/protocols/flexpack/interaction_graph/FlexbbInteractionGraph.hh
+++ b/source/src/protocols/flexpack/interaction_graph/FlexbbInteractionGraph.hh
@@ -287,9 +287,10 @@ private:
 	//bool resolved_considered_bb_move_;
 	//bool node_contacted_by_graph_about_bb_move_;
 
-	// uncopyable
-	FlexbbNode();
-	FlexbbNode( FlexbbNode const & );
+public:
+	FlexbbNode() = delete;
+	FlexbbNode( FlexbbNode const & ) = delete;
+	FlexbbNode & operator = ( FlexbbNode const & ) = delete;
 
 };
 
@@ -421,9 +422,10 @@ private:
 	bool nodes_considering_bb_move_;
 
 
-	// uncopyable
-	FlexbbEdge();
-	FlexbbEdge( FlexbbEdge const & );
+public:
+	FlexbbEdge() = delete;
+	FlexbbEdge( FlexbbEdge const & ) = delete;
+	FlexbbEdge & operator = ( FlexbbEdge const & ) = delete;
 };
 
 

--- a/source/src/protocols/jd2/JobInputterFactory.hh
+++ b/source/src/protocols/jd2/JobInputterFactory.hh
@@ -63,10 +63,6 @@ private:
 
 	JobInputterFactory();
 
-	// Unimplemented -- uncopyable
-	JobInputterFactory( JobInputterFactory const & );
-	JobInputterFactory const & operator = ( JobInputterFactory const & );
-
 private:
 
 	JobInputterMap job_inputter_creator_map_;

--- a/source/src/protocols/jd2/JobOutputterFactory.hh
+++ b/source/src/protocols/jd2/JobOutputterFactory.hh
@@ -69,10 +69,6 @@ private:
 
 	JobOutputterFactory();
 
-	// Unimplemented -- uncopyable
-	JobOutputterFactory( JobOutputterFactory const & );
-	JobOutputterFactory const & operator = ( JobOutputterFactory const & );
-
 private:
 
 	JobOutputterMap job_outputter_creator_map_;

--- a/source/src/protocols/jd3/JobDigraph.hh
+++ b/source/src/protocols/jd3/JobDigraph.hh
@@ -142,10 +142,10 @@ private:
 	std::string node_label_;
 	core::Size n_predecessors_w_outstanding_jobs_;
 
-	//no default constructor, uncopyable
-	JobDirectedNode();
-	JobDirectedNode( JobDirectedNode const & );
-	JobDirectedNode & operator = ( JobDirectedNode & );
+public:
+	JobDirectedNode() = delete;
+	JobDirectedNode( JobDirectedNode const & ) = delete;
+	JobDirectedNode & operator = ( JobDirectedNode const & ) = delete;
 };
 
 /// @brief A run-of-the-mill directed edge to use in JobDigraphs
@@ -213,10 +213,10 @@ protected:
 
 private:
 
-	//no default constructor, uncopyable
-	JobDirectedEdge();
-	JobDirectedEdge( JobDirectedEdge const & );
-	JobDirectedEdge & operator = ( JobDirectedEdge & );
+public:
+	JobDirectedEdge() = delete;
+	JobDirectedEdge( JobDirectedEdge const & ) = delete;
+	JobDirectedEdge & operator = ( JobDirectedEdge const & ) = delete;
 
 };
 

--- a/source/src/protocols/loops/LoopMoverFactory.hh
+++ b/source/src/protocols/loops/LoopMoverFactory.hh
@@ -44,10 +44,6 @@ private:
 
 	// Private constructor to make it singleton managed
 	LoopMoverFactory();
-	LoopMoverFactory(const LoopMoverFactory & src); // unimplemented
-
-	LoopMoverFactory const &
-	operator=( LoopMoverFactory const & ); // unimplemented
 
 public:
 

--- a/source/src/protocols/loops/loop_mover/refine/LoopRefineInnerCycleFactory.hh
+++ b/source/src/protocols/loops/loop_mover/refine/LoopRefineInnerCycleFactory.hh
@@ -73,10 +73,6 @@ public:
 private: // methods
 	// Private constructor - singleton
 	LoopRefineInnerCycleFactory();
-	LoopRefineInnerCycleFactory(const LoopRefineInnerCycleFactory & src); // unimplemented
-
-	LoopRefineInnerCycleFactory const &
-	operator=( LoopRefineInnerCycleFactory const & ); // unimplemented
 
 	LoopRefineInnerCycleOP make_inner_cycle_from_string_name( std::string const & name ) const;
 	void setup_known_types();

--- a/source/src/protocols/loops/loops_definers/LoopsDefinerFactory.hh
+++ b/source/src/protocols/loops/loops_definers/LoopsDefinerFactory.hh
@@ -50,10 +50,6 @@ private: // constructors
 
 	// Private constructor to make it singleton managed
 	LoopsDefinerFactory();
-	LoopsDefinerFactory(const LoopsDefinerFactory & src); // unimplemented
-
-	LoopsDefinerFactory const &
-	operator=( LoopsDefinerFactory const & ); // unimplemented
 
 public:
 

--- a/source/src/protocols/match/Matcher.hh
+++ b/source/src/protocols/match/Matcher.hh
@@ -501,10 +501,9 @@ private:
 	void
 	note_primary_change_to_geom_csts_hitlist( core::Size geom_cst_id );
 
-private:
-	/// uncopyable -- unimplemented
-	Matcher( Matcher const & );
-	Matcher const & operator = ( Matcher const & rhs );
+public:
+	Matcher( Matcher const & ) = delete;
+	Matcher & operator = ( Matcher const & ) = delete;
 
 private:
 

--- a/source/src/protocols/moves/MonteCarlo.hh
+++ b/source/src/protocols/moves/MonteCarlo.hh
@@ -700,9 +700,8 @@ protected:
 		return *last_accepted_pose_;
 	}
 
-private:
-	/// unimplemented -- do not use
-	MonteCarlo const & operator = ( MonteCarlo const & ); // assignment operator -- do not use.
+public:
+	MonteCarlo & operator = ( MonteCarlo const & ) = delete;
 
 
 protected:

--- a/source/src/protocols/qsar/scoring_grid/GridFactory.hh
+++ b/source/src/protocols/qsar/scoring_grid/GridFactory.hh
@@ -67,9 +67,6 @@ public:
 
 private:
 	GridFactory();
-	//unimplemented -- uncopyable
-	GridFactory(GridFactory const & );
-	GridFactory const & operator = (GridFactory const &);
 
 private:
 

--- a/source/src/protocols/rosetta_scripts/PoseSelectorFactory.hh
+++ b/source/src/protocols/rosetta_scripts/PoseSelectorFactory.hh
@@ -79,10 +79,6 @@ public:
 private:
 	PoseSelectorFactory();
 
-	// Unimplemented -- uncopyable
-	PoseSelectorFactory( PoseSelectorFactory const & );
-	PoseSelectorFactory const & operator = ( PoseSelectorFactory const & );
-
 
 private:
 

--- a/source/src/protocols/rotamer_recovery/RotamerRecoveryFactory.hh
+++ b/source/src/protocols/rotamer_recovery/RotamerRecoveryFactory.hh
@@ -47,10 +47,6 @@ public:
 private:
 	// Private constructor to make it singleton managed
 	RotamerRecoveryFactory();
-	RotamerRecoveryFactory(const RotamerRecoveryFactory & src); // unimplemented
-
-	RotamerRecoveryFactory const &
-	operator=( RotamerRecoveryFactory const & ); // unimplemented
 
 public:
 

--- a/source/src/protocols/sewing/requirements/AssemblyRequirementFactory.hh
+++ b/source/src/protocols/sewing/requirements/AssemblyRequirementFactory.hh
@@ -54,14 +54,6 @@ private:
 	// Private constructor to make it singleton managed
 	AssemblyRequirementFactory();
 
-	AssemblyRequirementFactory const &
-	operator=( AssemblyRequirementFactory const & ); // unimplemented
-	//This should be covered by the singleton base
-	/*
-	/// @brief private singleton creation function to be used with
-	/// utility::thread::threadsafe_singleton
-	static AssemblyRequirementFactory * create_singleton_instance();
-	*/
 public:
 	// Warning this is not called because of the singleton pattern
 	virtual ~AssemblyRequirementFactory();

--- a/source/src/protocols/sewing/scoring/AssemblyScorerFactory.hh
+++ b/source/src/protocols/sewing/scoring/AssemblyScorerFactory.hh
@@ -55,13 +55,6 @@ private:
 	// Private constructor to make it singleton managed
 	AssemblyScorerFactory();
 
-	AssemblyScorerFactory const &
-	operator=( AssemblyScorerFactory const & ); // unimplemented
-	/*
-	/// @brief private singleton creation function to be used with
-	/// utility::thread::threadsafe_singleton
-	static AssemblyScorerFactory * create_singleton_instance();
-	*/
 public:
 	// Warning this is not called because of the singleton pattern
 	virtual ~AssemblyScorerFactory();


### PR DESCRIPTION
## Summary

Modernize 31 headers across `core/` and `protocols/` that used the pre-C++11 idiom of declaring (but not defining) private copy constructor and assignment operator to forbid copies. The link-error-as-enforcement trick is fragile (silent breakage if anyone defines them in the same translation unit, confusing diagnostics on misuse, and falsely implies the class has a copy constructor).

Two flavours of fix applied:

1. **Stand-alone non-copyable classes** — InteractionGraphBase node/edge/graph family (9 files, 23 classes total), FlexbbInteractionGraph (2 classes), JobDigraph (2 classes), AtomTreeCollection's ResidueAtomTreeCollection, Matcher, and MonteCarlo's `operator=`: replace the private unimplemented declarations with public `= delete`. Where the old assignment took a non-const reference or returned `T const &` (a C++03 idiom holdover), the modernized signatures take `T const &` and return `T &`.

2. **Singleton-derived factories** (`utility::SingletonBase` children) — `RotamerLibrarySpecificationFactory`, `SingleResidueRotamerLibraryFactory`, `RotamerLibrary`, `CenrotLibrary`, plus `DockingHighResFactory`, `EvaluatorFactory`, `JobInputterFactory`, `JobOutputterFactory`, `LoopMoverFactory`, `LoopRefineInnerCycleFactory`, `LoopsDefinerFactory`, `GridFactory`, `PoseSelectorFactory`, `RotamerRecoveryFactory`, `AssemblyRequirementFactory`, `AssemblyScorerFactory`: simply drop the redundant unimplemented copy/assignment declarations. `SingletonBase` already `= delete`s its own copy/assignment, which transitively deletes the derived class's implicit versions, so the extra lines were noise.

No behaviour change: copy/assignment attempts that were link errors before are now compile errors, which is the intended diagnostic-quality improvement. Debug build passes clean.