### PR TITLE
Apply Rule of Zero to protocols/ classes with redundant destructors

### DIFF
--- a/source/src/protocols/antibody/clusters/CDRClusterSet.cc
+++ b/source/src/protocols/antibody/clusters/CDRClusterSet.cc
@@ -48,8 +48,6 @@ CDRClusterSet::CDRClusterSet(AntibodyInfo * ab_info){
 	clear();
 }
 
-CDRClusterSet::~CDRClusterSet()= default;
-
 void
 CDRClusterSet::identify_and_set_cdr_cluster(core::pose::Pose const & pose, CDRNameEnum cdr){
 	clear(cdr);

--- a/source/src/protocols/antibody/clusters/CDRClusterSet.hh
+++ b/source/src/protocols/antibody/clusters/CDRClusterSet.hh
@@ -47,8 +47,6 @@ public:
 
 	// Undefined, commenting out to fix PyRosetta build  CDRClusterSet(CDRClusterSet const & src);
 
-	~CDRClusterSet() override;
-
 	/// @brief Identify the cluster of the CDR, using numbering information held in AntibodyInfo. Replace data if already present.
 	void
 	identify_and_set_cdr_cluster( core::pose::Pose const & pose, CDRNameEnum cdr);

--- a/source/src/protocols/hbnet/NetworkState.hh
+++ b/source/src/protocols/hbnet/NetworkState.hh
@@ -37,8 +37,6 @@ public:
 		core::scoring::hbonds::graph::HBondGraphOP const & hbond_graph
 	);
 
-	~NetworkState(){}
-
 	bool operator < ( NetworkState const & rhs) const {
 		return full_twobody_energy_ < rhs.full_twobody_energy_;
 	}

--- a/source/src/protocols/jobdist/JobDistributors.cc
+++ b/source/src/protocols/jobdist/JobDistributors.cc
@@ -548,8 +548,6 @@ AtomTreeDiffJobDistributor::AtomTreeDiffJobDistributor(JobVector jobs, std::stri
 	}
 }
 
-AtomTreeDiffJobDistributor::~AtomTreeDiffJobDistributor() = default;
-
 void AtomTreeDiffJobDistributor::dump_pose(
 	std::string const & tag,
 	std::map< std::string, core::Real > const & scores,

--- a/source/src/protocols/jobdist/JobDistributors.hh
+++ b/source/src/protocols/jobdist/JobDistributors.hh
@@ -270,7 +270,6 @@ protected:
 public:
 
 	AtomTreeDiffJobDistributor(JobVector jobs, std::string outfile_name);
-	~AtomTreeDiffJobDistributor() override;
 
 	/// @brief Appends pose to the silent file
 	virtual void dump_pose(

--- a/source/src/protocols/nmr/pcs/PCSLigandTransformMover.cc
+++ b/source/src/protocols/nmr/pcs/PCSLigandTransformMover.cc
@@ -90,8 +90,6 @@ AtomGridPoint::AtomGridPoint(
 	residue_(&residue)
 {}
 
-AtomGridPoint::~AtomGridPoint() {}
-
 
 AtomGrid::AtomGrid(
 	Real const & resolution,

--- a/source/src/protocols/nmr/pcs/PCSLigandTransformMover.hh
+++ b/source/src/protocols/nmr/pcs/PCSLigandTransformMover.hh
@@ -66,9 +66,6 @@ public:
 		core::conformation::Residue const & residue
 	);
 
-	/// @brief Destructor
-	~AtomGridPoint() override;
-
 	/// @brief Is relevant for neighbor search
 	bool is_relevant_neighbor() const { return true; }
 

--- a/source/src/protocols/noesy_assign/FloatingResonance.cc
+++ b/source/src/protocols/noesy_assign/FloatingResonance.cc
@@ -56,9 +56,6 @@ FloatingResonance::FloatingResonance( Resonance const& resin, FloatList const& p
 	}
 }
 
-FloatingResonance::~FloatingResonance() = default;
-
-
 core::Size FloatingResonance::float_label( core::Size ifloat ) const {
 	for ( auto it = partner_ids_.begin(); it!=partner_ids_.end(); ++it, --ifloat ) {
 		if ( ifloat==1 ) return *it;

--- a/source/src/protocols/noesy_assign/FloatingResonance.hh
+++ b/source/src/protocols/noesy_assign/FloatingResonance.hh
@@ -51,7 +51,6 @@ private:
 public:
 	FloatingResonance();
 	FloatingResonance( Resonance const& res, FloatList const&, ResonanceList* );
-	~FloatingResonance() override;
 
 	ResonanceOP clone() override {
 		return utility::pointer::make_shared< FloatingResonance >( *this );

--- a/source/src/protocols/noesy_assign/PeakAssignment.cc
+++ b/source/src/protocols/noesy_assign/PeakAssignment.cc
@@ -49,8 +49,6 @@ static basic::Tracer tr( "protocols.noesy_assign.assignments" );
 namespace protocols {
 namespace noesy_assign {
 
-/// @details Auto-generated virtual destructor
-PeakAssignment::~PeakAssignment() = default;
 using namespace core;
 
 PeakAssignment::PeakAssignment( CrossPeak * cp, core::Size assign_spin1, core::Size assign_spin2 )

--- a/source/src/protocols/noesy_assign/PeakAssignment.hh
+++ b/source/src/protocols/noesy_assign/PeakAssignment.hh
@@ -53,8 +53,6 @@ namespace noesy_assign {
 /// WHICH RELIES ON THREAD-UNSAFE SINGLETON CovalentCompliance
 class PeakAssignment : public utility::VirtualBase {
 public:
-	/// @brief Automatically generated virtual destructor for class deriving directly from VirtualBase
-	~PeakAssignment() override;
 	typedef core::scoring::constraints::AmbiguousNMRDistanceConstraintOP NmrConstraintOP;
 	typedef core::scoring::constraints::AmbiguousNMRDistanceConstraint NmrConstraint;
 

--- a/source/src/protocols/peptide_deriver/PeptideDeriverBasicStreamOutputter.cc
+++ b/source/src/protocols/peptide_deriver/PeptideDeriverBasicStreamOutputter.cc
@@ -42,14 +42,6 @@ PeptideDeriverBasicStreamOutputter::PeptideDeriverBasicStreamOutputter(utility::
 
 }
 
-PeptideDeriverBasicStreamOutputter::~PeptideDeriverBasicStreamOutputter()= default;
-
-PeptideDeriverBasicStreamOutputter::PeptideDeriverBasicStreamOutputter( PeptideDeriverBasicStreamOutputter const & src ) {
-	out_p_=src.out_p_;
-	prefix_=src.prefix_;
-
-}
-
 PeptideDeriverBasicStreamOutputterOP
 PeptideDeriverBasicStreamOutputter::clone() const {
 	return utility::pointer::make_shared< PeptideDeriverBasicStreamOutputter >( *this );

--- a/source/src/protocols/peptide_deriver/PeptideDeriverBasicStreamOutputter.hh
+++ b/source/src/protocols/peptide_deriver/PeptideDeriverBasicStreamOutputter.hh
@@ -40,10 +40,6 @@ public:
 	/// @param prefix a string prefix to prepend to each output line
 	PeptideDeriverBasicStreamOutputter(utility::io::orstream & out, std::string prefix);
 
-	PeptideDeriverBasicStreamOutputter(PeptideDeriverBasicStreamOutputter const & src);
-
-	~PeptideDeriverBasicStreamOutputter() override;
-
 	PeptideDeriverBasicStreamOutputterOP clone() const;
 
 	void begin_structure(core::pose::Pose const &, std::string const &) override;


### PR DESCRIPTION
## Summary

Applies the Rule of Zero to a set of `protocols/` classes that declared a redundant special member — a destructor equivalent to the implicitly-generated one — and lets the compiler generate it instead. Each removed destructor was either `= default` or an empty `{}` body, and in every case the class holds only **non-owning** raw pointers (back-references it does not allocate or free), so no destructor logic is lost and ownership semantics are unchanged.

Classes updated:

- `antibody/clusters/CDRClusterSet` — drop `= default` dtor (`ab_info_` is a non-owning back-pointer).
- `hbnet/NetworkState` — drop empty `~NetworkState(){}` (non-owning `HBondEdge const *`).
- `jobdist/AtomTreeDiffJobDistributor` — drop `= default` dtor (non-owning `Pose const * last_ref_pose_`).
- `nmr/pcs/AtomGridPoint` — drop empty dtor (non-owning `Residue const *`).
- `noesy_assign/FloatingResonance` — drop `= default` dtor (non-owning `ResonanceList const *`).
- `noesy_assign/PeakAssignment` — drop `= default` dtor (non-owning `CrossPeak *`).
- `peptide_deriver/PeptideDeriverBasicStreamOutputter` — drop `= default` dtor **and** the user-declared copy constructor, which performed a plain memberwise copy (`out_p_`, `prefix_`) identical to the implicit one. `out_p_` is a non-owning `orstream *`.

For the classes deriving from a base with a virtual destructor (`override` dtors), the implicitly-generated destructor is virtual and inherited, so polymorphic destruction is unchanged. Removing these destructors also re-enables implicit move operations (previously suppressed), which is harmless for these value/back-pointer members. A couple of now-moot "auto-generated destructor" doc comments were removed alongside their declarations.

## Note on diff size

This is a small diff (32 deletions). The `protocols/` `rule_of_zero` scan surfaced ~26 candidates, but the large majority are **not** safe to refactor — they own their pointers (e.g. MPI buffers and arrays allocated/freed in the destructor, like `triangleIterator`'s `delete gradPtr`), are singletons/factories that legitimately prevent copying, are observers whose destructors detach from a subject, or have intentionally partial/custom copy constructors. After vetting each candidate's `.hh` and `.cc`, the seven classes here are the subset whose destructor is provably redundant and whose pointers are non-owning. The risk profiles of the excluded candidates genuinely diverge, so they are intentionally left out rather than bundled.
