### PR TITLE
Fix off-by-one loops over 1-indexed residue/atom/element ranges

### DIFF
--- a/source/src/core/energy_methods/RNA_LJ_BaseEnergy.cc
+++ b/source/src/core/energy_methods/RNA_LJ_BaseEnergy.cc
@@ -325,7 +325,7 @@ RNA_LJ_BaseEnergy::eval_atom_energy(
 
 	Vector const heavy_atom_i( rsd1.xyz( m ) );
 
-	for ( Size j = 1; j < pose.size(); j ++ ) {
+	for ( Size j = 1; j <= pose.size(); j ++ ) {
 		if ( i == j ) continue;
 
 		conformation::Residue const & rsd2( pose.residue( j ) );

--- a/source/src/core/io/pose_to_sfr/PoseToStructFileRepConverter.cc
+++ b/source/src/core/io/pose_to_sfr/PoseToStructFileRepConverter.cc
@@ -1503,7 +1503,7 @@ PoseToStructFileRepConverter::generate_secondary_structure_informations( core::p
 	core::Size new_tercount( 0 ); //we have to track this for ResidueInformation
 
 	//Now we are going to iterate through the pose, identifying secondary structure elements
-	for ( Size ires=1; ires<pose.size(); ++ires ) {
+	for ( Size ires=1; ires<=pose.size(); ++ires ) {
 		char secstruct = secstructs[ires-1]; //H, E, or L; note indexing fix
 		Size chain = pose.residue(ires).chain();
 		Size jres = ires;

--- a/source/src/core/pack/interaction_graph/SurfacePotential.cc
+++ b/source/src/core/pack/interaction_graph/SurfacePotential.cc
@@ -293,7 +293,7 @@ void SurfacePotential::compute_residue_surface_energy( conformation::Residue con
 	// in (being considered) rotamer, not of the wild type sequence rotamer.  In a small percent of the cases, using the wild type
 	// nbr_atom will give a different count than when using the new rotamer nbr_atom position.
 	Real distanceBetweenAtoms = 0.0;
-	for ( Size res2_position = 1; res2_position < pose.size(); ++res2_position ) {
+	for ( Size res2_position = 1; res2_position <= pose.size(); ++res2_position ) {
 
 		if ( resid == res2_position ) { continue; }
 		conformation::Residue const & rsd2 = pose.residue( res2_position );
@@ -419,7 +419,7 @@ void SurfacePotential::compute_pose_surface_energy( pose::Pose const & pose, Rea
 		conformation::Residue const & rsd1 = pose.residue( res1_position );
 		Real distanceBetweenAtoms = 0.0;
 
-		for ( Size res2_position = 1; res2_position < pose.size(); ++res2_position ) {
+		for ( Size res2_position = 1; res2_position <= pose.size(); ++res2_position ) {
 			if ( pose.residue( res2_position ).aa() > core::chemical::num_canonical_aas ) continue;
 			if ( symm_info && !symm_info->bb_is_independent(res2_position) ) continue;
 
@@ -462,7 +462,7 @@ void SurfacePotential::compute_pose_surface_energy( pose::Pose const & pose, Rea
 
 
 	total_surface_energy_ = 0.0;
-	for ( Size ii=1; ii < residue_surface_energy_.size(); ++ii ) {
+	for ( Size ii=1; ii <= residue_surface_energy_.size(); ++ii ) {
 		total_surface_energy_ += residue_surface_energy_[ii];
 	}
 

--- a/source/src/core/pose/rna/util.cc
+++ b/source/src/core/pose/rna/util.cc
@@ -2058,7 +2058,7 @@ detect_base_contacts( core::pose::Pose const & pose ) {
 				if ( i == j ) continue;
 				if ( ( pose.residue( i ).nbr_atom_xyz() - pose.residue( j ).nbr_atom_xyz() ).length() > NBR_DIST_CUTOFF ) continue;
 
-				for ( Size jj = 1; jj < pose.residue_type( j ).nheavyatoms(); jj++ ) {
+				for ( Size jj = 1; jj <= pose.residue_type( j ).nheavyatoms(); jj++ ) {
 					if ( pose.residue_type( j ).is_virtual( jj ) ) continue;
 					if ( ( pose.residue( i ).xyz( ii ) - pose.residue( j ).xyz( jj ) ).length() < CONTACT_DIST_CUTOFF ) {
 						//      TR << "FOUND CONTACT " << pose.pdb_info()->chain(i) << ":" << pose.pdb_info()->number( i ) << " " << pose.residue(i).atom_name(ii)

--- a/source/src/core/select/residue_selector/JumpUpstreamSelector.cc
+++ b/source/src/core/select/residue_selector/JumpUpstreamSelector.cc
@@ -77,7 +77,7 @@ JumpUpstreamSelector::apply( core::pose::Pose const & pose ) const
 	ObjexxFCL::FArray1D_bool upstream( pose.size() );
 	pose.fold_tree().partition_by_jump( jump_, upstream );
 
-	for ( core::Size ii = 1; ii < upstream.size(); ++ii ) {
+	for ( core::Size ii = 1; ii <= upstream.size(); ++ii ) {
 		subset[ ii ] = upstream( ii );
 	}
 	return subset;

--- a/source/src/protocols/antibody/residue_selector/CDRResidueSelector.cc
+++ b/source/src/protocols/antibody/residue_selector/CDRResidueSelector.cc
@@ -130,7 +130,7 @@ void
 CDRResidueSelector::set_cdrs( utility::vector1< CDRNameEnum > cdrs ){
 	cdrs_.clear();
 	cdrs_.resize(8, false);
-	for ( core::Size i = 1; i < cdrs.size(); ++i ) {
+	for ( core::Size i = 1; i <= cdrs.size(); ++i ) {
 		cdrs_[ cdrs[ i ] ] = true;
 	}
 }

--- a/source/src/protocols/canonical_sampling/mc_convergence_checks/HierarchicalLevel.cc
+++ b/source/src/protocols/canonical_sampling/mc_convergence_checks/HierarchicalLevel.cc
@@ -307,7 +307,7 @@ HierarchicalLevel::num_matching_levels( utility::vector1< core::Size > & address
 	utility::vector1< core::Size > & address2 ){
 	runtime_assert( address1.size() == address2.size() );
 	core::Size num_matching_levels = 0;
-	for ( core::Size ii = 1; ii < address1.size(); ii++ ) {
+	for ( core::Size ii = 1; ii <= address1.size(); ii++ ) {
 		if ( address1[ ii ] == address2[ ii ] ) {
 			num_matching_levels++;
 		}

--- a/source/src/protocols/cartesian/md.cc
+++ b/source/src/protocols/cartesian/md.cc
@@ -1275,7 +1275,7 @@ void MolecularDynamics::applyForces_ConjugateGradient(
 
 		}
 	} else { // this block is for Step == 0 - its just a standard SD Step
-		for ( core::Size i = 1; i < cartom.size(); i++ ) {
+		for ( core::Size i = 1; i <= cartom.size(); i++ ) {
 			cartom[i].old_position    =  cartom[i].position; // save position (old position = current position)
 			cartom[i].old_force       =  cartom[i].force * forcemul; // save old forces
 			cartom[i].old_velocity    =  -cartom[i].force * forcemul; // save old directions, equal to old force
@@ -1483,7 +1483,7 @@ void MolecularDynamics::testCartesianDerivatives( core::scoring::ScoreFunction c
 	}
 
 
-	for ( core::Size i = 1; i < cartom.size(); i++ ) {
+	for ( core::Size i = 1; i <= cartom.size(); i++ ) {
 
 		if (  ( fabs( cartom[i].force.x()  -  numeriv[i].x()     ) > 0.1 ) ||
 				( fabs( cartom[i].force.y()  -  numeriv[i].y()     ) > 0.1 ) ||

--- a/source/src/protocols/cutoutdomain/CutOutDomain.cc
+++ b/source/src/protocols/cutoutdomain/CutOutDomain.cc
@@ -90,7 +90,7 @@ core::Size
 CutOutDomain::find_nearest_res( core::pose::Pose const & source, core::pose::Pose const & target, core::Size const res, core::Size const chain/*=0*/ ){
 	core::Real min_dist( 100000 ); core::Size nearest_res( 0 );
 	core::Size i;
-	for ( i = 1; i < target.size(); ++i ) {
+	for ( i = 1; i <= target.size(); ++i ) {
 		if ( target.residue( i ).is_ligand() ) continue;
 		if ( chain && target.residue( i ).chain() != chain ) continue;
 		// TR<<"the residue examnied is:"<<i<<target.residue(i).name1()<<std::endl;

--- a/source/src/protocols/denovo_design/components/FoldGraph.cc
+++ b/source/src/protocols/denovo_design/components/FoldGraph.cc
@@ -852,7 +852,7 @@ FoldGraph::compute_best_solution( SegmentNames const & staple_loops ) const
 						solutions[sol].push_back( new_visited );
 					} else {
 						Solution tmpset;
-						for ( core::Size t=1; t<solutions[sol].size(); ++t ) {
+						for ( core::Size t=1; t<=solutions[sol].size(); ++t ) {
 							tmpset.push_back( solutions[sol][t] );
 						}
 						tmpset.push_back( new_visited );

--- a/source/src/protocols/docking/DockingEnsemblePrepackProtocol.cc
+++ b/source/src/protocols/docking/DockingEnsemblePrepackProtocol.cc
@@ -304,7 +304,7 @@ void DockingEnsemblePrepackProtocol::check_ensemble_member_compatibility() {
 
 			// if the chain identities are not equivalent, error!
 			// assuming ensemble 1 chains are first reported in parterns flag
-			for ( core::Size k=1; k<chains.size(); ++k ) {
+			for ( core::Size k=1; k<=chains.size(); ++k ) {
 				if ( chains[k] != partners.partner1[k] ) {
 					std::string exit_message = "Ensemble 1 member differs in chain identity from partners flag!\n";
 					exit_message = exit_message + "Member " + std::to_string(i) + ": " + chains[k] + " vs. " + partners.partner1[k] + "\n";
@@ -328,7 +328,7 @@ void DockingEnsemblePrepackProtocol::check_ensemble_member_compatibility() {
 
 			// if the chain identities are not equivalent, error!
 			// assuming ensemble 2 chains are second reported in parterns flag
-			for ( core::Size k=1; k<chains.size(); ++k ) {
+			for ( core::Size k=1; k<=chains.size(); ++k ) {
 				if ( chains[k] != partners.partner2[k] ) {
 					std::string exit_message = "Ensemble 2 member differs in chain identity from partners flag!\n";
 					exit_message = exit_message + "Member " + std::to_string(i) + ": " + chains[k] + " vs. " + partners.partner2[k] + "\n";

--- a/source/src/protocols/docking/metrics.cc
+++ b/source/src/protocols/docking/metrics.cc
@@ -521,7 +521,7 @@ calc_Fnonnat( const core::pose::Pose & pose, const core::pose::Pose & native_pos
 
 		//generate list of interface residues for partner 1 and partner 2
 		core::Size cutpoint = 0;
-		for ( core::Size i = 1; i < pose.size(); i++ ) {
+		for ( core::Size i = 1; i <= pose.size(); i++ ) {
 			if ( !temp_part( i ) ) {
 				cutpoint = i;
 				break;
@@ -596,7 +596,7 @@ calc_Fnonnat( const core::pose::Pose & pose, std::string const& list_file, DockJ
 		ObjexxFCL::FArray1D_bool temp_part ( pose.size(), false );
 		pose.fold_tree().partition_by_jump( rb_jump, temp_part );
 		core::Size cutpoint = 0;
-		for ( core::Size i = 1; i < pose.size(); i++ ) {
+		for ( core::Size i = 1; i <= pose.size(); i++ ) {
 			if ( !temp_part( i ) ) {
 				cutpoint = i;
 				break;

--- a/source/src/protocols/enzdes/EnzRepackMinimize.cc
+++ b/source/src/protocols/enzdes/EnzRepackMinimize.cc
@@ -134,7 +134,7 @@ EnzRepackMinimize::apply( pose::Pose & pose )
 			core::kinematics::MoveMapOP movemap = enzprot->create_enzdes_movemap( pose, task_, minimize_prot_jumps_  );
 			core::scoring::ScoreFunctionCOP br_scorefxn = scorefxn_minimize_;
 			utility::vector1<core::Size> residues;
-			for ( core::Size i =1; i<pose.size(); ++i ) {
+			for ( core::Size i =1; i<=pose.size(); ++i ) {
 				if ( movemap->get_bb(i) ) residues.push_back(i);
 			}
 			TR<<"Now Backrub minimizing:  min_sc "<<min_sc_<<" min_bb "<< min_bb_<<std::endl;

--- a/source/src/protocols/features/strand_assembly/StrandBundleFeatures.cc
+++ b/source/src/protocols/features/strand_assembly/StrandBundleFeatures.cc
@@ -934,8 +934,8 @@ StrandBundleFeatures::shortest_dis_sidechain(
 
 		for ( core::Size strand_j_res=0; strand_j_res < strand_j.get_size(); strand_j_res++ ) {
 			core::Size j_resnum = strand_j.get_start()+strand_j_res;
-			for ( core::Size i_AtomNum=1; i_AtomNum < pose.residue(i_resnum).natoms(); i_AtomNum++ ) {
-				for ( core::Size j_AtomNum=1; j_AtomNum < pose.residue(j_resnum).natoms(); j_AtomNum++ ) {
+			for ( core::Size i_AtomNum=1; i_AtomNum <= pose.residue(i_resnum).natoms(); i_AtomNum++ ) {
+				for ( core::Size j_AtomNum=1; j_AtomNum <= pose.residue(j_resnum).natoms(); j_AtomNum++ ) {
 					Real dis_sc_sc = pose.residue(i_resnum).xyz(i_AtomNum).distance(pose.residue(j_resnum).xyz(j_AtomNum));
 					if ( temp_shortest_dis > dis_sc_sc ) {
 						temp_shortest_dis = dis_sc_sc;

--- a/source/src/protocols/fldsgn/MatchResidues.cc
+++ b/source/src/protocols/fldsgn/MatchResidues.cc
@@ -62,7 +62,7 @@ core::Real
 MatchResidues::compute_comb( core::pose::Pose const & pose, VecSize const & comb ) const
 {
 	std::map< core::id::AtomID, core::id::AtomID > atom_id_map;
-	for ( core::Size i = 1; i < comb.size(); i++ ) {
+	for ( core::Size i = 1; i <= comb.size(); i++ ) {
 		const core::id::AtomID mod_id(pose.residue_type( comb[i] ).atom_index( "CA" ), comb[i] );
 		const core::id::AtomID ref_id(pose.residue_type( reference_residues_indexes_[i] ).atom_index( "CA" ), reference_residues_indexes_[i]);
 		atom_id_map.insert( std::make_pair(mod_id, ref_id) );
@@ -75,7 +75,7 @@ MatchResidues::superimpose_comb( core::pose::Pose & pose, VecSize const & comb )
 {
 	core::id::AtomID_Map< core::id::AtomID > atom_map;
 	core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
-	for ( core::Size i = 1; i < comb.size(); ++i ) {
+	for ( core::Size i = 1; i <= comb.size(); ++i ) {
 		const core::id::AtomID mod_id(pose.residue_type( comb[i] ).atom_index( "CA" ), comb[i] );
 		const core::id::AtomID ref_id(pose.residue_type( reference_residues_indexes_[i] ).atom_index( "CA" ), reference_residues_indexes_[i]);
 		atom_map.set( mod_id, ref_id);

--- a/source/src/protocols/frag_picker/GrabAllCollector.hh
+++ b/source/src/protocols/frag_picker/GrabAllCollector.hh
@@ -66,7 +66,7 @@ public:
 
 	inline void clear() override
 	{
-		for ( core::Size i=1; i<storage_.size(); ++i ) {
+		for ( core::Size i=1; i<=storage_.size(); ++i ) {
 			storage_[i].clear();
 		}
 	}

--- a/source/src/protocols/frag_picker/VallProvider.cc
+++ b/source/src/protocols/frag_picker/VallProvider.cc
@@ -66,7 +66,7 @@ VallChunkOP VallProvider::find_chunk(std::string pdb_id, char chain_id, core::Si
 		if ( c->get_chain_id() != chain_id ) {
 			continue;
 		}
-		for ( core::Size j = 1; j < c->size(); ++j ) {
+		for ( core::Size j = 1; j <= c->size(); ++j ) {
 			if ( c->at(j)->resi() == residue_id ) {
 				return c;
 			}

--- a/source/src/protocols/frag_picker/quota/QuotaCollector.cc
+++ b/source/src/protocols/frag_picker/quota/QuotaCollector.cc
@@ -51,9 +51,9 @@ bool QuotaCollector::add(std::pair<FragmentCandidateOP, scores::FragmentScoreMap
 
 void QuotaCollector::list_pools(std::ostream & where) const {
 
-	for ( core::Size i=1; i<storage_.size(); ++i ) {
+	for ( core::Size i=1; i<=storage_.size(); ++i ) {
 		where << std::setw(3) << i;
-		for ( core::Size j=1; j<storage_[i].size(); ++j ) {
+		for ( core::Size j=1; j<=storage_[i].size(); ++j ) {
 			where << std::setw(10) << storage_[i][j]->get_pool_name() << "(" << std::setw(3) << storage_[i][j]->total_size() << ") ";
 		}
 		where << std::endl;
@@ -64,7 +64,7 @@ void QuotaCollector::list_pools(std::ostream & where) const {
 void QuotaCollector::clear() {
 
 	for ( core::Size i=1; i<=storage_.size(); ++i ) {
-		for ( core::Size j=1; j<storage_[i].size(); ++j ) {
+		for ( core::Size j=1; j<=storage_[i].size(); ++j ) {
 			storage_[i][j]->clear();
 		}
 	}
@@ -73,7 +73,7 @@ void QuotaCollector::clear() {
 core::Size QuotaCollector::count_candidates(core::Size pos) const {
 
 	core::Size cnt = 0;
-	for ( core::Size j=1; j<storage_[pos].size(); ++j ) {
+	for ( core::Size j=1; j<=storage_[pos].size(); ++j ) {
 		cnt += storage_[pos][j]->count_candidates();
 	}
 
@@ -83,7 +83,7 @@ core::Size QuotaCollector::count_candidates(core::Size pos) const {
 core::Size QuotaCollector::count_candidates() const {
 	core::Size cnt = 0;
 	for ( core::Size i=1; i<=storage_.size(); ++i ) {
-		for ( core::Size j=1; j<storage_[i].size(); ++j ) {
+		for ( core::Size j=1; j<=storage_[i].size(); ++j ) {
 			cnt += storage_[i][j]->count_candidates();
 		}
 	}

--- a/source/src/protocols/frag_picker/scores/AtomBasedConstraintsScore.cc
+++ b/source/src/protocols/frag_picker/scores/AtomBasedConstraintsScore.cc
@@ -46,7 +46,7 @@ AtomBasedConstraintsScore::AtomBasedConstraintsScore(core::Size priority,
 	CachingScoringMethod(priority, lowest_acceptable_value, use_lowest, score_name) {
 
 	query_size_ = query_size;
-	for ( core::Size i = 1; i < constrainable_atoms.size(); ++i ) {
+	for ( core::Size i = 1; i <= constrainable_atoms.size(); ++i ) {
 		constrainable_atoms_.insert(std::pair<std::string, core::Size>(
 			constrainable_atoms[i], i));
 	}
@@ -97,7 +97,7 @@ void AtomBasedConstraintsScore::do_caching(VallChunkOP chunk) {
 		utility::vector1<bool> flag_row(constrainable_atoms_.size());
 		utility::vector1<numeric::xyzVector<core::Real> > row(
 			constrainable_atoms_.size());
-		for ( core::Size j = 1; j < constrainable_atoms_.size(); ++j ) {
+		for ( core::Size j = 1; j <= constrainable_atoms_.size(); ++j ) {
 			flag_row[j] = false;
 			row[j] = empty_one;
 		}

--- a/source/src/protocols/jd3/JobGenealogist.cc
+++ b/source/src/protocols/jd3/JobGenealogist.cc
@@ -437,7 +437,7 @@ JobGenealogist::newick_tree() const {
 	utility::vector1< std::list< JGResultNodeCAP > > parentless_results_for_input_source;
 	parentless_results_for_input_source.resize( num_input_sources_ );
 
-	for ( unsigned int i = 1; i < job_nodes_for_dag_node_.size(); ++i ) {
+	for ( unsigned int i = 1; i <= job_nodes_for_dag_node_.size(); ++i ) {
 		for ( auto const & job_node_cop : job_nodes_for_dag_node_[ i ] ) {
 			debug_assert( job_node_cop != nullptr );
 			if ( job_node_cop->parents().empty() ) {

--- a/source/src/protocols/legacy_sewing/conformation/Assembly.cc
+++ b/source/src/protocols/legacy_sewing/conformation/Assembly.cc
@@ -1259,7 +1259,7 @@ Assembly::natives_select(
 utility::vector1<core::Size>
 Assembly::pose_loop_anchors() const {
 	utility::vector1<core::Size> loop_anchors;
-	for ( core::Size i=1; i<segments_.size(); ++i ) {
+	for ( core::Size i=1; i<=segments_.size(); ++i ) {
 		if ( !segments_.has_next(i) ) {
 			loop_anchors.push_back(pose_num(segments_[i].model_id_, segments_[i].residues_.back().resnum_));
 		}
@@ -1271,7 +1271,7 @@ Assembly::pose_loop_anchors() const {
 utility::vector1<core::Size>
 Assembly::disconnected_segments() const {
 	utility::vector1<core::Size> disconnected_segments;
-	for ( core::Size i=1; i<segments_.size(); ++i ) {
+	for ( core::Size i=1; i<=segments_.size(); ++i ) {
 		if ( !segments_.has_next(i) ) {
 			disconnected_segments.push_back(i);
 		}

--- a/source/src/protocols/loops/util.cc
+++ b/source/src/protocols/loops/util.cc
@@ -224,7 +224,7 @@ void addScoresForLoopParts(
 
 	core::Size nres = pose.size();
 	utility::vector1< core::Size > all_loop_list;
-	for ( core::Size i = 1; i < nres; i ++ ) {
+	for ( core::Size i = 1; i <= nres; i ++ ) {
 		if ( loops.is_loop_residue(i) ) all_loop_list.push_back( i );
 	}
 	scorefxn(pose);
@@ -241,7 +241,7 @@ void addScoresForLoopParts(
 		}
 		utility::vector1< core::Size > loop_list;
 		utility::vector1< core::Size > non_loop_list;
-		for ( core::Size i = 1; i < nres; i ++ ) {
+		for ( core::Size i = 1; i <= nres; i ++ ) {
 			if ( ( i < loops[l].start() ) || ( i > loops[l].stop() ) ) {
 				loop_list.push_back( i );
 			} else {
@@ -544,7 +544,7 @@ protocols::loops::Loops find_non_protein_chunks(core::pose::Pose const & pose) {
 	Loop new_loop;
 	bool chunk_started = false;
 
-	for ( core::Size ires = 1; ires < pose.size(); ++ires ) {
+	for ( core::Size ires = 1; ires <= pose.size(); ++ires ) {
 		if ( pose.residue_type(ires).is_protein() ) continue;
 		if ( !chunk_started ) {
 			new_loop.set_start(ires);

--- a/source/src/protocols/match/output/UpstreamDownstreamCollisionFilter.cc
+++ b/source/src/protocols/match/output/UpstreamDownstreamCollisionFilter.cc
@@ -158,7 +158,7 @@ bool UpstreamDownstreamCollisionFilter::passes_etable_filter( match_dspos1 const
 
 	using namespace core::scoring;
 	EnergyMap emap;
-	for ( core::Size ii = 1; ii < m.upstream_hits.size(); ++ii ) {
+	for ( core::Size ii = 1; ii <= m.upstream_hits.size(); ++ii ) {
 		if ( ii == m.originating_geom_cst_for_dspos ) continue; // don't collision check since we've presumably done so already
 		if ( us_ds_chemical_bond_[ ii ] ) continue;
 		for ( core::Size jj = 1; jj <= downstream_pose_->size(); ++jj ) {

--- a/source/src/protocols/membrane/MPLipidAccessibility.cc
+++ b/source/src/protocols/membrane/MPLipidAccessibility.cc
@@ -227,7 +227,7 @@ void MPLipidAccessibility::apply( core::pose::Pose & pose ){
 	}
 
 	// go through slices
-	for ( core::Size s = 1; s < slice_zmin_.size(); ++s ) {
+	for ( core::Size s = 1; s <= slice_zmin_.size(); ++s ) {
 
 		// go through residues
 		for ( core::Size r = 1; r <= resi_[ s ].size(); ++r ) {
@@ -502,7 +502,7 @@ void MPLipidAccessibility::fill_up_slices( core::pose::Pose & pose ) {
 void MPLipidAccessibility::compute_slice_com(){
 
 	// go through slices and compute COMs
-	for ( core::Size s = 1; s < slice_zmin_.size(); ++s ) {
+	for ( core::Size s = 1; s <= slice_zmin_.size(); ++s ) {
 
 		core::Vector com( 0, 0, 0 );
 

--- a/source/src/protocols/membrane/util.cc
+++ b/source/src/protocols/membrane/util.cc
@@ -616,6 +616,7 @@ core::Size create_membrane_foldtree_anchor_com( core::pose::Pose & pose ) {
 	utility::vector1< core::Size > anchors;
 
 	// get residues closest to COMs for all chains which will be new jump anchor residues
+	// needs to < chains.size() because the MEM is an additional chain
 	for ( core::Size i = 1; i < chains.size(); ++i ) {
 		core::Size anchor = rsd_closest_to_chain_com( pose, chains[ i ] );
 		anchors.push_back( anchor );

--- a/source/src/protocols/moves/PyMOLMover.cc
+++ b/source/src/protocols/moves/PyMOLMover.cc
@@ -548,7 +548,7 @@ void PyMOLMover::send_membrane_planes( Pose const & pose ) {
 	// Compute radius of gyration of the pose
 	utility::vector1< bool > relevant_residues;
 	relevant_residues.resize( pose.size() );
-	for ( core::Size i = 1; i < relevant_residues.size(); ++i ) {
+	for ( core::Size i = 1; i <= relevant_residues.size(); ++i ) {
 		relevant_residues[i] = true;
 	}
 

--- a/source/src/protocols/pose_metric_calculators/DecomposeAndReweightEnergiesCalculator.cc
+++ b/source/src/protocols/pose_metric_calculators/DecomposeAndReweightEnergiesCalculator.cc
@@ -418,7 +418,7 @@ DecomposeAndReweightEnergiesCalculator::nonzero_weight_score_types() const
 	utility::vector1<core::scoring::ScoreType> score_types;
 
 	for ( int i = 1; i < core::scoring::n_score_types; ++i ) {
-		for ( core::Size j = 1; j < weight_map_vector.size(); ++j ) {
+		for ( core::Size j = 1; j <= weight_map_vector.size(); ++j ) {
 			if ( weight_map_vector[j][core::scoring::ScoreType(i)] ) {
 				score_types.push_back(core::scoring::ScoreType(i));
 				break;

--- a/source/src/protocols/pose_metric_calculators/SurfaceCalculator.cc
+++ b/source/src/protocols/pose_metric_calculators/SurfaceCalculator.cc
@@ -82,7 +82,7 @@ SurfaceCalculator::print( std::string const & key ) const {
 	} else if ( key == "residue_surface" ) {
 		std::ostringstream ss;
 		ss << "[";
-		for ( core::Size ii=1; ii < residue_surface_energy_.size(); ++ii ) {
+		for ( core::Size ii=1; ii <= residue_surface_energy_.size(); ++ii ) {
 			ss << ii << ":";
 			if ( residue_surface_energy_[ ii ] != 0.00 ) {
 				ss << ObjexxFCL::format::F(8,4, residue_surface_energy_[ ii ]);

--- a/source/src/protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc
+++ b/source/src/protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc
@@ -92,11 +92,11 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 
 	std::pair<core::Size, core::Size> helix_pair;
 
-	for ( core::Size upstream_res = 1; upstream_res < pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.secstruct(upstream_res) == 'H' ) {
 			for ( core::Size downstream_res = upstream_res+1; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.secstruct(downstream_res) == 'H' ) {
-					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2)) <= crit_dist_ ) {
+					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(downstream_res).xyz(2)) <= crit_dist_ ) {
 						helix_pair.first = element_blocks[upstream_res];
 						helix_pair.second = element_blocks[downstream_res];
 						helix_pairs.insert(helix_pair);
@@ -117,7 +117,7 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 	//core::Size label_res = 1;
 	for ( auto current_pair : helix_pairs ) {
 		scc.Reset(); // this may not be needed anymore, but I'm leaving it here for safety
-		for ( core::Size current_res = 1; current_res < pose.size(); ++current_res ) {
+		for ( core::Size current_res = 1; current_res <= pose.size(); ++current_res ) {
 			if ( element_blocks[current_res] == current_pair.first ) {
 				scc.AddResidue( 0, pose.residue(current_res) );
 			}
@@ -134,7 +134,7 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 		d_median = r.distance;
 		has_disulfide = false;
 		core::Size last_upstream_res = 1;
-		for ( core::Size upstream_res = 1; upstream_res <pose.size(); ++upstream_res ) {
+		for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 			if ( pose.residue(upstream_res).type().is_disulfide_bonded() && element_blocks[upstream_res] == current_pair.first ) {
 				for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 					if ( pose.residue(downstream_res).type().is_disulfide_bonded() && pose.residue(upstream_res).is_bonded(pose.residue(downstream_res)) && element_blocks[downstream_res] == current_pair.second ) {

--- a/source/src/protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc
+++ b/source/src/protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc
@@ -132,7 +132,7 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 	std::string label;
 
 	//pose.pdb_info()->add_reslabel(1,label);
-	for ( core::Size upstream_res = 1; upstream_res <pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.residue(upstream_res).type().is_disulfide_bonded() ) {
 			for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.residue(downstream_res).type().is_disulfide_bonded() && pose.residue(upstream_res).is_bonded(pose.residue(downstream_res)) ) {
@@ -170,11 +170,11 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 
 	std::pair<core::Size, core::Size> helix_pair;
 
-	for ( core::Size upstream_res = 1; upstream_res < pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.secstruct(upstream_res) == 'H' ) {
 			for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.secstruct(downstream_res) == 'H' ) {
-					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2)) <= crit_dist_ ) {
+					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(downstream_res).xyz(2)) <= crit_dist_ ) {
 						helix_pair.first = element_blocks[upstream_res];
 						helix_pair.second = element_blocks[downstream_res];
 						helix_pairs.insert(helix_pair);
@@ -195,7 +195,7 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 		utility::vector1< core::Size > selection1;
 		utility::vector1< core::Size > selection2;
 
-		for ( core::Size current_res = 1; current_res < pose.size(); ++current_res ) {
+		for ( core::Size current_res = 1; current_res <= pose.size(); ++current_res ) {
 			if ( element_blocks[current_res] == current_pair.first ) {
 				selection1.push_back(current_res);
 			}

--- a/source/src/protocols/rna/movers/RNAIdealizeMover.cc
+++ b/source/src/protocols/rna/movers/RNAIdealizeMover.cc
@@ -237,7 +237,7 @@ RNAIdealizeMover::apply( pose::Pose & pose )
 	suite_mm->set_jump( true );
 	protocols::minimization_packing::MinMoverOP minm = utility::pointer::make_shared< protocols::minimization_packing::MinMover >( suite_mm, scorefxn, "lbfgs_armijo_nonmonotone", 0.001, true );
 
-	for ( Size ii = 1; ii < ideal_pose.size(); ++ii ) {
+	for ( Size ii = 1; ii <= ideal_pose.size(); ++ii ) {
 
 		for ( Size jj = 1; jj <= ideal_pose.residue_type( ii ).natoms(); ++jj ) {
 			ConstraintOP constraint = utility::pointer::make_shared< CoordinateConstraint >( core::id::AtomID( jj, ii ), core::id::AtomID( 1, my_anchor ),

--- a/source/src/protocols/splice/SampleRotamersFromPDB.cc
+++ b/source/src/protocols/splice/SampleRotamersFromPDB.cc
@@ -229,7 +229,7 @@ void SampleRotamersFromPDB_RotamerSetOperation::fill_rotamer_matrix_from_db_file
 			}
 			//new_res->set_all_chi(Rots_real);
 			bool res_exsits_in_db = false;
-			for ( core::Size i=1; i<resi_vec_[resi_num].size(); i++ ) {
+			for ( core::Size i=1; i<=resi_vec_[resi_num].size(); i++ ) {
 				res_exsits_in_db = is_identical_rotamer(resi_vec_[resi_num][i],new_res);
 				if ( res_exsits_in_db ) break;
 				//TR<<"Found identical residue"<<std::endl;
@@ -780,7 +780,7 @@ rot_matrix RotLibdb::fill_rotamer_matrix_from_db_file(std::string fname) {
 			}
 
 			bool res_exsits_in_db = false;
-			for ( core::Size i=1; i<resi_mat[resi_num].size(); i++ ) {
+			for ( core::Size i=1; i<=resi_mat[resi_num].size(); i++ ) {
 				res_exsits_in_db = is_identical_rotamer(resi_mat[resi_num][i],new_res);
 				if ( res_exsits_in_db ) break;
 				//TR<<"Found identical residue"<<std::endl;

--- a/source/src/protocols/splice/SpliceManager.cc
+++ b/source/src/protocols/splice/SpliceManager.cc
@@ -333,7 +333,7 @@ SpliceManager::update_pose_stem_positions() {
 }
 
 void SpliceManager::check_sequence_profile(core::pose::Pose & pose, core::id::SequenceMappingOP smap, core::sequence::SequenceProfileOP seqprof){
-	for ( core::Size row = 1; row < seqprof->size(); row++ ) { //go over all the PSSM sements provided by the user
+	for ( core::Size row = 1; row <= seqprof->size(); row++ ) { //go over all the PSSM sements provided by the user
 		utility::vector1< core::Size > cur_prof_row = seqprof->prof_row(row);
 
 

--- a/source/src/protocols/stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc
+++ b/source/src/protocols/stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc
@@ -233,7 +233,7 @@ StepWiseWorkingParametersSetup::get_user_input_alignment_res_list( core::Size co
 
 			ObjexxFCL::FArray1D < bool > const & partition_definition = working_parameters_->partition_definition();
 			bool contain_non_root_partition_seq_num = false;
-			for ( core::Size ii = 1; ii < working_alignment.size(); ii++ ) {
+			for ( core::Size ii = 1; ii <= working_alignment.size(); ii++ ) {
 				if ( partition_definition( working_alignment[ii] ) != partition_definition( root_res ) ) contain_non_root_partition_seq_num = true;
 			}
 

--- a/source/src/protocols/unfolded_state_energy_calculator/UnfoldedStateEnergyCalculatorMover.cc
+++ b/source/src/protocols/unfolded_state_energy_calculator/UnfoldedStateEnergyCalculatorMover.cc
@@ -116,7 +116,7 @@ UnfoldedStateEnergyCalculatorMover::create_random_fragments( Pose & pose, vector
 {
 	// get number of protein residues
 	core::Size num_protein_res( 0 );
-	for ( core::Size i = 1; i < pose.size(); ++i ) {
+	for ( core::Size i = 1; i <= pose.size(); ++i ) {
 		if ( pose.residue( i ).type().is_protein() ) {
 			num_protein_res++;
 		}


### PR DESCRIPTION
## Summary

Audit-pass fix for a family of off-by-one bugs of the same shape across 35 files. Continues the pattern from #695 and #701; this batch covers loops the earlier audits did not reach.

### Off-by-one in 1-indexed loops (33 files)

Each loop uses `for ( Size i = 1; i < container.size(); ++i )` (or `< pose.size()` / `< pose.total_residue()` / `< natoms()` / `< nres`) and the body uses `i` as a direct 1-indexed element accessor — `pose.residue(i)`, `vec[i]`, `xyz(i)`, etc. The last element is therefore silently skipped. Replaced with `<=` to include it.

Affected functions cover residue iteration in:
- `core/energy_methods/RNA_LJ_BaseEnergy.cc` (RNA neighbor scan)
- `core/io/pose_to_sfr/PoseToStructFileRepConverter.cc` (SS element enumeration — a 1-residue SS element at the C-terminus was dropped)
- `core/pack/interaction_graph/SurfacePotential.cc` ×3 (neighbor count, surface energy sum)
- `core/pose/rna/util.cc` (heavy-atom contact scan)
- `core/select/residue_selector/JumpUpstreamSelector.cc` (subset assignment, divergent from sibling `JumpDownstreamSelector` which uses `<=`)
- `protocols/antibody/residue_selector/CDRResidueSelector.cc`
- `protocols/canonical_sampling/mc_convergence_checks/HierarchicalLevel.cc` (address match count)
- `protocols/cartesian/md.cc` ×2 (per-atom state save/derivative check)
- `protocols/cutoutdomain/CutOutDomain.cc` (find_nearest_res)
- `protocols/denovo_design/components/FoldGraph.cc`
- `protocols/docking/DockingEnsemblePrepackProtocol.cc` ×2 (chain identity validation)
- `protocols/docking/metrics.cc` ×2 (cutpoint scan in Irmsd / contact metrics)
- `protocols/enzdes/EnzRepackMinimize.cc` (movable-residue collection for backrub)
- `protocols/features/strand_assembly/StrandBundleFeatures.cc` ×2 (per-atom distance scan)
- `protocols/fldsgn/MatchResidues.cc` ×2 (RMSD/superimpose atom-id map build)
- `protocols/frag_picker/GrabAllCollector.hh` (`clear`)
- `protocols/frag_picker/VallProvider.cc` (`find_chunk`)
- `protocols/frag_picker/quota/QuotaCollector.cc` ×5 (per-position pool enumeration)
- `protocols/frag_picker/scores/AtomBasedConstraintsScore.cc` ×2 (`constrainable_atoms` map fill, per-row state init)
- `protocols/jd3/JobGenealogist.cc`
- `protocols/legacy_sewing/conformation/Assembly.cc` ×2 (`pose_loop_anchors`, `disconnected_segments` — the last segment, which by definition has no next, was being skipped — exactly the case the predicate `!has_next(i)` is meant to catch)
- `protocols/loops/util.cc` ×3 (non-protein-chunk and per-loop accounting)
- `protocols/match/output/UpstreamDownstreamCollisionFilter.cc`
- `protocols/membrane/MPLipidAccessibility.cc` ×2 (slice iteration)
- `protocols/moves/PyMOLMover.cc` (`relevant_residues` mask init — last entry left default `false` despite the intent of "all relevant")
- `protocols/pose_metric_calculators/DecomposeAndReweightEnergiesCalculator.cc`
- `protocols/pose_metric_calculators/SurfaceCalculator.cc` (per-residue summary string)
- `protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc` ×2
- `protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc` ×3
- `protocols/rna/movers/RNAIdealizeMover.cc` (CoordinateConstraint application)
- `protocols/splice/SampleRotamersFromPDB.cc` ×2 (rotamer-deduplication scan)
- `protocols/splice/SpliceManager.cc` (PSSM row check — comment says "go over all the PSSM segments")
- `protocols/stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc`
- `protocols/unfolded_state_energy_calculator/UnfoldedStateEnergyCalculatorMover.cc` (protein-residue count)

### Self-distance copy/paste bug (folded into 2 of the above files)

`pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2))` is identically `0`, so the `<= crit_dist_` gate was always satisfied — the distance filter was a no-op. Fixed to `.distance(pose.residue(downstream_res).xyz(2))` in:
- `protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc`
- `protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc`

### What was deliberately NOT touched

The audit also turned up many candidate matches that are actually intentional and were left alone:

- Loops with explicit pair access `vec[i+1]` / `pose.residue(i+1)` (need to stop at `size-1` to stay in bounds — e.g., `is_cutpoint` scans, SS-transition checks, adjacent-distance checks).
- Membrane-pose iterations that intentionally skip the trailing MEM virtual chain.
- "Separator" output patterns (`for i<size: print sep; print last`) — e.g., `protocols/jd3/InnerLarvalJob.cc`, `protocols/ligand_evolution/Scorer.cc`.
- Suite / connection enumerations where N segments produce N-1 connections by definition.
- Variant-by-cutpoint scans where the variable indexes a between-residue position.
- Self-pacing decompositions that already handle the last index in a special branch after the loop.
- Loops where the analysis script flagged a 0-indexed `std::vector` body that is in fact correctly bounded (e.g., `protocols/cluster/calibur/Clustering.cc`, `protocols/cluster/cluster.cc` — cluster center at `[0]` plus members at `[1..N-1]`).
- Commented-out code (in `SurfaceInteractionGraph.hh`, `RNAIdealizeMover.cc`, etc.).

Debug build (`mode=debug`) is clean.