### PR TITLE
Modernize pre-C++11 copy prevention to = delete across core/ and protocols/

### DIFF
--- a/source/src/basic/resource_manager/locator/FileSystemResourceLocator.hh
+++ b/source/src/basic/resource_manager/locator/FileSystemResourceLocator.hh
@@ -60,8 +60,7 @@ public:
 	stream() override;
 
 private:
-	/// @brief This is private and unimplemented. The FileStream shouldn't be copied
-	FileStream( FileStream const & );
+	FileStream( FileStream const & ) = delete;
 
 private: // members
 	utility::io::izstream stream_;

--- a/source/src/core/conformation/RotamerSetBase.hh
+++ b/source/src/core/conformation/RotamerSetBase.hh
@@ -116,8 +116,7 @@ public:
 
 
 private:
-	// deny use of the copy constructor (no pass-by-value)
-	RotamerSetBase( RotamerSetBase const & );
+	RotamerSetBase( RotamerSetBase const & ) = delete;
 
 	/// @brief BasicDataCache indexed by enum in core/pack/rotamer_set/RotamerSetCacheableDataType.hh
 	/// @warning DataCache must always be initialized with the number of cacheable

--- a/source/src/core/environment/DofPassport.hh
+++ b/source/src/core/environment/DofPassport.hh
@@ -97,7 +97,7 @@ private:
 
 	DofPassport( std::string const & mover, Size env_id);
 
-	DofPassport( DofPassport const& );
+	DofPassport( DofPassport const& ) = delete;
 
 	//General code used by most (all?) access checks.
 	bool access_check( EnvCore const& env, bool type_specific_check ) const;

--- a/source/src/core/fragment/ConstantLengthFragSetIterator_.hh
+++ b/source/src/core/fragment/ConstantLengthFragSetIterator_.hh
@@ -47,7 +47,7 @@ namespace fragment {
 class ConstantLengthFragSetIterator_ : public FrameIteratorWorker_ {
 	friend class ConstantLengthFragSet;
 
-	ConstantLengthFragSetIterator_ & operator = (ConstantLengthFragSetIterator_ const&);
+	ConstantLengthFragSetIterator_ & operator = (ConstantLengthFragSetIterator_ const&) = delete;
 protected:
 	ConstantLengthFragSetIterator_( FrameList::const_iterator it, FrameList::const_iterator eit ) : it_( it ), eit_( eit ) {
 		if ( it != eit ) {

--- a/source/src/core/fragment/FrameListIterator_.hh
+++ b/source/src/core/fragment/FrameListIterator_.hh
@@ -39,7 +39,7 @@ class FrameListIterator_ : public FrameIteratorWorker_ {
 	friend class FrameList;
 	friend class FragID_Iterator;
 
-	FrameListIterator_ & operator = (FrameListIterator_ const&);
+	FrameListIterator_ & operator = (FrameListIterator_ const&) = delete;
 
 protected:
 	FrameListIterator_( FrameList::iterator it ) : it_( it ) {};

--- a/source/src/core/fragment/MinimalFragSetIterator_.hh
+++ b/source/src/core/fragment/MinimalFragSetIterator_.hh
@@ -48,7 +48,7 @@ class MinimalFragSetIterator_ : public FrameIteratorWorker_ {
 	typedef FrameMap::const_iterator OuterIterator;
 	typedef FrameList::const_iterator InnerIterator;
 
-	MinimalFragSetIterator_ & operator = (MinimalFragSetIterator_ const&);
+	MinimalFragSetIterator_ & operator = (MinimalFragSetIterator_ const&) = delete;
 protected:
 	MinimalFragSetIterator_( OuterIterator it, OuterIterator eit ) : outer_( it ), outer_end_( eit ) {
 		if ( outer_ != outer_end_ ) {

--- a/source/src/core/fragment/OrderedFragSetIterator_.hh
+++ b/source/src/core/fragment/OrderedFragSetIterator_.hh
@@ -45,7 +45,7 @@ class OrderedFragSetIterator_ : public FrameIteratorWorker_ {
 	typedef FrameMap::const_iterator OuterIterator;
 	typedef FrameList::const_iterator InnerIterator;
 
-	OrderedFragSetIterator_ & operator = (OrderedFragSetIterator_ const&);
+	OrderedFragSetIterator_ & operator = (OrderedFragSetIterator_ const&) = delete;
 protected:
 	OrderedFragSetIterator_( OuterIterator it, OuterIterator eit ) : outer_( it ), outer_end_( eit ) {
 		if ( outer_ != outer_end_ ) {

--- a/source/src/core/pack/rotamer_set/RotamerSet.hh
+++ b/source/src/core/pack/rotamer_set/RotamerSet.hh
@@ -255,8 +255,7 @@ public:
 	update_rotamer_offsets() const = 0;
 
 private:
-	// deny use of the copy constructor (no pass-by-value)
-	RotamerSet( RotamerSet const & );
+	RotamerSet( RotamerSet const & ) = delete;
 
 	Size resid_; //which residue is this?
 

--- a/source/src/core/pack/rotamer_set/RotamerSet_.hh
+++ b/source/src/core/pack/rotamer_set/RotamerSet_.hh
@@ -214,7 +214,7 @@ public:
 	) const override {}
 
 private:
-	RotamerSet_( RotamerSet_ const & );
+	RotamerSet_( RotamerSet_ const & ) = delete;
 
 
 protected:

--- a/source/src/core/pack/rotamer_set/RotamerSubset.hh
+++ b/source/src/core/pack/rotamer_set/RotamerSubset.hh
@@ -168,8 +168,7 @@ public:
 	show( std::ostream & out ) const override;
 
 private:
-	/// @brief (private) No copy-constructor
-	RotamerSubset( RotamerSubset const & );
+	RotamerSubset( RotamerSubset const & ) = delete;
 
 	/// @brief declare that a new block of residue types has begun, and that new residues
 	/// are about to be pushed back. NOT IMPLEMENTED.

--- a/source/src/core/scoring/DockingScoreFunction.hh
+++ b/source/src/core/scoring/DockingScoreFunction.hh
@@ -47,10 +47,8 @@ public:
 
 private:
 	/// @brief Copy constructor and assignment operators private for *ScoreFunctions as they discard subtype info.
-	DockingScoreFunction &
-	operator=( DockingScoreFunction const & );
-
-	DockingScoreFunction( DockingScoreFunction const & );
+	DockingScoreFunction & operator=( DockingScoreFunction const & ) = delete;
+	DockingScoreFunction( DockingScoreFunction const & ) = delete;
 
 public:
 

--- a/source/src/core/scoring/MinScoreScoreFunction.hh
+++ b/source/src/core/scoring/MinScoreScoreFunction.hh
@@ -50,10 +50,8 @@ public:
 
 private:
 
-	MinScoreScoreFunction &
-	operator=( MinScoreScoreFunction const & );
-
-	MinScoreScoreFunction( MinScoreScoreFunction const & );
+	MinScoreScoreFunction & operator=( MinScoreScoreFunction const & ) = delete;
+	MinScoreScoreFunction( MinScoreScoreFunction const & ) = delete;
 
 public:
 

--- a/source/src/core/scoring/ScoreFunction.hh
+++ b/source/src/core/scoring/ScoreFunction.hh
@@ -139,16 +139,9 @@ public:
 	// inline ScoreFunctionAP get_self_weak_ptr() { return ScoreFunctionAP( shared_from_this() ); }
 
 private:
-	/// @brief The ScoreFunction copy constructor is explicitly private
-	/// as using it to make a copy is just too attractive, but discards subclass information.
-	/// Use ScoreFunction::clone() instead.
-	ScoreFunction( ScoreFunction const & );
-
-	/// @brief The ScoreFunction assignment operator is explicitly private
-	/// as using it discards subclass information.
-	/// Rework your algorithm to use ScoreFunctionOP's instead.
-	ScoreFunction &
-	operator=( ScoreFunction const & );
+	/// @brief Copying a ScoreFunction discards subclass information; use ScoreFunction::clone() instead.
+	ScoreFunction( ScoreFunction const & ) = delete;
+	ScoreFunction & operator=( ScoreFunction const & ) = delete;
 
 public:
 

--- a/source/src/protocols/flexpack/OtherContextScoreFunction.hh
+++ b/source/src/protocols/flexpack/OtherContextScoreFunction.hh
@@ -47,12 +47,9 @@ public:
 	);
 
 private:
-	// private assignment and copy constructors to avoid discarding subtype information
-
-	OtherContextScoreFunction( OtherContextScoreFunction const & );
-
-	OtherContextScoreFunction &
-	operator=( OtherContextScoreFunction const & );
+	// Avoid discarding subtype information; clone() must be used to duplicate.
+	OtherContextScoreFunction( OtherContextScoreFunction const & ) = delete;
+	OtherContextScoreFunction & operator=( OtherContextScoreFunction const & ) = delete;
 
 public:
 

--- a/source/src/protocols/frag_picker/FragmentPicker.hh
+++ b/source/src/protocols/frag_picker/FragmentPicker.hh
@@ -77,7 +77,7 @@ public:
 	core::Size max_pools();
 
 private:
-	QuotaDebug(QuotaDebug const &);
+	QuotaDebug(QuotaDebug const &) = delete;
 };
 
 /// @brief The core of the fragment picking machinery

--- a/source/src/protocols/matdes/SymDofMoverSampler.hh
+++ b/source/src/protocols/matdes/SymDofMoverSampler.hh
@@ -51,10 +51,8 @@ public:
 	void step();
 
 private:
-	// Don't implement the methods belowed, this class is a singleton.
+	// Singleton — only SingletonBase constructs instances.
 	SymDofMoverSampler();
-	SymDofMoverSampler(SymDofMoverSampler const&);
-	void operator=(SymDofMoverSampler const&);
 
 private:
 


### PR DESCRIPTION
## Summary

Replace the pre-C++11 idiom (declared-but-undefined private copy ctor / copy assignment used to prevent copies via link error) with explicit `= delete`. 16 files, no behaviour change — just turning latent link errors into clear compile-time errors. Same kind of work as #685 / #674 / #672 / #671 / etc.

Two flavours:

1. **Stand-alone non-copyable classes** (14 files): replace the unimplemented private declarations with `= delete`. Drops redundant comments (`"deny use of the copy constructor"`, `"private and unimplemented"`) that `= delete` already conveys. Keeps the explanatory rationale only where the *why* is non-obvious (`ScoreFunction` / `DockingScoreFunction` / `OtherContextScoreFunction`: copies would discard subclass information; use `clone()` instead).

2. **Singleton** (`SymDofMoverSampler`, inheriting `utility::SingletonBase`): drop the redundant copy/assignment declarations entirely — the base already `= delete`s its own copies, which transitively deletes the derived copies.

### Files touched

`core/scoring/`: `ScoreFunction.hh`, `MinScoreScoreFunction.hh`, `DockingScoreFunction.hh`
`core/pack/rotamer_set/`: `RotamerSet.hh`, `RotamerSet_.hh`, `RotamerSubset.hh`
`core/conformation/`: `RotamerSetBase.hh`
`core/environment/`: `DofPassport.hh`
`core/fragment/`: `ConstantLengthFragSetIterator_.hh`, `FrameListIterator_.hh`, `MinimalFragSetIterator_.hh`, `OrderedFragSetIterator_.hh`
`basic/resource_manager/locator/`: `FileSystemResourceLocator.hh` (the inner `FileStream`)
`protocols/flexpack/`: `OtherContextScoreFunction.hh`
`protocols/frag_picker/`: `FragmentPicker.hh` (the inner `QuotaDebug`)
`protocols/matdes/`: `SymDofMoverSampler.hh`

Debug build passes clean.