### PR TITLE
Apply Rule of Zero to utility/keys container family (corrected)

### DIFF
--- a/source/src/utility/keys/ClassKeyMap.hh
+++ b/source/src/utility/keys/ClassKeyMap.hh
@@ -109,16 +109,10 @@ public: // Creation
 
 
 	/// @brief Default constructor
-	inline
-	ClassKeyMap()
-	= default;
-
-
-	/// @brief Copy constructor
-	inline
-	ClassKeyMap( ClassKeyMap const & a ) :
-		v_( a.v_ )
-	{}
+	// The templated iterator-range constructor below is a user-declared constructor,
+	// which suppresses the implicit default. Keep an explicit = default so that
+	// expressions like `ClassKeyMap<K,T,C> m;` continue to compile.
+	ClassKeyMap() = default;
 
 
 	/// @brief Iterator range constructor
@@ -136,24 +130,7 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~ClassKeyMap() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	ClassKeyMap &
-	operator =( ClassKeyMap const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements

--- a/source/src/utility/keys/ClassKeyVector.hh
+++ b/source/src/utility/keys/ClassKeyVector.hh
@@ -99,16 +99,9 @@ public: // Creation
 
 
 	/// @brief Default constructor
-	inline
-	ClassKeyVector()
-	= default;
-
-
-	/// @brief Copy constructor
-	inline
-	ClassKeyVector( ClassKeyVector const & a ) :
-		v_( a.v_ )
-	{}
+	// The other user-declared constructors below suppress the implicit default,
+	// so keep an explicit = default so that `ClassKeyVector<K,T,C> v;` compiles.
+	ClassKeyVector() = default;
 
 
 	/// @brief Size constructor
@@ -140,24 +133,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~ClassKeyVector() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	ClassKeyVector &
-	operator =( ClassKeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements

--- a/source/src/utility/keys/KeyVector.hh
+++ b/source/src/utility/keys/KeyVector.hh
@@ -90,9 +90,9 @@ public: // Creation
 
 
 	/// @brief Default constructor
-	inline
-	KeyVector()
-	= default;
+	// The other user-declared constructors below suppress the implicit default,
+	// so keep an explicit = default so that `KeyVector<K,T> v;` compiles.
+	KeyVector() = default;
 
 
 	/// @brief Size constructor
@@ -124,25 +124,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~KeyVector()
-	= default;
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	KeyVector &
-	operator =( KeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to elements

--- a/source/src/utility/keys/SmallKeyMap.hh
+++ b/source/src/utility/keys/SmallKeyMap.hh
@@ -111,15 +111,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Copy constructor
-	inline
-	SmallKeyMap( SmallKeyMap const & a ) :
-		v_( a.v_ ),
-		m_( a.m_ ),
-		u_( a.u_ )
-	{}
-
-
 	/// @brief Iterator range constructor
 	template< typename InputIterator >
 	inline
@@ -136,26 +127,7 @@ public: // Creation
 	}
 
 
-	/// @brief Destructor
-	inline
-	~SmallKeyMap() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	SmallKeyMap &
-	operator =( SmallKeyMap const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-			m_ = a.m_;
-			u_ = a.u_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform mapped value assignment to current elements

--- a/source/src/utility/keys/SmallKeyVector.hh
+++ b/source/src/utility/keys/SmallKeyVector.hh
@@ -105,15 +105,6 @@ public: // Creation
 	{}
 
 
-	/// @brief Copy constructor
-	inline
-	SmallKeyVector( SmallKeyVector const & a ) :
-		v_( a.v_ ),
-		m_( a.m_ ),
-		u_( a.u_ )
-	{}
-
-
 	/// @brief Size constructor
 	inline
 	explicit
@@ -146,26 +137,7 @@ public: // Creation
 	{}
 
 
-	/// @brief Destructor
-	inline
-	~SmallKeyVector() {}
-
-
 public: // Assignment
-
-
-	/// @brief Copy assignment
-	inline
-	SmallKeyVector &
-	operator =( SmallKeyVector const & a )
-	{
-		if ( this != &a ) {
-			v_ = a.v_;
-			m_ = a.m_;
-			u_ = a.u_;
-		}
-		return *this;
-	}
 
 
 	/// @brief Uniform value assignment to current elements


### PR DESCRIPTION
## Summary

Re-applies the Rule-of-Zero refactor that was originally landed as #691 and then reverted in #703, fixing the bug that caused the revert. Supersedes #704 (the revert-revert), which still ships the same broken state and will fail `cat=test` on `test/utility/keys/ClassKeyMap.cxxtest.hh`.

### What was broken in #691 / #704

The original commit dropped the explicit `= default` default constructors from `ClassKeyMap`, `ClassKeyVector`, and `KeyVector` on the assumption that they would be synthesized implicitly. They are not. Each of those classes has a user-declared (non-default) constructor — the templated iterator-range constructor on `ClassKeyMap`, and the size / uniform-value / iterator-range constructors on `ClassKeyVector` and `KeyVector`. By the C++ rules, any user-declared constructor suppresses the implicit default. That broke `Map m;` in the unit test (`test/utility/keys/ClassKeyMap.cxxtest.hh`):

```
./test/utility/keys/ClassKeyMap.cxxtest.hh:32:7: error: no matching constructor
for initialization of 'Map' (aka 'ClassKeyMap<int, int, float>')
                Map m;
                    ^
```

### What this PR does

Same Rule-of-Zero cleanup as #691 — drops the redundant user-declared destructors, copy constructors, and copy-assignment operators on all five classes, so the implicitly defaulted versions (now including move constructor and move assignment) take over — but keeps an explicit `= default` default constructor on `ClassKeyMap`, `ClassKeyVector`, and `KeyVector`. `SmallKeyMap` and `SmallKeyVector` already keep a user-defined default constructor because they need to value-initialize the scalar `Index u_`.

Verified by building `mode=debug cat=test` end-to-end (no compile errors).