### PR TITLE
molfile_to_params: fix support for gzipped files.

### DIFF
--- a/source/scripts/python/public/rosetta_py/io/mdl_molfile.py
+++ b/source/scripts/python/public/rosetta_py/io/mdl_molfile.py
@@ -22,7 +22,7 @@ Author: Ian W. Davis
 '''
 
 from __future__ import print_function
-import os, sys, math, copy, gzip
+import os, sys, math, copy, gzip, io
 
 try: set
 except: from sets import Set as set
@@ -31,7 +31,7 @@ except: from sets import Set as set
 def gz_open(file,mode):
     filename, extension = os.path.splitext( file )
     if extension == ".gz":
-        return gzip.open(file,mode)
+        return io.TextIOWrapper(gzip.open(file,mode), encoding='utf-8')
     else:
         return open(file,mode)
 


### PR DESCRIPTION
In Python3, gzip returns a bytes-based object, rather than a string one (which is what open() returns), which results in errors later. We can use TextIOWrapper to fix the issue.