### PR TITLE
Fix Slab geometry thickness/steepness argument order in MembraneInfo (#719)

### DIFF
--- a/source/src/core/conformation/membrane/MembraneInfo.cc
+++ b/source/src/core/conformation/membrane/MembraneInfo.cc
@@ -100,7 +100,7 @@ MembraneInfo::MembraneInfo(
 	spanning_topology_( topology ),
 	implicit_lipids_( nullptr ),
 	per_atom_lipid_accessibility_(),
-	membrane_geometry_( utility::pointer::make_shared< membrane_geometry::Slab >( thickness, steepness ) )
+	membrane_geometry_( utility::pointer::make_shared< membrane_geometry::Slab >( steepness, thickness ) )
 {}
 
 /// @brief Create MembraneInfo from initialized data
@@ -122,7 +122,7 @@ MembraneInfo::MembraneInfo(
 {
 	implicit_lipids_ = ImplicitLipidInfoOP( new ImplicitLipidInfo( lipid_composition_name, lipid_composition_temp ) );
 	thickness_ = implicit_lipids_->water_thickness();
-	membrane_geometry_ = MembraneGeometryOP( new membrane_geometry::Slab( thickness, steepness ) );
+	membrane_geometry_ = MembraneGeometryOP( new membrane_geometry::Slab( steepness, thickness_ ) );
 
 }
 


### PR DESCRIPTION
## Summary

Fixes #719. `Slab`'s constructor is `Slab(core::Real steepness, core::Real thickness)`, but two `MembraneInfo` constructors in `core/conformation/membrane/MembraneInfo.cc` called it with the arguments in the wrong order.

**(1) Plain 6-arg constructor** passed `Slab(thickness, steepness)`, so the `Slab` geometry stored thickness and steepness swapped. The `fa_2012` energy methods (`FaMPEnv`/`FaMPSolv` → `mpframework_smooth_fa_2012`) read thickness/steepness off the geometry, so this silently changed scores (e.g. with `thickness=15.6, steepness=10`, the IMM1 transition midpoint became 10 Å instead of 15.6 Å with a far steeper transition). Now passes `Slab(steepness, thickness)`.

**(2) Implicit-lipid constructor** passed `Slab(thickness, steepness)`, where the bare `thickness` token was *not* the member `thickness_` (just set from `implicit_lipids_->water_thickness()`) but the unscoped `MEM::thickness` enum (`== 1`) from `MembraneParams.hh` — both live in `core::conformation::membrane`. The call was therefore effectively `Slab(1, steepness)`: the lipid water thickness was dropped and `1` landed in the steepness slot. Now passes `Slab(steepness, thickness_)`, matching the sibling lipid + `MP_GEOMETRY_TRANSITION` constructor's `SLAB` case. This path is currently latent (these constructors set `implicit_lipids_`, so `use_franklin()` is true and the geometry thickness/steepness aren't read), but it was still wrong.

All other `Slab` call sites in the file already use the correct `(steepness, thickness)` / `(steepness, thickness_)` order, so these two lines are the complete set of violations.

Diagnosis and reproduction by @vuoanh in #719.

## Note on diff size

This is a 2-line, single-file change — below the usual bundling threshold. There is no sibling buggy pattern to bundle: every other `Slab` construction in the file is already correct, so this is the complete and self-contained fix for the reported issue.
