### PR TITLE
Apply Rule of Zero to empty destructors across core/

### DIFF
--- a/source/src/core/conformation/membrane/AqueousPoreParameters.cc
+++ b/source/src/core/conformation/membrane/AqueousPoreParameters.cc
@@ -99,8 +99,6 @@ AqueousPoreParameters::AqueousPoreParameters(
 	pore_rotation_angle_( pore_rotation_angle )
 {}
 
-AqueousPoreParameters::~AqueousPoreParameters() {}
-
 AqueousPoreParameters::AqueousPoreParameters( AqueousPoreParameters const & src )
 : utility::VirtualBase( src ),
 	min_center_x_( src.min_center_x_ ),

--- a/source/src/core/conformation/membrane/AqueousPoreParameters.hh
+++ b/source/src/core/conformation/membrane/AqueousPoreParameters.hh
@@ -70,7 +70,6 @@ public:
 	);
 
 	AqueousPoreParameters(AqueousPoreParameters const & src);
-	~AqueousPoreParameters() override;
 
 	AqueousPoreParametersOP
 	clone() const;

--- a/source/src/core/conformation/membrane/ImplicitLipidInfo.cc
+++ b/source/src/core/conformation/membrane/ImplicitLipidInfo.cc
@@ -98,8 +98,6 @@ ImplicitLipidInfo::ImplicitLipidInfo(
 	initialize_implicit_lipid_electricfield_parameters();
 }
 
-ImplicitLipidInfo::~ImplicitLipidInfo() {}
-
 ImplicitLipidInfoOP
 ImplicitLipidInfo::clone() const {
 	return ImplicitLipidInfoOP( new ImplicitLipidInfo( *this ) );

--- a/source/src/core/conformation/membrane/ImplicitLipidInfo.hh
+++ b/source/src/core/conformation/membrane/ImplicitLipidInfo.hh
@@ -62,9 +62,6 @@ public:
 		core::Real temperature
 	);
 
-
-	~ImplicitLipidInfo() override;
-
 	ImplicitLipidInfoOP
 	clone() const;
 

--- a/source/src/core/conformation/membrane/MembraneGeometry.cc
+++ b/source/src/core/conformation/membrane/MembraneGeometry.cc
@@ -90,10 +90,6 @@ MembraneGeometry::MembraneGeometry(
 }
 
 
-/// @brief Destructor
-MembraneGeometry::~MembraneGeometry() {}
-
-
 /// @brief Are we accommodating the aqueous pore?
 bool
 MembraneGeometry::has_pore() const {

--- a/source/src/core/conformation/membrane/MembraneGeometry.hh
+++ b/source/src/core/conformation/membrane/MembraneGeometry.hh
@@ -80,9 +80,6 @@ public: // Constructors & Setup
 		AqueousPoreParametersOP aqueous_pore
 	);
 
-	/// @brief Destructor
-	~MembraneGeometry() override;
-
 	virtual MembraneGeometryOP
 	clone() const = 0;
 

--- a/source/src/core/conformation/membrane/MembraneInfo.cc
+++ b/source/src/core/conformation/membrane/MembraneInfo.cc
@@ -327,9 +327,6 @@ MembraneInfo::operator=( MembraneInfo const & src ) {
 	return *this;
 }
 
-/// @brief Destructor
-MembraneInfo::~MembraneInfo() {}
-
 /// @brief Generate a string representation of information represented by ths MembraneInfo
 void
 MembraneInfo::show() const {

--- a/source/src/core/conformation/membrane/MembraneInfo.hh
+++ b/source/src/core/conformation/membrane/MembraneInfo.hh
@@ -145,9 +145,6 @@ public: // Constructors & Setup
 	MembraneInfo &
 	operator=( MembraneInfo const & src );
 
-	/// @brief Destructor
-	~MembraneInfo() override;
-
 	/// @brief Generate a string representation of information represented by this MembraneInfo and send it to std::cout
 	virtual void show() const;
 

--- a/source/src/core/conformation/membrane/membrane_geometry/Bicelle.cc
+++ b/source/src/core/conformation/membrane/membrane_geometry/Bicelle.cc
@@ -113,9 +113,6 @@ Bicelle::Bicelle(
 	update_outer_radius();
 }
 
-/// @brief Destructor
-Bicelle::~Bicelle() {}
-
 
 MembraneGeometryOP
 Bicelle::clone() const {

--- a/source/src/core/conformation/membrane/membrane_geometry/Bicelle.hh
+++ b/source/src/core/conformation/membrane/membrane_geometry/Bicelle.hh
@@ -68,9 +68,6 @@ public: // Constructors & Setup
 
 	Bicelle( core::Real steepness, core::Real thickness, core::Real bicelle_inner_radius, AqueousPoreParametersOP aqueous_pore );
 
-	/// @brief Destructor
-	~Bicelle() override;
-
 	MembraneGeometryOP
 	clone() const override;
 

--- a/source/src/core/conformation/membrane/membrane_geometry/DoubleVesicle.cc
+++ b/source/src/core/conformation/membrane/membrane_geometry/DoubleVesicle.cc
@@ -105,9 +105,6 @@ DoubleVesicle::DoubleVesicle(
 }
 
 
-/// @brief Destructor
-DoubleVesicle::~DoubleVesicle() {}
-
 MembraneGeometryOP DoubleVesicle::clone() const {
 	return DoubleVesicleOP( new DoubleVesicle( *this ) );
 }

--- a/source/src/core/conformation/membrane/membrane_geometry/DoubleVesicle.hh
+++ b/source/src/core/conformation/membrane/membrane_geometry/DoubleVesicle.hh
@@ -64,9 +64,6 @@ public: // Constructors & Setup
 
 	DoubleVesicle( core::Real steepness, core::Real thickness, core::Real inner_radius, core::Real distance, AqueousPoreParametersOP aqueous_pore);
 
-	/// @brief Destructor
-	~DoubleVesicle() override;
-
 	MembraneGeometryOP
 	clone() const override;
 

--- a/source/src/core/conformation/membrane/membrane_geometry/Slab.cc
+++ b/source/src/core/conformation/membrane/membrane_geometry/Slab.cc
@@ -80,9 +80,6 @@ Slab::Slab(
 	MembraneGeometry( steepness, thickness, aqueous_pore )
 {}
 
-/// @brief Destructor
-Slab::~Slab() {}
-
 MembraneGeometryOP Slab::clone() const {
 	return SlabOP( new Slab( *this ) );
 }

--- a/source/src/core/conformation/membrane/membrane_geometry/Slab.hh
+++ b/source/src/core/conformation/membrane/membrane_geometry/Slab.hh
@@ -60,9 +60,6 @@ public: // Constructors & Setup
 
 	Slab( core::Real steepness, core::Real thickness, AqueousPoreParametersOP aqueous_pore );
 
-	/// @brief Destructor
-	~Slab() override;
-
 	MembraneGeometryOP
 	clone() const override;
 

--- a/source/src/core/conformation/membrane/membrane_geometry/Vesicle.cc
+++ b/source/src/core/conformation/membrane/membrane_geometry/Vesicle.cc
@@ -95,9 +95,6 @@ Vesicle::Vesicle(
 	radius_( radius )
 {}
 
-/// @brief Destructor
-Vesicle::~Vesicle() {}
-
 MembraneGeometryOP Vesicle::clone() const {
 	return VesicleOP( new Vesicle( *this ) );
 }

--- a/source/src/core/conformation/membrane/membrane_geometry/Vesicle.hh
+++ b/source/src/core/conformation/membrane/membrane_geometry/Vesicle.hh
@@ -62,9 +62,6 @@ public: // Constructors & Setup
 
 	Vesicle( core::Real steepness, core::Real thickness, core::Real radius, AqueousPoreParametersOP aqueous_pore );
 
-	/// @brief Destructor
-	~Vesicle() override;
-
 	MembraneGeometryOP
 	clone() const override;
 

--- a/source/src/core/conformation/parametric/BooleanValuedParameter.cc
+++ b/source/src/core/conformation/parametric/BooleanValuedParameter.cc
@@ -64,8 +64,6 @@ BooleanValuedParameter::BooleanValuedParameter( BooleanValuedParameter const & s
 {
 }
 
-BooleanValuedParameter::~BooleanValuedParameter() {}
-
 /// @brief Make a copy of this object ( allocate actual memory for it )
 ///
 ParameterOP

--- a/source/src/core/conformation/parametric/BooleanValuedParameter.hh
+++ b/source/src/core/conformation/parametric/BooleanValuedParameter.hh
@@ -52,8 +52,6 @@ public:
 
 	BooleanValuedParameter( BooleanValuedParameter const & src );
 
-	~BooleanValuedParameter() override;
-
 	/// @brief Make a copy of this object ( allocate actual memory for it )
 	///
 	ParameterOP clone() const override;

--- a/source/src/core/conformation/parametric/RealValuedParameter.cc
+++ b/source/src/core/conformation/parametric/RealValuedParameter.cc
@@ -86,8 +86,6 @@ RealValuedParameter::RealValuedParameter( RealValuedParameter const & src ) :
 {
 }
 
-RealValuedParameter::~RealValuedParameter() {}
-
 
 /// @brief Make a copy of this object ( allocate actual memory for it )
 ///

--- a/source/src/core/conformation/parametric/RealValuedParameter.hh
+++ b/source/src/core/conformation/parametric/RealValuedParameter.hh
@@ -65,8 +65,6 @@ public:
 
 	RealValuedParameter( RealValuedParameter const & src );
 
-	~RealValuedParameter() override;
-
 	/// @brief Make a copy of this object ( allocate actual memory for it )
 	///
 	ParameterOP clone() const override;

--- a/source/src/core/conformation/parametric/RealVectorValuedParameter.cc
+++ b/source/src/core/conformation/parametric/RealVectorValuedParameter.cc
@@ -67,8 +67,6 @@ RealVectorValuedParameter::RealVectorValuedParameter( RealVectorValuedParameter 
 {
 }
 
-RealVectorValuedParameter::~RealVectorValuedParameter() {}
-
 
 /// @brief Make a copy of this object ( allocate actual memory for it )
 ///

--- a/source/src/core/conformation/parametric/RealVectorValuedParameter.hh
+++ b/source/src/core/conformation/parametric/RealVectorValuedParameter.hh
@@ -54,8 +54,6 @@ public:
 
 	RealVectorValuedParameter( RealVectorValuedParameter const & src );
 
-	~RealVectorValuedParameter() override;
-
 	/// @brief Make a copy of this object ( allocate actual memory for it )
 	///
 	ParameterOP clone() const override;

--- a/source/src/core/conformation/parametric/SizeValuedParameter.cc
+++ b/source/src/core/conformation/parametric/SizeValuedParameter.cc
@@ -65,8 +65,6 @@ SizeValuedParameter::SizeValuedParameter( SizeValuedParameter const & src ) :
 {
 }
 
-SizeValuedParameter::~SizeValuedParameter() {}
-
 /// @brief Make a copy of this object ( allocate actual memory for it )
 ///
 ParameterOP

--- a/source/src/core/conformation/parametric/SizeValuedParameter.hh
+++ b/source/src/core/conformation/parametric/SizeValuedParameter.hh
@@ -53,8 +53,6 @@ public:
 
 	SizeValuedParameter( SizeValuedParameter const & src );
 
-	~SizeValuedParameter() override;
-
 	/// @brief Make a copy of this object ( allocate actual memory for it )
 	///
 	ParameterOP clone() const override;

--- a/source/src/core/conformation/parametric/SizeVectorValuedParameter.cc
+++ b/source/src/core/conformation/parametric/SizeVectorValuedParameter.cc
@@ -69,8 +69,6 @@ SizeVectorValuedParameter::SizeVectorValuedParameter( SizeVectorValuedParameter 
 {
 }
 
-SizeVectorValuedParameter::~SizeVectorValuedParameter() {}
-
 /// @brief Make a copy of this object ( allocate actual memory for it )
 ///
 ParameterOP

--- a/source/src/core/conformation/parametric/SizeVectorValuedParameter.hh
+++ b/source/src/core/conformation/parametric/SizeVectorValuedParameter.hh
@@ -54,8 +54,6 @@ public:
 
 	SizeVectorValuedParameter( SizeVectorValuedParameter const & src );
 
-	~SizeVectorValuedParameter() override;
-
 	/// @brief Make a copy of this object ( allocate actual memory for it )
 	///
 	ParameterOP clone() const override;

--- a/source/src/core/energy_methods/SAXSEnergy.hh
+++ b/source/src/core/energy_methods/SAXSEnergy.hh
@@ -53,8 +53,6 @@ public:
 	SAXSEnergy(const std::string &,const utility::vector1<Real> &,const utility::vector1<Real> &,
 		core::scoring::ScoreType, core::scoring::methods::EnergyMethodCreatorOP);
 
-	~SAXSEnergy() override {}
-
 	core::scoring::methods::EnergyMethodOP clone() const override {
 
 		if ( saxs_score_variant_ == core::scoring::saxs_fa_score ) {

--- a/source/src/core/io/silent/SilentFileData.hh
+++ b/source/src/core/io/silent/SilentFileData.hh
@@ -450,8 +450,6 @@ public:
 			it_( s_iter)
 		{}
 
-		~iterator() {}
-
 		bool operator==( const iterator& other ) const {
 			return ( it_ == other.it_ );
 		}
@@ -504,8 +502,6 @@ public:
 		const_iterator( Structure_Map::const_iterator s_iter ) :
 			it_( s_iter )
 		{}
-
-		~const_iterator() {}
 
 		bool operator==( const const_iterator& other ) {
 			return ( it_ == other.it_ );

--- a/source/src/core/pack/interaction_graph/RotamerDots.cc
+++ b/source/src/core/pack/interaction_graph/RotamerDots.cc
@@ -183,9 +183,6 @@ DotSphere::DotSphere() :
 }
 
 ///
-DotSphere::~DotSphere() = default;
-
-///
 /// @brief
 /// copy constructor
 ///
@@ -519,11 +516,6 @@ RotamerDots::RotamerDots(
 		radii_ = RotamerDotsRadiusData::get_instance()->get_NACCESS_SASA_radii();
 	}
 
-}
-
-///
-RotamerDots::~RotamerDots() {
-	//TR_RD << "called destructor" << std::endl;
 }
 
 ///
@@ -1577,9 +1569,6 @@ RotamerDotsCache::RotamerDotsCache( Size num_atoms ) {
 RotamerDotsCache::RotamerDotsCache( RotamerDotsCache const & /*rhs*/ ) = default;
 
 ///
-RotamerDotsCache::~RotamerDotsCache() = default;
-
-///
 /// @brief
 /// assignment operator
 ///
@@ -1681,8 +1670,6 @@ InvRotamerDots::InvRotamerDots( InvRotamerDots const & src ) :
 	inv_dots_( src.inv_dots_ ),
 	radii_( src.radii_ )
 {}
-
-InvRotamerDots::~InvRotamerDots() = default;
 
 InvRotamerDots &
 InvRotamerDots::operator= ( InvRotamerDots const & rhs ) {

--- a/source/src/core/pack/interaction_graph/RotamerDots.hh
+++ b/source/src/core/pack/interaction_graph/RotamerDots.hh
@@ -65,7 +65,6 @@ class DotSphere {
 
 public:
 	DotSphere();
-	~DotSphere();
 	DotSphere( DotSphere const & rhs );
 	DotSphere & operator= ( DotSphere const & rhs );
 	bool operator!= ( DotSphere const & rhs );
@@ -139,7 +138,6 @@ class RotamerDots : public utility::VirtualBase {
 public:
 	RotamerDots();
 	RotamerDots( conformation::ResidueCOP rotamer, bool exclude_hydrogen_atoms = false, bool use_expanded_polar_atom_radii = false );
-	~RotamerDots() override;
 	RotamerDots( RotamerDots const & rhs );
 
 	void copy(RotamerDots const & rhs);
@@ -334,7 +332,6 @@ public:
 	RotamerDotsCache( core::Size num_atoms );
 	RotamerDotsCache( RotamerDotsCache const & rhs );
 	RotamerDotsCache & operator= ( RotamerDotsCache const & rhs );
-	~RotamerDotsCache();
 
 	void resize( core::Size num_atoms );
 	void zero();
@@ -362,7 +359,6 @@ class InvRotamerDots : public utility::VirtualBase {
 public:
 	InvRotamerDots();
 	InvRotamerDots( InvRotamerDots const & src );
-	~InvRotamerDots() override;
 
 	InvRotamerDots & operator = ( InvRotamerDots const & rhs );
 

--- a/source/src/core/scoring/etable/EtableEnergy.cc
+++ b/source/src/core/scoring/etable/EtableEnergy.cc
@@ -356,8 +356,6 @@ EtableEvaluator::EtableEvaluator( Etable const & etable ) :
 	hydrogen_interaction_cutoff2_( etable.hydrogen_interaction_cutoff2() )
 {}
 
-EtableEvaluator::~EtableEvaluator() = default;
-
 TableLookupEvaluator::TableLookupEvaluator(
 	Etable const & etable_in
 ) :
@@ -373,8 +371,6 @@ TableLookupEvaluator::TableLookupEvaluator(
 	etable_bins_per_A2_( etable_in.get_bins_per_A2() )
 	//dis2_step_( 1.0 / (Real) etable_bins_per_A2_ )
 {}
-
-TableLookupEvaluator::~TableLookupEvaluator() = default;
 
 EtableEvaluatorOP
 TableLookupEvaluator::clone() const {
@@ -475,8 +471,6 @@ AnalyticEtableEvaluator::AnalyticEtableEvaluator( Etable const & etable ) :
 	etable_( etable ),
 	safe_max_dis2_( etable.get_safe_max_dis2() )
 {}
-
-AnalyticEtableEvaluator::~AnalyticEtableEvaluator() = default;
 
 EtableEvaluatorOP
 AnalyticEtableEvaluator::clone() const {

--- a/source/src/core/scoring/etable/EtableEnergy.hh
+++ b/source/src/core/scoring/etable/EtableEnergy.hh
@@ -50,7 +50,6 @@ class EtableEvaluator : public utility::VirtualBase {
 
 public:
 	EtableEvaluator( Etable const & etable );
-	~EtableEvaluator() override;
 
 	virtual EtableEvaluatorOP clone() const = 0;
 
@@ -216,7 +215,6 @@ class AnalyticEtableEvaluator : public EtableEvaluator
 {
 public:
 	AnalyticEtableEvaluator( Etable const & etable );
-	~AnalyticEtableEvaluator() override;
 
 	EtableEvaluatorOP clone() const override;
 
@@ -507,7 +505,6 @@ class TableLookupEvaluator : public EtableEvaluator
 {
 public:
 	TableLookupEvaluator( Etable const & etable_in );
-	~TableLookupEvaluator() override;
 
 	EtableEvaluatorOP clone() const override;
 

--- a/source/src/core/scoring/hbonds/graph/HBondInfo.hh
+++ b/source/src/core/scoring/hbonds/graph/HBondInfo.hh
@@ -24,9 +24,7 @@ namespace graph {
 
 class LKHBondInfo {
 public:
-	LKHBondInfo( LKHBondInfo const & ){}
-
-	virtual ~LKHBondInfo(){}
+	virtual ~LKHBondInfo() = default;
 
 public:
 
@@ -74,7 +72,7 @@ public:
 	{}
 
 
-	virtual ~HBondInfo(){}
+	virtual ~HBondInfo() = default;
 
 public:
 	bool first_node_is_donor() const {

--- a/source/src/core/scoring/nmr/NMRDummySpinlabelVoxelGrid.cc
+++ b/source/src/core/scoring/nmr/NMRDummySpinlabelVoxelGrid.cc
@@ -60,9 +60,6 @@ VoxelGridPoint::VoxelGridPoint(
 	coords_(coords)
 {}
 
-/// @brief Destructor
-VoxelGridPoint::~VoxelGridPoint() {}
-
 /// @brief Type name of this voxel grid point
 std::string
 VoxelGridPoint::type() const {
@@ -96,9 +93,6 @@ NMRDummySpinlabelAtom::NMRDummySpinlabelAtom(
 	VoxelGridPoint(name, id, coords),
 	conformer_(&conformer)
 {}
-
-/// @brief Destructor
-NMRDummySpinlabelAtom::~NMRDummySpinlabelAtom() {}
 
 /// @brief Type name of this voxel grid point
 std::string
@@ -134,9 +128,6 @@ VoxelGridPoint_AA::VoxelGridPoint_AA(
 	VoxelGridPoint(name, id, coords),
 	residue_(&resi)
 {}
-
-/// @brief Destructor
-VoxelGridPoint_AA::~VoxelGridPoint_AA() {}
 
 /// @brief Type name of this voxel grid point
 std::string
@@ -174,9 +165,6 @@ NMRDummySpinlabelVoxelGrid::NMRDummySpinlabelVoxelGrid(
 {
 	SetObjects(points);
 }
-
-/// @brief Destructor
-NMRDummySpinlabelVoxelGrid::~NMRDummySpinlabelVoxelGrid() {}
 
 /// @brief Extract the 3D coordinate of a given object of type VoxelGridPoint.
 Vector const *

--- a/source/src/core/scoring/nmr/NMRDummySpinlabelVoxelGrid.hh
+++ b/source/src/core/scoring/nmr/NMRDummySpinlabelVoxelGrid.hh
@@ -55,9 +55,6 @@ public: // Methods
 		Vector const & coords
 	);
 
-	/// @brief Destructor
-	~VoxelGridPoint() override;
-
 	/// @brief Type name of this voxel grid point
 	virtual std::string type() const;
 
@@ -100,9 +97,6 @@ public: // Methods
 		NMRDummySpinlabelConformer const & conformer
 	);
 
-	/// @brief Destructor
-	~NMRDummySpinlabelAtom() override;
-
 	/// @brief Type name of this voxel grid point
 	std::string type() const override;
 
@@ -135,9 +129,6 @@ public: // Methods
 		conformation::Residue const & resi
 	);
 
-	/// @brief Destructor
-	~VoxelGridPoint_AA() override;
-
 	/// @brief Type name of this voxel grid point
 	std::string type() const override;
 
@@ -167,9 +158,6 @@ public: // Methods
 		utility::vector1< VoxelGridPoint const * > const & points,
 		bool const & cache_edges = false
 	);
-
-	/// @brief Destructor
-	~NMRDummySpinlabelVoxelGrid() override;
 
 	/// @brief Extract the 3D coordinate of a given object of type VoxelGridPoint.
 	Vector const *

--- a/source/src/core/scoring/sc/MolecularSurfaceCalculator.cc
+++ b/source/src/core/scoring/sc/MolecularSurfaceCalculator.cc
@@ -1320,8 +1320,6 @@ Atom::Atom() : numeric::xyzVector < MolecularSurfaceCalculator::ScValue > (0.0)
 	memset(residue, 0, sizeof(residue));
 }
 
-Atom::~Atom() = default;
-
 // The End
 ////////////////////////////////////////////////////////////////////////////
 

--- a/source/src/core/scoring/sc/MolecularSurfaceCalculator.hh
+++ b/source/src/core/scoring/sc/MolecularSurfaceCalculator.hh
@@ -158,7 +158,6 @@ public:
 
 public:
 	Atom();
-	~Atom();
 
 	int operator ==(Atom const &atom2) {
 		// <EVIL>


### PR DESCRIPTION
## Summary

Remove trivially empty (`~X() {}`) or `= default;`-bodied destructors across `core/`, **deleting the declaration outright** rather than re-declaring it as `= default` in the header. The now-redundant out-of-line `.cc` definitions are removed as well.

Per @roccomoretti's review, two corrections to the original approach:

1. **`~X() override = default;` is unnecessary.** For every derived class here the base already declares a virtual destructor, so the destructor is virtual by inheritance whether or not it is declared — the explicit declaration bought nothing. Omitting it is the actual Rule of Zero: it keeps the destructor virtual (inherited) and drops the boilerplate.
2. **Defaulting the destructor does *not* restore the implicit move members.** A `~X() = default;` destructor is still *user-declared*, which suppresses the implicit move constructor/assignment exactly as a user-provided one would. (An earlier version of this description wrongly claimed defaulting "unlocks" moves.) Only omitting the destructor entirely lets the implicit moves be generated — and then only for classes with no other user-declared special members.

Two classes are polymorphic bases that need an explicitly-declared virtual destructor and therefore **keep `virtual ~X() = default;`**: `LKHBondInfo` and `HBondInfo`.

## Affected sibling groups

- `core/conformation/membrane/{AqueousPoreParameters, ImplicitLipidInfo, MembraneGeometry, MembraneInfo}` and `membrane_geometry/{Bicelle, DoubleVesicle, Slab, Vesicle}` — 8 classes
- `core/conformation/parametric/{Boolean, Real, RealVector, Size, SizeVector}ValuedParameter` — 5 classes
- `core/io/silent/SilentFileData::{iterator, const_iterator}` — inline empty dtors removed
- `core/pack/interaction_graph/RotamerDots.{hh,cc}` — `DotSphere`, `RotamerDots`, `RotamerDotsCache`, `InvRotamerDots`
- `core/scoring/etable/EtableEnergy.{hh,cc}` — `EtableEvaluator`, `AnalyticEtableEvaluator`, `TableLookupEvaluator`
- `core/scoring/hbonds/graph/HBondInfo.hh` — `LKHBondInfo`, `HBondInfo` kept as `virtual ~X() = default;` (polymorphic roots); also removed an unused user-defined empty copy ctor on `LKHBondInfo`
- `core/scoring/nmr/NMRDummySpinlabelVoxelGrid.{hh,cc}` — `VoxelGridPoint`, `NMRDummySpinlabelAtom`, `VoxelGridPoint_AA`, `NMRDummySpinlabelVoxelGrid`
- `core/scoring/sc/MolecularSurfaceCalculator::Atom`
- `core/energy_methods/SAXSEnergy`

Verified that no `.cc` retains an out-of-line definition for any removed destructor, and the native Rosetta beautifier reports no formatting changes on the touched headers. Pure code-style refactor; no intended behavior change.
