### PR TITLE
Update deprecated Dask `LocalCluster` method parameters in PyRosetta unit tests

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/test_dask.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/test_dask.py
@@ -32,21 +32,22 @@ class TestDaskDistribution(unittest.TestCase):
             if not self._dask_scheduler:
                 n_workers = 2
                 threads_per_worker = 2
-                diagnostics_port = None
+                dashboard_address = None
+                local_cluster_kwargs = dict(
+                    n_workers=n_workers,
+                    threads_per_worker=threads_per_worker,
+                    dashboard_address=dashboard_address,
+                    local_directory=local_dir,
+                )
                 if __dask_version__ <= (2, 1, 0):
-                    self.local_cluster = dask.distributed.LocalCluster(
-                        n_workers=n_workers,
-                        threads_per_worker=threads_per_worker,
-                        diagnostics_port=diagnostics_port,
-                        local_dir=local_dir,
+                    local_cluster_kwargs["local_dir"] = local_cluster_kwargs.pop(
+                        "local_directory", local_dir
                     )
-                else:
-                    self.local_cluster = dask.distributed.LocalCluster(
-                        n_workers=n_workers,
-                        threads_per_worker=threads_per_worker,
-                        diagnostics_port=diagnostics_port,
-                        local_directory=local_dir,
+                if __dask_version__ < (2026, 6, 0):
+                    local_cluster_kwargs["diagnostics_port"] = local_cluster_kwargs.pop(
+                        "dashboard_address", dashboard_address
                     )
+                self.local_cluster = dask.distributed.LocalCluster(**local_cluster_kwargs)
                 cluster = self.local_cluster
             else:
                 self.local_cluster = None

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/test_dask_worker.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/test_dask_worker.py
@@ -14,6 +14,10 @@ import tempfile
 import time
 import unittest
 
+from pyrosetta.utility import get_package_version
+
+
+__dask_version__ = get_package_version("dask")
 
 class TestDaskArgs(unittest.TestCase):
 
@@ -36,8 +40,14 @@ class TestDaskArgs(unittest.TestCase):
         import pyrosetta.distributed.tasks.score as score
 
         # Setup cluster scheduler and working directory
+        dashboard_address = None
+        local_cluster_kwargs = dict(n_workers=0, dashboard_address=dashboard_address)
+        if __dask_version__ < (2026, 6, 0):
+            local_cluster_kwargs["diagnostics_port"] = local_cluster_kwargs.pop(
+                "dashboard_address", dashboard_address
+            )
         with tempfile.TemporaryDirectory() as workdir, LocalCluster(
-            n_workers=0, diagnostics_port=None
+            **local_cluster_kwargs
         ) as cluster:
 
             # Context manager controls launch & teardown of test worker
@@ -102,8 +112,8 @@ class TestDaskArgs(unittest.TestCase):
                 cluster_result = delayed(protocol)(pose).compute()
 
             self.assertEqual(
-                cluster_result.scores["total_score"],
-                local_result.scores["total_score"]
+                cluster_result.pose.cache["total_score"],
+                local_result.pose.cache["total_score"]
             )
 
 

--- a/source/src/python/PyRosetta/src/test/T900_distributed.py
+++ b/source/src/python/PyRosetta/src/test/T900_distributed.py
@@ -16,6 +16,7 @@ def main(wait: bool, streaming: bool, timeout: int) -> None:
         "pyrosetta.tests.bindings.core.test_pose",
         "pyrosetta.tests.distributed.test_concurrency",
         "pyrosetta.tests.distributed.test_dask",
+        "pyrosetta.tests.distributed.test_dask_worker",
         "pyrosetta.tests.distributed.test_gil",
         "pyrosetta.tests.distributed.test_smoke",
         "pyrosetta.tests.distributed.test_viewer",

--- a/source/src/python/PyRosetta/src/test/T900_distributed.py
+++ b/source/src/python/PyRosetta/src/test/T900_distributed.py
@@ -16,7 +16,6 @@ def main(wait: bool, streaming: bool, timeout: int) -> None:
         "pyrosetta.tests.bindings.core.test_pose",
         "pyrosetta.tests.distributed.test_concurrency",
         "pyrosetta.tests.distributed.test_dask",
-        "pyrosetta.tests.distributed.test_dask_worker",
         "pyrosetta.tests.distributed.test_gil",
         "pyrosetta.tests.distributed.test_smoke",
         "pyrosetta.tests.distributed.test_viewer",


### PR DESCRIPTION
This quick PR aims to update some PyRosetta tests' usage of the deprecated `diagnostics_port` parameter in Dask's `LocalCluster` constructor, resulting in the following error since release `2026.6.0`:
```
TypeError: Server.__init__() got an unexpected keyword argument 'diagnostics_port'
```
Reference: https://b3.graylab.jhu.edu/test/913839