### PR TITLE
Drop template-id from ctor/dtor names in numeric/ (GCC 14/15 -Werror=template-id-cdtor)

### DIFF
--- a/source/src/numeric/MathMatrix.hh
+++ b/source/src/numeric/MathMatrix.hh
@@ -59,7 +59,7 @@ public:
 	//////////////////////////////////
 
 	/// @brief default constructor
-	MathMatrix< T>() :
+	MathMatrix() :
 	NumberRows_( 0),
 	NumberCols_( 0),
 	size_( 0 ),
@@ -79,7 +79,7 @@ public:
 	/// @param NUMBER_ROWS number of rows in matrix
 	/// @param NUMBER_COLS number of cols in matrix
 	/// @param FILL_VALUE assign every element to that value
-	explicit MathMatrix< T>
+	explicit MathMatrix
 	(
 		const Size NUMBER_ROWS,
 		const Size NUMBER_COLS,
@@ -98,7 +98,7 @@ public:
 	/// @param NUMBER_ROWS number of rows in matrix
 	/// @param NUMBER_COLS number of cols in matrix
 	/// @param DATA pointer to field of data
-	MathMatrix< T>
+	MathMatrix
 	(
 		const Size NUMBER_ROWS,
 		const Size NUMBER_COLS,
@@ -133,7 +133,7 @@ public:
 	}
 
 	/// @brief destructor
-	~MathMatrix< T>()
+	~MathMatrix()
 	{
 		delete[] data_;
 	}

--- a/source/src/numeric/MathMatrix.hh
+++ b/source/src/numeric/MathMatrix.hh
@@ -60,10 +60,10 @@ public:
 
 	/// @brief default constructor
 	MathMatrix() :
-	NumberRows_( 0),
-	NumberCols_( 0),
-	size_( 0 ),
-	data_( nullptr )
+		NumberRows_( 0),
+		NumberCols_( 0),
+		size_( 0 ),
+		data_( nullptr )
 	{
 	}
 
@@ -85,10 +85,10 @@ public:
 		const Size NUMBER_COLS,
 		const T &FILL_VALUE = T( 0)
 	) :
-	NumberRows_( NUMBER_ROWS),
-	NumberCols_( NUMBER_COLS),
-	size_( NumberRows_ * NumberCols_ ),
-	data_( new T[ size_ ])
+		NumberRows_( NUMBER_ROWS),
+		NumberCols_( NUMBER_COLS),
+		size_( NumberRows_ * NumberCols_ ),
+		data_( new T[ size_ ])
 	{
 		// set all values to FILL_VALUE
 		std::fill( data_, data_ + size_, FILL_VALUE);
@@ -104,10 +104,10 @@ public:
 		const Size NUMBER_COLS,
 		const T *DATA
 	) :
-	NumberRows_( NUMBER_ROWS),
-	NumberCols_( NUMBER_COLS),
-	size_( NumberRows_ * NumberCols_ ),
-	data_( new T[ NumberRows_ * NumberCols_])
+		NumberRows_( NUMBER_ROWS),
+		NumberCols_( NUMBER_COLS),
+		size_( NumberRows_ * NumberCols_ ),
+		data_( new T[ NumberRows_ * NumberCols_])
 	{
 		// copy data
 		std::copy( DATA, DATA + size_, data_);

--- a/source/src/numeric/MathVector.hh
+++ b/source/src/numeric/MathVector.hh
@@ -67,8 +67,8 @@ public:
 
 	/// @brief default constructor
 	MathVector() :
-	size_( 0),
-	data_( nullptr )
+		size_( 0),
+		data_( nullptr )
 	{
 	}
 
@@ -82,8 +82,8 @@ public:
 	/// @param SIZE number fo elements in Vector
 	/// @param FILL_VALUE assign every element to that value
 	explicit MathVector( const Size SIZE, const T &FILL_VALUE= T( 0)) :
-	size_( SIZE),
-	data_( new T[ SIZE])
+		size_( SIZE),
+		data_( new T[ SIZE])
 	{
 
 		// set all values to FILL_VALUE
@@ -92,8 +92,8 @@ public:
 
 	/// @brief construct from length and pointer to data
 	MathVector( const Size SIZE, const T *DATA) :
-	size_( SIZE),
-	data_( new T[ SIZE])
+		size_( SIZE),
+		data_( new T[ SIZE])
 	{
 		std::copy( DATA, DATA + SIZE, data_);
 	}

--- a/source/src/numeric/MathVector.hh
+++ b/source/src/numeric/MathVector.hh
@@ -66,7 +66,7 @@ public:
 	//////////////////////////////////
 
 	/// @brief default constructor
-	MathVector< T>() :
+	MathVector() :
 	size_( 0),
 	data_( nullptr )
 	{
@@ -81,7 +81,7 @@ public:
 	/// @brief construct from size and possible filler
 	/// @param SIZE number fo elements in Vector
 	/// @param FILL_VALUE assign every element to that value
-	explicit MathVector< T>( const Size SIZE, const T &FILL_VALUE= T( 0)) :
+	explicit MathVector( const Size SIZE, const T &FILL_VALUE= T( 0)) :
 	size_( SIZE),
 	data_( new T[ SIZE])
 	{
@@ -91,7 +91,7 @@ public:
 	}
 
 	/// @brief construct from length and pointer to data
-	MathVector< T>( const Size SIZE, const T *DATA) :
+	MathVector( const Size SIZE, const T *DATA) :
 	size_( SIZE),
 	data_( new T[ SIZE])
 	{
@@ -116,7 +116,7 @@ public:
 	}
 
 	/// @ brief destructor
-	~MathVector< T>()
+	~MathVector()
 	{
 		delete[] data_;
 	}

--- a/source/src/numeric/histograms/OneDHistogram.hh
+++ b/source/src/numeric/histograms/OneDHistogram.hh
@@ -38,7 +38,7 @@ class OneDHistogram {
 
 public:
 
-	OneDHistogram<key1>()= default;
+	OneDHistogram()= default;
 
 	void insert_data(key1 key_1, platform::Size counts){
 		histogram_.insert(std::make_pair(key_1, counts));

--- a/source/src/numeric/histograms/OneDHistogram.hh
+++ b/source/src/numeric/histograms/OneDHistogram.hh
@@ -29,8 +29,8 @@
 #include <map>
 #include <platform/types.hh>
 
-namespace numeric{
-namespace histograms{
+namespace numeric {
+namespace histograms {
 
 
 template<typename key1>
@@ -52,7 +52,7 @@ public:
 
 
 private:
-std::map< key1, platform::Size > histogram_;
+	std::map< key1, platform::Size > histogram_;
 
 
 };


### PR DESCRIPTION
## Summary

GCC 14+ enforces `-Werror=template-id-cdtor`: a class template may not name its own constructors or destructors with explicit template arguments — the injected-class-name must be used without `<...>`. `numeric/MathVector.hh`, `numeric/MathMatrix.hh`, and `numeric/histograms/OneDHistogram.hh` declared constructors (and, for the first two, the destructor) in the disallowed form, e.g.:

```cpp
MathVector< T>() : ...
explicit MathVector< T>( const Size SIZE, ... ) : ...
~MathVector< T>() { ... }
OneDHistogram<key1>()= default;
```

Under GCC 14/15 in C++20 mode this fails to compile (`error: template-id not allowed for constructor/destructor in C++20`). The `numeric/` occurrences broke the plain library debug build before it could even reach `basic/` or `core/`. The `OneDHistogram.hh` occurrence is more subtle: its default constructor is only instantiated by a unit test (`numeric/histograms/OneDHistogram.cxxtest.hh`), not by any library code, so it slipped past a library-only build and only surfaced when building/running the unit test suite — this is what broke CI on the previous version of this PR.

This drops the `< T>` / `<key1>` from the constructor and destructor declarator-ids, making them consistent with the copy constructors in the same classes, which already use the correct injected-class-name form. Return types, operators, and `new` expressions that legitimately use the templated name are untouched. Pure syntactic correction, no semantic change.

Verified with a clean `mode=debug` library build **and** `mode=debug cat=test` unit-test build under GCC 15 (this machine's default), plus a full library build under GCC 14 — both fully green. A targeted scan of `source/src`, `source/test`, and `source/src/devel` for the same declaration pattern turned up no other occurrences.

## Relationship to existing GCC 15 PRs (#555, #556)

This is not the first attempt at the GCC 15 build. Two earlier community PRs are still open and overlap with this one:

- **#555 — "Fix C++20 template-id errors in constructors/destructors"** (@saberger). This contains the **identical** MathVector/MathMatrix/OneDHistogram template-id fix as this PR, and additionally covers `core/scoring/lkball/LK_DomeEnergy.cc`, `protocols/forge/remodel/RemodelGlobalFrame.cc`, `utility/options/VectorOption_T_.hh`, two unit tests, and `tools/build/basic.settings` — none of which have this same template-id-cdtor pattern currently (checked directly), so those are addressing separate GCC 15 issues.
- **#556 — "Fixes for compiling with gcc15"** (@roccomoretti). The broader assorted GCC 15 fixes. Does not touch these three files.

Because #555 already lands the same fix, #723 is largely redundant with the `numeric/` slice of that effort. It's offered as a minimal, narrowly-scoped version of just the `template-id-cdtor` correction in case it's useful to merge the build-blocking part independently; otherwise #555 (combined with #556, per its author's note) supersedes it. Closing this in favor of #555 + #556 is fine if the maintainers prefer to consolidate the GCC 15 work.

## Note on diff size

This is a small change (three files, ~18 lines) — below the usual bundling threshold — but it is the complete fix for this pattern across the codebase: a scan of `source/src`, `source/test`, and `source/src/devel` found no other occurrences of a class template naming its own constructor/destructor with a template-id. Kept narrowly scoped to this one toolchain-compatibility pattern.
