### PR TITLE
Fix off-by-one in 1-indexed loops in core/ (split 1/4 of #707)

### DIFF
--- a/source/src/core/energy_methods/RNA_LJ_BaseEnergy.cc
+++ b/source/src/core/energy_methods/RNA_LJ_BaseEnergy.cc
@@ -325,7 +325,7 @@ RNA_LJ_BaseEnergy::eval_atom_energy(
 
 	Vector const heavy_atom_i( rsd1.xyz( m ) );
 
-	for ( Size j = 1; j < pose.size(); j ++ ) {
+	for ( Size j = 1; j <= pose.size(); j ++ ) {
 		if ( i == j ) continue;
 
 		conformation::Residue const & rsd2( pose.residue( j ) );

--- a/source/src/core/io/pose_to_sfr/PoseToStructFileRepConverter.cc
+++ b/source/src/core/io/pose_to_sfr/PoseToStructFileRepConverter.cc
@@ -1503,7 +1503,7 @@ PoseToStructFileRepConverter::generate_secondary_structure_informations( core::p
 	core::Size new_tercount( 0 ); //we have to track this for ResidueInformation
 
 	//Now we are going to iterate through the pose, identifying secondary structure elements
-	for ( Size ires=1; ires<pose.size(); ++ires ) {
+	for ( Size ires=1; ires<=pose.size(); ++ires ) {
 		char secstruct = secstructs[ires-1]; //H, E, or L; note indexing fix
 		Size chain = pose.residue(ires).chain();
 		Size jres = ires;

--- a/source/src/core/pack/interaction_graph/SurfacePotential.cc
+++ b/source/src/core/pack/interaction_graph/SurfacePotential.cc
@@ -293,7 +293,7 @@ void SurfacePotential::compute_residue_surface_energy( conformation::Residue con
 	// in (being considered) rotamer, not of the wild type sequence rotamer.  In a small percent of the cases, using the wild type
 	// nbr_atom will give a different count than when using the new rotamer nbr_atom position.
 	Real distanceBetweenAtoms = 0.0;
-	for ( Size res2_position = 1; res2_position < pose.size(); ++res2_position ) {
+	for ( Size res2_position = 1; res2_position <= pose.size(); ++res2_position ) {
 
 		if ( resid == res2_position ) { continue; }
 		conformation::Residue const & rsd2 = pose.residue( res2_position );
@@ -419,7 +419,7 @@ void SurfacePotential::compute_pose_surface_energy( pose::Pose const & pose, Rea
 		conformation::Residue const & rsd1 = pose.residue( res1_position );
 		Real distanceBetweenAtoms = 0.0;
 
-		for ( Size res2_position = 1; res2_position < pose.size(); ++res2_position ) {
+		for ( Size res2_position = 1; res2_position <= pose.size(); ++res2_position ) {
 			if ( pose.residue( res2_position ).aa() > core::chemical::num_canonical_aas ) continue;
 			if ( symm_info && !symm_info->bb_is_independent(res2_position) ) continue;
 
@@ -462,7 +462,7 @@ void SurfacePotential::compute_pose_surface_energy( pose::Pose const & pose, Rea
 
 
 	total_surface_energy_ = 0.0;
-	for ( Size ii=1; ii < residue_surface_energy_.size(); ++ii ) {
+	for ( Size ii=1; ii <= residue_surface_energy_.size(); ++ii ) {
 		total_surface_energy_ += residue_surface_energy_[ii];
 	}
 

--- a/source/src/core/pose/rna/util.cc
+++ b/source/src/core/pose/rna/util.cc
@@ -2058,7 +2058,7 @@ detect_base_contacts( core::pose::Pose const & pose ) {
 				if ( i == j ) continue;
 				if ( ( pose.residue( i ).nbr_atom_xyz() - pose.residue( j ).nbr_atom_xyz() ).length() > NBR_DIST_CUTOFF ) continue;
 
-				for ( Size jj = 1; jj < pose.residue_type( j ).nheavyatoms(); jj++ ) {
+				for ( Size jj = 1; jj <= pose.residue_type( j ).nheavyatoms(); jj++ ) {
 					if ( pose.residue_type( j ).is_virtual( jj ) ) continue;
 					if ( ( pose.residue( i ).xyz( ii ) - pose.residue( j ).xyz( jj ) ).length() < CONTACT_DIST_CUTOFF ) {
 						//      TR << "FOUND CONTACT " << pose.pdb_info()->chain(i) << ":" << pose.pdb_info()->number( i ) << " " << pose.residue(i).atom_name(ii)

--- a/source/src/core/select/residue_selector/JumpUpstreamSelector.cc
+++ b/source/src/core/select/residue_selector/JumpUpstreamSelector.cc
@@ -77,7 +77,7 @@ JumpUpstreamSelector::apply( core::pose::Pose const & pose ) const
 	ObjexxFCL::FArray1D_bool upstream( pose.size() );
 	pose.fold_tree().partition_by_jump( jump_, upstream );
 
-	for ( core::Size ii = 1; ii < upstream.size(); ++ii ) {
+	for ( core::Size ii = 1; ii <= upstream.size(); ++ii ) {
 		subset[ ii ] = upstream( ii );
 	}
 	return subset;


### PR DESCRIPTION
## Summary

One of **four PRs splitting #707** (originally a single 35-file off-by-one batch) into coherent, per-subsystem pieces, so each can be reviewed and its regression-test impact assessed independently. #707 is being closed in favor of these four. The split is deliberate — the individual diffs are below the usual bundling threshold — because the changes are behavior-affecting and the maintainer asked to isolate regression-test impact per subsystem.

**This PR: `core/` (5 files).**

Each loop uses `for ( Size i = 1; i < container.size(); ++i )` (or `< pose.size()` / `< nheavyatoms()` / `< upstream.size()`) and the body uses `i` as a direct 1-indexed accessor — `pose.residue(i)`, `vec[i]`, `xyz(i)` — so the last element is silently skipped. Changed `<` to `<=` to include it.

- `core/energy_methods/RNA_LJ_BaseEnergy.cc` — RNA neighbor scan
- `core/io/pose_to_sfr/PoseToStructFileRepConverter.cc` — SS-element enumeration; a 1-residue SS element at the C-terminus was dropped
- `core/pack/interaction_graph/SurfacePotential.cc` ×3 — neighbor count, surface-energy sum
- `core/pose/rna/util.cc` — heavy-atom contact scan
- `core/select/residue_selector/JumpUpstreamSelector.cc` — subset assignment; diverged from sibling `JumpDownstreamSelector`, which already uses `<=`

## Regression tests

None of the changed regression tests reported for #707 (`enzdes`, `inverse_rotamer_remodel`, `ligand_dock_cholesterol`, `mp_f19_relax`, `mpil_load_implicit_lipids`, `pose_sewing`, `unfolded_state_energy_calc`) fall in this subsystem, so this PR is expected to be inert with respect to that set. CI will confirm.
