### PR TITLE
Fix GCC 16 (trunk) debug build: real bug + dead unused-but-set-variable cleanup

### DIFF
--- a/source/src/core/chemical/CacheableResidueTypeSets.cc
+++ b/source/src/core/chemical/CacheableResidueTypeSets.cc
@@ -42,7 +42,7 @@ CacheableResidueTypeSets::CacheableResidueTypeSets():
 CacheableResidueTypeSets::~CacheableResidueTypeSets()= default;
 
 CacheableResidueTypeSets::CacheableResidueTypeSets( CacheableResidueTypeSets const & other ) :
-	basic::datacache::CacheableData(*this),
+	basic::datacache::CacheableData(other),
 	// Shallow copy of the PoseResidueTypeSets
 	res_type_sets_( other.res_type_sets_ )
 {}

--- a/source/src/core/io/mmtf/mmtf_writer.cc
+++ b/source/src/core/io/mmtf/mmtf_writer.cc
@@ -245,15 +245,13 @@ add_bonds_to_sd(::mmtf::StructureData & sd,
 	aiModels const & AIM, std::map<core::Size, sd_index> const & atom_num_to_sd_map)
 {
 	int32_t groupIndex = 0;
-	int32_t chainIndex = 0; // unused
-	int32_t modelIndex = 0;
 	unsigned int atomIndex = 0;
 	//int group_bonds(0), inter_bonds(0);
 	std::vector<core::Size>type_check;
 	// TODO this function sucks :(
-	for ( core::Size i=0; i<AIM.size(); ++i, ++modelIndex ) {  // for each model
+	for ( core::Size i=0; i<AIM.size(); ++i ) {  // for each model
 		aiPose const & AIP(AIM[i]);
-		for ( core::Size j=0; j<AIP.size(); ++j, ++chainIndex ) {  // for each chain
+		for ( core::Size j=0; j<AIP.size(); ++j ) {  // for each chain
 			for ( core::Size k=0; k<AIP[j].size(); ++k, ++groupIndex ) {  // for each group
 				for ( core::Size l=0; l<AIP[j][k].size(); ++l, ++atomIndex ) {  // for each atom
 					AtomInformation const & ai = AIP[j][k][l];

--- a/source/src/core/pack/guidance_scoreterms/sap/SapConstraintHelper.cc
+++ b/source/src/core/pack/guidance_scoreterms/sap/SapConstraintHelper.cc
@@ -1769,6 +1769,7 @@ SapConstraintHelper::find_lightning_2b(
 			}
 		}
 	}
+	(void)offset; // tracked for symmetry with the section above; never actually needed
 	return twobody;
 }
 

--- a/source/src/core/pose/PDBInfo.cc
+++ b/source/src/core/pose/PDBInfo.cc
@@ -796,10 +796,9 @@ PDBInfo::copy(
 	debug_assert( start_from <= residue_rec_.size() );
 
 	// force erase data from map
-	Size idx = start_from;
 	ResidueRecords::const_iterator const begin = residue_rec_.begin() + ( start_from - 1 );
 	ResidueRecords::const_iterator const end = begin + ( copy_to - copy_from + 1 );
-	for ( ResidueRecords::const_iterator i = begin; i < end; ++i, ++idx ) {
+	for ( ResidueRecords::const_iterator i = begin; i < end; ++i ) {
 		pdb2pose_.erase( i->chainID, i->resSeq, i->iCode, i->segmentID );
 	}
 
@@ -956,8 +955,7 @@ PDBInfo::delete_res(
 	auto start = residue_rec_.begin() + ( res - 1 );
 
 	// sync map first (force erase)
-	Size idx = res;
-	for ( auto i = start, ie = start + n; i < ie; ++i, ++idx ) {
+	for ( auto i = start, ie = start + n; i < ie; ++i ) {
 		pdb2pose_.erase( i->chainID, i->resSeq, i->iCode, i->segmentID );
 	}
 

--- a/source/src/core/scoring/EnergyGraph.hh
+++ b/source/src/core/scoring/EnergyGraph.hh
@@ -293,7 +293,7 @@ EnergyEdge::store_active_energies( EnergyMap const & emap, ScoreTypes const & su
 {
 	utility::vector1< int > const & st2active( get_energy_owner()->score_type_2_active() );
 
-	for ( Size ii = 1, iilag = 0; ii <= subset.size(); ++ii, ++iilag ) {
+	for ( Size ii = 1; ii <= subset.size(); ++ii ) {
 		if ( st2active[ subset[ ii ]] >= 0 ) {
 			array_[ st2active[ subset[ ii ]] ] = emap[ subset[ ii ] ];
 		}
@@ -333,7 +333,7 @@ void EnergyEdge::add_to_energy_map( EnergyMap & emap, ScoreTypes const & subset 
 {
 	utility::vector1< int > const & st2active( get_energy_owner()->score_type_2_active() );
 
-	for ( Size ii = 1, iilag = 0; ii <= subset.size(); ++ii, ++iilag ) {
+	for ( Size ii = 1; ii <= subset.size(); ++ii ) {
 		if ( st2active[ subset[ ii ]] >= 0 ) {
 			emap[ subset[ ii ] ] += array_[ st2active[ subset[ ii ]] ];
 		}

--- a/source/src/numeric/MathMatrix.hh
+++ b/source/src/numeric/MathMatrix.hh
@@ -59,7 +59,7 @@ public:
 	//////////////////////////////////
 
 	/// @brief default constructor
-	MathMatrix< T>() :
+	MathMatrix() :
 	NumberRows_( 0),
 	NumberCols_( 0),
 	size_( 0 ),
@@ -79,7 +79,7 @@ public:
 	/// @param NUMBER_ROWS number of rows in matrix
 	/// @param NUMBER_COLS number of cols in matrix
 	/// @param FILL_VALUE assign every element to that value
-	explicit MathMatrix< T>
+	explicit MathMatrix
 	(
 		const Size NUMBER_ROWS,
 		const Size NUMBER_COLS,
@@ -98,7 +98,7 @@ public:
 	/// @param NUMBER_ROWS number of rows in matrix
 	/// @param NUMBER_COLS number of cols in matrix
 	/// @param DATA pointer to field of data
-	MathMatrix< T>
+	MathMatrix
 	(
 		const Size NUMBER_ROWS,
 		const Size NUMBER_COLS,
@@ -133,7 +133,7 @@ public:
 	}
 
 	/// @brief destructor
-	~MathMatrix< T>()
+	~MathMatrix()
 	{
 		delete[] data_;
 	}

--- a/source/src/numeric/MathMatrix.hh
+++ b/source/src/numeric/MathMatrix.hh
@@ -60,10 +60,10 @@ public:
 
 	/// @brief default constructor
 	MathMatrix() :
-	NumberRows_( 0),
-	NumberCols_( 0),
-	size_( 0 ),
-	data_( nullptr )
+		NumberRows_( 0),
+		NumberCols_( 0),
+		size_( 0 ),
+		data_( nullptr )
 	{
 	}
 
@@ -85,10 +85,10 @@ public:
 		const Size NUMBER_COLS,
 		const T &FILL_VALUE = T( 0)
 	) :
-	NumberRows_( NUMBER_ROWS),
-	NumberCols_( NUMBER_COLS),
-	size_( NumberRows_ * NumberCols_ ),
-	data_( new T[ size_ ])
+		NumberRows_( NUMBER_ROWS),
+		NumberCols_( NUMBER_COLS),
+		size_( NumberRows_ * NumberCols_ ),
+		data_( new T[ size_ ])
 	{
 		// set all values to FILL_VALUE
 		std::fill( data_, data_ + size_, FILL_VALUE);
@@ -104,10 +104,10 @@ public:
 		const Size NUMBER_COLS,
 		const T *DATA
 	) :
-	NumberRows_( NUMBER_ROWS),
-	NumberCols_( NUMBER_COLS),
-	size_( NumberRows_ * NumberCols_ ),
-	data_( new T[ NumberRows_ * NumberCols_])
+		NumberRows_( NUMBER_ROWS),
+		NumberCols_( NUMBER_COLS),
+		size_( NumberRows_ * NumberCols_ ),
+		data_( new T[ NumberRows_ * NumberCols_])
 	{
 		// copy data
 		std::copy( DATA, DATA + size_, data_);

--- a/source/src/numeric/MathVector.hh
+++ b/source/src/numeric/MathVector.hh
@@ -67,8 +67,8 @@ public:
 
 	/// @brief default constructor
 	MathVector() :
-	size_( 0),
-	data_( nullptr )
+		size_( 0),
+		data_( nullptr )
 	{
 	}
 
@@ -82,8 +82,8 @@ public:
 	/// @param SIZE number fo elements in Vector
 	/// @param FILL_VALUE assign every element to that value
 	explicit MathVector( const Size SIZE, const T &FILL_VALUE= T( 0)) :
-	size_( SIZE),
-	data_( new T[ SIZE])
+		size_( SIZE),
+		data_( new T[ SIZE])
 	{
 
 		// set all values to FILL_VALUE
@@ -92,8 +92,8 @@ public:
 
 	/// @brief construct from length and pointer to data
 	MathVector( const Size SIZE, const T *DATA) :
-	size_( SIZE),
-	data_( new T[ SIZE])
+		size_( SIZE),
+		data_( new T[ SIZE])
 	{
 		std::copy( DATA, DATA + SIZE, data_);
 	}

--- a/source/src/numeric/MathVector.hh
+++ b/source/src/numeric/MathVector.hh
@@ -66,7 +66,7 @@ public:
 	//////////////////////////////////
 
 	/// @brief default constructor
-	MathVector< T>() :
+	MathVector() :
 	size_( 0),
 	data_( nullptr )
 	{
@@ -81,7 +81,7 @@ public:
 	/// @brief construct from size and possible filler
 	/// @param SIZE number fo elements in Vector
 	/// @param FILL_VALUE assign every element to that value
-	explicit MathVector< T>( const Size SIZE, const T &FILL_VALUE= T( 0)) :
+	explicit MathVector( const Size SIZE, const T &FILL_VALUE= T( 0)) :
 	size_( SIZE),
 	data_( new T[ SIZE])
 	{
@@ -91,7 +91,7 @@ public:
 	}
 
 	/// @brief construct from length and pointer to data
-	MathVector< T>( const Size SIZE, const T *DATA) :
+	MathVector( const Size SIZE, const T *DATA) :
 	size_( SIZE),
 	data_( new T[ SIZE])
 	{
@@ -116,7 +116,7 @@ public:
 	}
 
 	/// @ brief destructor
-	~MathVector< T>()
+	~MathVector()
 	{
 		delete[] data_;
 	}

--- a/source/src/numeric/histograms/OneDHistogram.hh
+++ b/source/src/numeric/histograms/OneDHistogram.hh
@@ -38,7 +38,7 @@ class OneDHistogram {
 
 public:
 
-	OneDHistogram<key1>()= default;
+	OneDHistogram()= default;
 
 	void insert_data(key1 key_1, platform::Size counts){
 		histogram_.insert(std::make_pair(key_1, counts));

--- a/source/src/numeric/histograms/OneDHistogram.hh
+++ b/source/src/numeric/histograms/OneDHistogram.hh
@@ -29,8 +29,8 @@
 #include <map>
 #include <platform/types.hh>
 
-namespace numeric{
-namespace histograms{
+namespace numeric {
+namespace histograms {
 
 
 template<typename key1>
@@ -52,7 +52,7 @@ public:
 
 
 private:
-std::map< key1, platform::Size > histogram_;
+	std::map< key1, platform::Size > histogram_;
 
 
 };

--- a/source/src/protocols/abinitio/FoldConstraints.cc
+++ b/source/src/protocols/abinitio/FoldConstraints.cc
@@ -213,10 +213,9 @@ FoldConstraints::do_stage1_cycles( pose::Pose& pose ) {
 	moves::MoverOP trial( stage1_mover( pose, trial_large() ) );
 	core::Real const cycle_factor( option[ fold_cst::stage1_ramp_cst_cycle_factor ] );
 	auto const cycles ( static_cast< core::Size > ( cycle_factor * stage1_cycles() ) );
-	int total_cycles = 0;
 	if ( tr.visible() ) pose.constraint_set()->show_violations( tr, pose, show_viol_level_ );
 	//first run a normal set of fragment insertions until extended chain is lost
-	total_cycles += Parent::do_stage1_cycles( pose );
+	Parent::do_stage1_cycles( pose );
 	if ( tr.visible() ) pose.constraint_set()->show_violations( tr, pose, show_viol_level_ );
 
 	if ( pose.constraint_set()->has_residue_pair_constraints() ) {
@@ -226,7 +225,7 @@ FoldConstraints::do_stage1_cycles( pose::Pose& pose ) {
 			set_max_seq_sep( pose, jk);
 			if ( tr.visible() ) pose.constraint_set()->show_violations( tr, pose, show_viol_level_ );
 			if ( old_constraint_score == evaluate_constraint_energy ( pose, mc().score_function() ) ) continue;
-			for ( core::Size j = 1; j <= cycles; ++j, ++total_cycles ) {
+			for ( core::Size j = 1; j <= cycles; ++j ) {
 				//   if ( evaluate_constraint_energy( pose, mc().score_function() ) < 10.0 ) break; this is unlikely to be triggered for cnc and always triggered for james-cst
 				if ( numeric::mod( j, (core::Size)10)==0 && bSkipOnNoViolation_ && pose.constraint_set()->show_violations( tr, pose, 0 ) == 0 ) break;
 				trial->apply( pose );

--- a/source/src/protocols/cartesian/md.cc
+++ b/source/src/protocols/cartesian/md.cc
@@ -184,9 +184,8 @@ void MolecularDynamics::getCartesianDerivatives(
 
 	// now loop over the torsions in the map (the map MUST be a map of everything!)
 
-	int imap( 1 ); // for indexing into de_dvars( imap )
 	for ( auto it=min_map.begin(), ite=min_map.end();
-			it != ite; ++it, ++imap ) {
+			it != ite; ++it ) {
 		using namespace id;
 
 		DOF_Node const & dof_node( **it );

--- a/source/src/protocols/denovo_design/components/StructureDataFactory.cc
+++ b/source/src/protocols/denovo_design/components/StructureDataFactory.cc
@@ -383,9 +383,8 @@ StructureDataFactory::infer_from_pose( core::pose::Pose const & pose, SegmentNam
 	utility::vector1< core::Size > chain_endings = pose.conformation().chain_endings();
 	chain_endings.push_back( pose.size() );
 	core::Size chain_start = 1;
-	core::Size cur_chain = 1;
 	SegmentCounts counts( pose );
-	for ( utility::vector1< core::Size >::const_iterator r=chain_endings.begin(); r!=chain_endings.end(); ++r, ++cur_chain ) {
+	for ( utility::vector1< core::Size >::const_iterator r=chain_endings.begin(); r!=chain_endings.end(); ++r ) {
 		core::Size const chain_end = *r;
 
 		// collect information about the residues from [ chain_start, chain_end ]

--- a/source/src/protocols/denovo_design/movers/FoldArchitectMover.cc
+++ b/source/src/protocols/denovo_design/movers/FoldArchitectMover.cc
@@ -717,8 +717,7 @@ void
 FoldArchitectMover::apply_movers( MoverOPs const & movers, core::pose::Pose & pose ) const
 {
 	//pose.dump_pdb( "prefold_0.pdb" );
-	core::Size count = 1;
-	for ( auto m=movers.begin(); m!=movers.end(); ++m, ++count ) {
+	for ( auto m=movers.begin(); m!=movers.end(); ++m ) {
 		TR.Debug << "Running mover " << (*m)->get_name() << std::endl;
 		(*m)->apply( pose );
 		//pose.dump_pdb( "prefold_" + (*m)->get_name() + boost::lexical_cast< std::string >( count ) + ".pdb" );

--- a/source/src/protocols/forge/methods/pose_mod.hh
+++ b/source/src/protocols/forge/methods/pose_mod.hh
@@ -62,8 +62,7 @@ grow_left_r(
 	bool const had_lower_terminus = pose.residue( anchor ).is_lower_terminus();
 
 	// grow extension
-	core::Size current_pos = anchor; // tracks the anchor as it moves
-	for ( ResidueOPIterator i = begin; i != end; ++i, ++current_pos ) {
+	for ( ResidueOPIterator i = begin; i != end; ++i ) {
 		pose.conformation().safely_prepend_polymer_residue_before_seqpos( **i, anchor, !use_existing_crd ); // will remove any terminus
 	}
 

--- a/source/src/protocols/noesy_assign/DistanceScoreMover.cc
+++ b/source/src/protocols/noesy_assign/DistanceScoreMover.cc
@@ -260,8 +260,7 @@ void DistanceScoreMover::apply( pose::Pose& pose ) {
 
 void DistanceScoreMover::finalize_scoring() const {
 #ifndef WIN32
-	core::Size ct_peaks( 1 );
-	for ( auto it = cross_peaks_.begin(); it != cross_peaks_.end(); ++it, ++ct_peaks ) {
+	for ( auto it = cross_peaks_.begin(); it != cross_peaks_.end(); ++it ) {
 		for ( auto ait = (*it)->begin(); ait != (*it)->end(); ++ait ) {
 			(*ait)->set_decoy_compatibility( (*ait)->decoy_compatibility()/count_decoys_ );
 		}

--- a/source/src/protocols/noesy_assign/StructureDependentPeakCalibrator.cc
+++ b/source/src/protocols/noesy_assign/StructureDependentPeakCalibrator.cc
@@ -71,13 +71,12 @@ void StructureDependentPeakCalibrator::collect_upperbound_statistics( core::Size
 	Real inv_n_struct( 1.0 / structures_.size() );
 	runtime_assert( peak <= peaks().size() );
 	runtime_assert( constraints_.size() == peaks().size() );
-	core::Size pose_ct( 1 );
 	Real stddev( 0.0);
 	Real mean( 0.0 );
 	PeakAssignmentParameters const& params( *PeakAssignmentParameters::get_instance() );
 	if ( constraints_[ peak ] &&
 			!( params.calibration_ignore_eliminated_peaks_  && peaks()[ peak ]->eliminated() ) ) {
-		for ( PoseVector::const_iterator pose_it = structures_.begin(); pose_it != structures_.end(); ++pose_it, ++pose_ct ) {
+		for ( PoseVector::const_iterator pose_it = structures_.begin(); pose_it != structures_.end(); ++pose_it ) {
 			Real dist( constraints_[ peak ]->dist( **pose_it ) );
 			stddev += dist*dist;
 			mean += dist;

--- a/source/src/protocols/simple_moves/MissingDensityToJumpMover.cc
+++ b/source/src/protocols/simple_moves/MissingDensityToJumpMover.cc
@@ -40,7 +40,7 @@ namespace simple_moves {
 static basic::Tracer TR( "protocols.mover.MissingDensityToJumpMover" );
 
 // Default constructor
-MissingDensityToJumpMover::MissingDensityToJumpMover(): protocols::moves::Mover( MissingDensityToJumpMover::get_name() )
+MissingDensityToJumpMover::MissingDensityToJumpMover(): protocols::moves::Mover( "MissingDensityToJumpMover" )
 {}
 
 // Copy constructor


### PR DESCRIPTION
## Summary

This machine has GCC 12 through GCC 16 (16 is an experimental trunk build) installed side by side. A survey of the debug library build under each version found:

- **GCC 12, GCC 13**: build cleanly out of the box.
- **GCC 14, GCC 15**: need the `template-id-cdtor` fix in #723.
- **GCC 16**: needs #723's fix *plus* the changes in this PR.

Building under GCC 16 (with #723's fix applied) surfaced 16 unique `-Werror` sites — mostly `-Wunused-but-set-variable`, plus two `-Wmaybe-uninitialized` cases (one of which is a real bug):

1. **Real bug** — `core/chemical/CacheableResidueTypeSets.cc`: the copy constructor initialized its base class with `CacheableData(*this)` instead of `CacheableData(other)`, reading from the not-yet-constructed destination object rather than the fully-constructed source. Harmless today only because `CacheableData` has no data members of its own; still wrong and exactly what GCC 16 is right to flag.
2. **False-positive trigger** — `protocols/simple_moves/MissingDensityToJumpMover.cc`: the default constructor called `MissingDensityToJumpMover::get_name()` (a qualified call through `*this`, mid-construction) to build an argument for the `Mover` base class. `get_name()` just returns a string literal, so it's passed directly instead — avoids the pattern rather than working around a compiler quirk.
3. **Dead loop counters** (13 sites across 9 files) — variables incremented alongside a real loop iterator but never read anywhere: `EnergyGraph.hh` (`iilag`, 2 of 4 occurrences — the other two are real array indices and are untouched), `PDBInfo.cc` (`idx`, x2), `mmtf_writer.cc` (`chainIndex`, `modelIndex`), `md.cc` (`imap`), `StructureDataFactory.cc` (`cur_chain`), `FoldArchitectMover.cc` (`count`), `pose_mod.hh` (`current_pos`), `DistanceScoreMover.cc` (`ct_peaks`), `StructureDependentPeakCalibrator.cc` (`pose_ct`). No behavior change — removed the tracking, left the actual iteration logic untouched.
4. **Deliberately-unused, kept** — `SapConstraintHelper.cc`'s `offset` is tracked "for symmetry" per an existing comment even though never read. Rather than removing it against that stated intent, added an explicit `(void)offset;` cast to satisfy the warning.

Verified with a clean incremental `mode=debug` library build under GCC 16 after each fix.

## Dependency on #723

The first two commits on this branch are cherry-picked from #723 (`template-id-cdtor` fix for `numeric/MathVector.hh`, `MathMatrix.hh`, and `OneDHistogram.hh`) — GCC 16 hits the identical issue, and it's needed here just to get past `numeric/` far enough to reach the errors this PR actually fixes. No new work is claimed for that part; #723 is the canonical fix and should merge independently of this one. If #723 merges first, rebasing this branch will make those two commits disappear from the diff.
