### PR TITLE
Apply Rule of Zero to remaining LREnergyContainer iterator subclasses

### DIFF
--- a/source/src/core/scoring/DenseEnergyContainer.cc
+++ b/source/src/core/scoring/DenseEnergyContainer.cc
@@ -33,8 +33,6 @@ namespace scoring {
 
 ///////////////////////////////////////////////////////
 
-DenseNeighborIterator::~DenseNeighborIterator()= default;
-
 DenseNeighborIterator::DenseNeighborIterator(
 	Size const pos1_in,
 	Size const pos2_in,
@@ -147,8 +145,6 @@ DenseNeighborIterator::energy_computed() const
 }
 
 /////////////////////////////////////////////////////
-
-DenseNeighborConstIterator::~DenseNeighborConstIterator()= default;
 
 DenseNeighborConstIterator::DenseNeighborConstIterator(
 	Size const pos1_in,

--- a/source/src/core/scoring/DenseEnergyContainer.hh
+++ b/source/src/core/scoring/DenseEnergyContainer.hh
@@ -44,10 +44,7 @@ namespace scoring {
 
 class DenseNeighborIterator : public ResidueNeighborIterator
 {
-	DenseNeighborIterator & operator = (DenseNeighborIterator const & src );
 public:
-	~DenseNeighborIterator() override;
-
 	DenseNeighborIterator(
 		Size const pos1_in,
 		Size const pos2_in,
@@ -55,6 +52,11 @@ public:
 		ObjexxFCL::FArray2D< Real > * table_in,
 		ObjexxFCL::FArray2D< bool > * computed_in
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DenseNeighborIterator & operator = (DenseNeighborIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & src ) override;
 
@@ -98,10 +100,7 @@ private:
 
 class DenseNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	DenseNeighborConstIterator & operator = (DenseNeighborConstIterator const & src );
 public:
-	~DenseNeighborConstIterator() override;
-
 	DenseNeighborConstIterator(
 		Size const pos1_in,
 		Size const pos2_in,
@@ -109,6 +108,11 @@ public:
 		ObjexxFCL::FArray2D< Real > const * table_in,
 		ObjexxFCL::FArray2D< bool > const * computed_in
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DenseNeighborConstIterator & operator = (DenseNeighborConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & src ) override;
 

--- a/source/src/core/scoring/OneToAllEnergyContainer.cc
+++ b/source/src/core/scoring/OneToAllEnergyContainer.cc
@@ -33,8 +33,6 @@ namespace scoring {
 
 /////////////////////////////////////////////////////
 
-OneToAllNeighborIterator::~OneToAllNeighborIterator()= default;
-
 OneToAllNeighborIterator::OneToAllNeighborIterator(
 	Size const pos1_in,
 	Size const pos2_in,
@@ -135,8 +133,6 @@ bool OneToAllNeighborIterator::energy_computed() const
 
 
 /////////////////////////////////////////////////////
-
-OneToAllNeighborConstIterator::~OneToAllNeighborConstIterator()= default;
 
 OneToAllNeighborConstIterator::OneToAllNeighborConstIterator(
 	Size const pos1_in,

--- a/source/src/core/scoring/OneToAllEnergyContainer.hh
+++ b/source/src/core/scoring/OneToAllEnergyContainer.hh
@@ -42,10 +42,7 @@ namespace scoring {
 
 class OneToAllNeighborIterator : public ResidueNeighborIterator
 {
-	OneToAllNeighborIterator & operator = (OneToAllNeighborIterator const & src );
 public:
-	~OneToAllNeighborIterator() override;
-
 	OneToAllNeighborIterator(
 		Size const pos1_in,
 		Size const pos2_in,
@@ -54,6 +51,11 @@ public:
 		utility::vector1< Real > * table_in,
 		utility::vector1< bool > * computed_in
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	OneToAllNeighborIterator & operator = (OneToAllNeighborIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & src ) override;
 
@@ -97,10 +99,7 @@ private:
 
 class OneToAllNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	OneToAllNeighborConstIterator & operator = (OneToAllNeighborConstIterator const & src );
 public:
-	~OneToAllNeighborConstIterator() override;
-
 	OneToAllNeighborConstIterator(
 		Size const pos1_in,
 		Size const pos2_in,
@@ -109,6 +108,11 @@ public:
 		utility::vector1< Real > const * table_in,
 		utility::vector1< bool > const * computed_in
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	OneToAllNeighborConstIterator & operator = (OneToAllNeighborConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & src ) override;
 

--- a/source/src/core/scoring/PolymerBondedEnergyContainer.cc
+++ b/source/src/core/scoring/PolymerBondedEnergyContainer.cc
@@ -51,8 +51,6 @@ static basic::Tracer TR_it( "core.scoring.PolymerBondedNeighborIterator" );
 
 ///////////////////////////////////////////////////////
 
-PolymerBondedNeighborIterator::~PolymerBondedNeighborIterator()= default;
-
 PolymerBondedNeighborIterator::PolymerBondedNeighborIterator(
 	Size const base_in,
 	utility::vector1< Size > const & pos_in,
@@ -143,8 +141,6 @@ bool PolymerBondedNeighborIterator::energy_computed() const {
 }
 
 /////////////////////////////////////////////////////
-
-PolymerBondedNeighborConstIterator::~PolymerBondedNeighborConstIterator()= default;
 
 PolymerBondedNeighborConstIterator::PolymerBondedNeighborConstIterator(
 	Size const base_in,

--- a/source/src/core/scoring/PolymerBondedEnergyContainer.hh
+++ b/source/src/core/scoring/PolymerBondedEnergyContainer.hh
@@ -48,17 +48,18 @@ namespace scoring {
 
 class PolymerBondedNeighborIterator : public ResidueNeighborIterator
 {
-	PolymerBondedNeighborIterator & operator = (PolymerBondedNeighborIterator const & src );
-
 public:
-	~PolymerBondedNeighborIterator() override;
-
 	// Moves pos_in, so by-value
 	PolymerBondedNeighborIterator(
 		Size const base_in,
 		utility::vector1< Size > const & positions_in,
 		PolymerBondedEnergyContainer & parent
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	PolymerBondedNeighborIterator & operator = (PolymerBondedNeighborIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & src ) override;
 
@@ -99,16 +100,18 @@ private:
 
 class PolymerBondedNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	PolymerBondedNeighborConstIterator & operator = (PolymerBondedNeighborConstIterator const & src );
 public:
-	~PolymerBondedNeighborConstIterator() override;
-
 	// Moves pos_in, so by value
 	PolymerBondedNeighborConstIterator(
 		Size const base_in,
 		utility::vector1< Size > const & positions_in,
 		PolymerBondedEnergyContainer const & parent
 	);
+
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	PolymerBondedNeighborConstIterator & operator = (PolymerBondedNeighborConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & src ) override;
 

--- a/source/src/core/scoring/constraints/ConstraintEnergyContainer.cc
+++ b/source/src/core/scoring/constraints/ConstraintEnergyContainer.cc
@@ -48,8 +48,6 @@ CstResNeighbIterator::CstResNeighbIterator(
 {}
 
 
-CstResNeighbIterator::~CstResNeighbIterator() = default;
-
 ResidueNeighborIterator &
 CstResNeighbIterator::operator = ( ResidueNeighborIterator const & rhs)
 {
@@ -198,8 +196,6 @@ CstResNeighbConstIterator::CstResNeighbConstIterator(
 	focused_node_( focused_node ),
 	edge_iter_( edge_iter )
 {}
-
-CstResNeighbConstIterator::~CstResNeighbConstIterator() = default;
 
 ResidueNeighborConstIterator &
 CstResNeighbConstIterator::operator = ( ResidueNeighborConstIterator const & rhs )

--- a/source/src/core/scoring/constraints/ConstraintEnergyContainer.hh
+++ b/source/src/core/scoring/constraints/ConstraintEnergyContainer.hh
@@ -42,7 +42,6 @@ namespace scoring {
 namespace constraints {
 
 class CstResNeighbIterator : public ResidueNeighborIterator {
-	CstResNeighbIterator & operator = (CstResNeighbIterator const & );
 public:
 	typedef utility::graph::Node::EdgeListIter EdgeListIter;
 
@@ -50,7 +49,10 @@ public:
 
 	CstResNeighbIterator( Size focused_node, EdgeListIter edge_iter);
 
-	~CstResNeighbIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	CstResNeighbIterator & operator = (CstResNeighbIterator const & ) = delete;
 
 	ResidueNeighborIterator & operator = ( ResidueNeighborIterator const & ) override;
 	ResidueNeighborIterator const & operator ++ () override;
@@ -82,14 +84,16 @@ private:
 };
 
 class CstResNeighbConstIterator : public ResidueNeighborConstIterator {
-	CstResNeighbConstIterator & operator = (CstResNeighbConstIterator const & );
 public:
 	typedef utility::graph::Node::EdgeListConstIter EdgeListConstIter;
 
 public:
 	CstResNeighbConstIterator( Size focused_node, EdgeListConstIter edge_iter);
 
-	~CstResNeighbConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	CstResNeighbConstIterator & operator = (CstResNeighbConstIterator const & ) = delete;
 
 	ResidueNeighborConstIterator & operator = ( ResidueNeighborConstIterator const & ) override;
 	ResidueNeighborConstIterator const & operator ++ () override;


### PR DESCRIPTION
## Summary

Extends the disulfide-iterator pattern from PR #689 to the four remaining `ResidueNeighbor{,Const}Iterator` subclasses in `core/scoring/`:

- `DenseNeighbor{,Const}Iterator` (`DenseEnergyContainer.{hh,cc}`)
- `OneToAllNeighbor{,Const}Iterator` (`OneToAllEnergyContainer.{hh,cc}`)
- `PolymerBondedNeighbor{,Const}Iterator` (`PolymerBondedEnergyContainer.{hh,cc}`)
- `CstResNeighb{,Const}Iterator` (`constraints/ConstraintEnergyContainer.{hh,cc}`)

For each class:

- Remove the empty out-of-line destructor (`~X() override;` decl in `.hh` plus `X::~X() = default;` in `.cc`) — Rule of Zero suffices since the base destructor is already virtual.
- Replace the pre-C++11 private undefined derived-derived copy-assignment (`X & operator = (X const & );`) with an explicit `= delete` and a short comment explaining that all assignment must funnel through the polymorphic `operator = ( ResidueNeighbor{,Const}Iterator const & )` so derived members are downcast and copied correctly.

Together with PR #689 this exhausts the `LREnergyContainer` iterator family — every concrete container's iterator pair now follows the same idiom.

The bundle is smaller than the usual minimum (~77 lines) because no further sibling work exists in this hierarchy.