### PR TITLE
Apply Rule of Zero to remaining energy-container neighbor iterators

### DIFF
--- a/source/src/core/scoring/DenseEnergyContainer.cc
+++ b/source/src/core/scoring/DenseEnergyContainer.cc
@@ -33,8 +33,6 @@ namespace scoring {
 
 ///////////////////////////////////////////////////////
 
-DenseNeighborIterator::~DenseNeighborIterator()= default;
-
 DenseNeighborIterator::DenseNeighborIterator(
 	Size const pos1_in,
 	Size const pos2_in,
@@ -147,8 +145,6 @@ DenseNeighborIterator::energy_computed() const
 }
 
 /////////////////////////////////////////////////////
-
-DenseNeighborConstIterator::~DenseNeighborConstIterator()= default;
 
 DenseNeighborConstIterator::DenseNeighborConstIterator(
 	Size const pos1_in,

--- a/source/src/core/scoring/DenseEnergyContainer.hh
+++ b/source/src/core/scoring/DenseEnergyContainer.hh
@@ -44,9 +44,11 @@ namespace scoring {
 
 class DenseNeighborIterator : public ResidueNeighborIterator
 {
-	DenseNeighborIterator & operator = (DenseNeighborIterator const & src );
 public:
-	~DenseNeighborIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DenseNeighborIterator & operator = (DenseNeighborIterator const & ) = delete;
 
 	DenseNeighborIterator(
 		Size const pos1_in,
@@ -98,9 +100,11 @@ private:
 
 class DenseNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	DenseNeighborConstIterator & operator = (DenseNeighborConstIterator const & src );
 public:
-	~DenseNeighborConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	DenseNeighborConstIterator & operator = (DenseNeighborConstIterator const & ) = delete;
 
 	DenseNeighborConstIterator(
 		Size const pos1_in,

--- a/source/src/core/scoring/OneToAllEnergyContainer.cc
+++ b/source/src/core/scoring/OneToAllEnergyContainer.cc
@@ -33,8 +33,6 @@ namespace scoring {
 
 /////////////////////////////////////////////////////
 
-OneToAllNeighborIterator::~OneToAllNeighborIterator()= default;
-
 OneToAllNeighborIterator::OneToAllNeighborIterator(
 	Size const pos1_in,
 	Size const pos2_in,
@@ -135,8 +133,6 @@ bool OneToAllNeighborIterator::energy_computed() const
 
 
 /////////////////////////////////////////////////////
-
-OneToAllNeighborConstIterator::~OneToAllNeighborConstIterator()= default;
 
 OneToAllNeighborConstIterator::OneToAllNeighborConstIterator(
 	Size const pos1_in,

--- a/source/src/core/scoring/OneToAllEnergyContainer.hh
+++ b/source/src/core/scoring/OneToAllEnergyContainer.hh
@@ -42,9 +42,11 @@ namespace scoring {
 
 class OneToAllNeighborIterator : public ResidueNeighborIterator
 {
-	OneToAllNeighborIterator & operator = (OneToAllNeighborIterator const & src );
 public:
-	~OneToAllNeighborIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	OneToAllNeighborIterator & operator = (OneToAllNeighborIterator const & ) = delete;
 
 	OneToAllNeighborIterator(
 		Size const pos1_in,
@@ -97,9 +99,11 @@ private:
 
 class OneToAllNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	OneToAllNeighborConstIterator & operator = (OneToAllNeighborConstIterator const & src );
 public:
-	~OneToAllNeighborConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	OneToAllNeighborConstIterator & operator = (OneToAllNeighborConstIterator const & ) = delete;
 
 	OneToAllNeighborConstIterator(
 		Size const pos1_in,

--- a/source/src/core/scoring/PolymerBondedEnergyContainer.cc
+++ b/source/src/core/scoring/PolymerBondedEnergyContainer.cc
@@ -51,8 +51,6 @@ static basic::Tracer TR_it( "core.scoring.PolymerBondedNeighborIterator" );
 
 ///////////////////////////////////////////////////////
 
-PolymerBondedNeighborIterator::~PolymerBondedNeighborIterator()= default;
-
 PolymerBondedNeighborIterator::PolymerBondedNeighborIterator(
 	Size const base_in,
 	utility::vector1< Size > const & pos_in,
@@ -143,8 +141,6 @@ bool PolymerBondedNeighborIterator::energy_computed() const {
 }
 
 /////////////////////////////////////////////////////
-
-PolymerBondedNeighborConstIterator::~PolymerBondedNeighborConstIterator()= default;
 
 PolymerBondedNeighborConstIterator::PolymerBondedNeighborConstIterator(
 	Size const base_in,

--- a/source/src/core/scoring/PolymerBondedEnergyContainer.hh
+++ b/source/src/core/scoring/PolymerBondedEnergyContainer.hh
@@ -48,10 +48,11 @@ namespace scoring {
 
 class PolymerBondedNeighborIterator : public ResidueNeighborIterator
 {
-	PolymerBondedNeighborIterator & operator = (PolymerBondedNeighborIterator const & src );
-
 public:
-	~PolymerBondedNeighborIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	PolymerBondedNeighborIterator & operator = (PolymerBondedNeighborIterator const & ) = delete;
 
 	// Moves pos_in, so by-value
 	PolymerBondedNeighborIterator(
@@ -99,9 +100,11 @@ private:
 
 class PolymerBondedNeighborConstIterator : public ResidueNeighborConstIterator
 {
-	PolymerBondedNeighborConstIterator & operator = (PolymerBondedNeighborConstIterator const & src );
 public:
-	~PolymerBondedNeighborConstIterator() override;
+	// Assignment must go through the polymorphic operator= below, which
+	// downcasts and copies all members; suppress the implicit derived-derived
+	// copy assignment that would bypass it.
+	PolymerBondedNeighborConstIterator & operator = (PolymerBondedNeighborConstIterator const & ) = delete;
 
 	// Moves pos_in, so by value
 	PolymerBondedNeighborConstIterator(


### PR DESCRIPTION
## Summary

Applies the Rule of Zero to the neighbor-iterator classes of the three remaining `LREnergyContainer`-derived energy containers — `DenseEnergyContainer`, `OneToAllEnergyContainer`, and `PolymerBondedEnergyContainer` — completing the series begun in #689 (disulfide energy iterators) and #699 (remaining `LREnergyContainer` iterators). For all six iterator classes (`*NeighborIterator` and `*NeighborConstIterator`):

- **Remove the user-declared, defaulted destructor** (`~Foo() override;` in the header and `Foo::~Foo() = default;` in the `.cc`). The base classes `ResidueNeighborIterator` / `ResidueNeighborConstIterator` (both deriving from `utility::VirtualBase`) declare a virtual destructor, so the implicitly-generated destructor is virtual and does the same job.

- **Modernize the old-style C++03 copy-assignment prevention** — a private, declared-but-undefined derived-type `operator=` — to a public `= delete`. Behavior is unchanged: derived-to-derived assignment remains forbidden, so all assignment continues to flow through the polymorphic `operator=(BaseType const &)` override that downcasts and copies the members. A short comment records why the `= delete` is present.

The iterators hold only non-owning back-pointers into their container, so they never owned anything in their destructors; this is a pure ownership/semantics cleanup with no behavioral change.

## Note on diff size

At ~49 lines this is below the usual bundling threshold, but it is the complete remaining set of this exact sibling pattern: with the disulfide (#689) and `LREnergyContainer` (#699) iterators already done, `DenseEnergyContainer`, `OneToAllEnergyContainer`, and `PolymerBondedEnergyContainer` are the only `LREnergyContainer`-derived containers left with the private-undefined-`operator=` + defaulted-virtual-destructor idiom. There are no further same-pattern siblings to bundle.
