### PR TITLE
Fix off-by-one loops + self-distance bug in SEWING/splice/de novo/RNA (split 3/4 of #707)

### DIFF
--- a/source/src/protocols/denovo_design/components/FoldGraph.cc
+++ b/source/src/protocols/denovo_design/components/FoldGraph.cc
@@ -852,7 +852,7 @@ FoldGraph::compute_best_solution( SegmentNames const & staple_loops ) const
 						solutions[sol].push_back( new_visited );
 					} else {
 						Solution tmpset;
-						for ( core::Size t=1; t<solutions[sol].size(); ++t ) {
+						for ( core::Size t=1; t<=solutions[sol].size(); ++t ) {
 							tmpset.push_back( solutions[sol][t] );
 						}
 						tmpset.push_back( new_visited );

--- a/source/src/protocols/features/strand_assembly/StrandBundleFeatures.cc
+++ b/source/src/protocols/features/strand_assembly/StrandBundleFeatures.cc
@@ -934,8 +934,8 @@ StrandBundleFeatures::shortest_dis_sidechain(
 
 		for ( core::Size strand_j_res=0; strand_j_res < strand_j.get_size(); strand_j_res++ ) {
 			core::Size j_resnum = strand_j.get_start()+strand_j_res;
-			for ( core::Size i_AtomNum=1; i_AtomNum < pose.residue(i_resnum).natoms(); i_AtomNum++ ) {
-				for ( core::Size j_AtomNum=1; j_AtomNum < pose.residue(j_resnum).natoms(); j_AtomNum++ ) {
+			for ( core::Size i_AtomNum=1; i_AtomNum <= pose.residue(i_resnum).natoms(); i_AtomNum++ ) {
+				for ( core::Size j_AtomNum=1; j_AtomNum <= pose.residue(j_resnum).natoms(); j_AtomNum++ ) {
 					Real dis_sc_sc = pose.residue(i_resnum).xyz(i_AtomNum).distance(pose.residue(j_resnum).xyz(j_AtomNum));
 					if ( temp_shortest_dis > dis_sc_sc ) {
 						temp_shortest_dis = dis_sc_sc;

--- a/source/src/protocols/fldsgn/MatchResidues.cc
+++ b/source/src/protocols/fldsgn/MatchResidues.cc
@@ -62,7 +62,7 @@ core::Real
 MatchResidues::compute_comb( core::pose::Pose const & pose, VecSize const & comb ) const
 {
 	std::map< core::id::AtomID, core::id::AtomID > atom_id_map;
-	for ( core::Size i = 1; i < comb.size(); i++ ) {
+	for ( core::Size i = 1; i <= comb.size(); i++ ) {
 		const core::id::AtomID mod_id(pose.residue_type( comb[i] ).atom_index( "CA" ), comb[i] );
 		const core::id::AtomID ref_id(pose.residue_type( reference_residues_indexes_[i] ).atom_index( "CA" ), reference_residues_indexes_[i]);
 		atom_id_map.insert( std::make_pair(mod_id, ref_id) );
@@ -75,7 +75,7 @@ MatchResidues::superimpose_comb( core::pose::Pose & pose, VecSize const & comb )
 {
 	core::id::AtomID_Map< core::id::AtomID > atom_map;
 	core::pose::initialize_atomid_map( atom_map, pose, core::id::AtomID::BOGUS_ATOM_ID() );
-	for ( core::Size i = 1; i < comb.size(); ++i ) {
+	for ( core::Size i = 1; i <= comb.size(); ++i ) {
 		const core::id::AtomID mod_id(pose.residue_type( comb[i] ).atom_index( "CA" ), comb[i] );
 		const core::id::AtomID ref_id(pose.residue_type( reference_residues_indexes_[i] ).atom_index( "CA" ), reference_residues_indexes_[i]);
 		atom_map.set( mod_id, ref_id);

--- a/source/src/protocols/legacy_sewing/conformation/Assembly.cc
+++ b/source/src/protocols/legacy_sewing/conformation/Assembly.cc
@@ -1259,7 +1259,7 @@ Assembly::natives_select(
 utility::vector1<core::Size>
 Assembly::pose_loop_anchors() const {
 	utility::vector1<core::Size> loop_anchors;
-	for ( core::Size i=1; i<segments_.size(); ++i ) {
+	for ( core::Size i=1; i<=segments_.size(); ++i ) {
 		if ( !segments_.has_next(i) ) {
 			loop_anchors.push_back(pose_num(segments_[i].model_id_, segments_[i].residues_.back().resnum_));
 		}
@@ -1271,7 +1271,7 @@ Assembly::pose_loop_anchors() const {
 utility::vector1<core::Size>
 Assembly::disconnected_segments() const {
 	utility::vector1<core::Size> disconnected_segments;
-	for ( core::Size i=1; i<segments_.size(); ++i ) {
+	for ( core::Size i=1; i<=segments_.size(); ++i ) {
 		if ( !segments_.has_next(i) ) {
 			disconnected_segments.push_back(i);
 		}

--- a/source/src/protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc
+++ b/source/src/protocols/pose_sewing/movers/BlockwiseAnalysisMover.cc
@@ -92,11 +92,11 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 
 	std::pair<core::Size, core::Size> helix_pair;
 
-	for ( core::Size upstream_res = 1; upstream_res < pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.secstruct(upstream_res) == 'H' ) {
 			for ( core::Size downstream_res = upstream_res+1; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.secstruct(downstream_res) == 'H' ) {
-					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2)) <= crit_dist_ ) {
+					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(downstream_res).xyz(2)) <= crit_dist_ ) {
 						helix_pair.first = element_blocks[upstream_res];
 						helix_pair.second = element_blocks[downstream_res];
 						helix_pairs.insert(helix_pair);
@@ -117,7 +117,7 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 	//core::Size label_res = 1;
 	for ( auto current_pair : helix_pairs ) {
 		scc.Reset(); // this may not be needed anymore, but I'm leaving it here for safety
-		for ( core::Size current_res = 1; current_res < pose.size(); ++current_res ) {
+		for ( core::Size current_res = 1; current_res <= pose.size(); ++current_res ) {
 			if ( element_blocks[current_res] == current_pair.first ) {
 				scc.AddResidue( 0, pose.residue(current_res) );
 			}
@@ -134,7 +134,7 @@ BlockwiseAnalysisMover::apply( core::pose::Pose& pose){
 		d_median = r.distance;
 		has_disulfide = false;
 		core::Size last_upstream_res = 1;
-		for ( core::Size upstream_res = 1; upstream_res <pose.size(); ++upstream_res ) {
+		for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 			if ( pose.residue(upstream_res).type().is_disulfide_bonded() && element_blocks[upstream_res] == current_pair.first ) {
 				for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 					if ( pose.residue(downstream_res).type().is_disulfide_bonded() && pose.residue(upstream_res).is_bonded(pose.residue(downstream_res)) && element_blocks[downstream_res] == current_pair.second ) {

--- a/source/src/protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc
+++ b/source/src/protocols/pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc
@@ -132,7 +132,7 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 	std::string label;
 
 	//pose.pdb_info()->add_reslabel(1,label);
-	for ( core::Size upstream_res = 1; upstream_res <pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.residue(upstream_res).type().is_disulfide_bonded() ) {
 			for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.residue(downstream_res).type().is_disulfide_bonded() && pose.residue(upstream_res).is_bonded(pose.residue(downstream_res)) ) {
@@ -170,11 +170,11 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 
 	std::pair<core::Size, core::Size> helix_pair;
 
-	for ( core::Size upstream_res = 1; upstream_res < pose.size(); ++upstream_res ) {
+	for ( core::Size upstream_res = 1; upstream_res <= pose.size(); ++upstream_res ) {
 		if ( pose.secstruct(upstream_res) == 'H' ) {
 			for ( core::Size downstream_res = upstream_res+2; downstream_res <= pose.size(); ++downstream_res ) {
 				if ( pose.secstruct(downstream_res) == 'H' ) {
-					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2)) <= crit_dist_ ) {
+					if ( element_blocks[upstream_res] != element_blocks[downstream_res] && pose.residue(upstream_res).xyz(2).distance(pose.residue(downstream_res).xyz(2)) <= crit_dist_ ) {
 						helix_pair.first = element_blocks[upstream_res];
 						helix_pair.second = element_blocks[downstream_res];
 						helix_pairs.insert(helix_pair);
@@ -195,7 +195,7 @@ OmnibusDisulfideAnalysisLabelerMover::apply( core::pose::Pose& pose){
 		utility::vector1< core::Size > selection1;
 		utility::vector1< core::Size > selection2;
 
-		for ( core::Size current_res = 1; current_res < pose.size(); ++current_res ) {
+		for ( core::Size current_res = 1; current_res <= pose.size(); ++current_res ) {
 			if ( element_blocks[current_res] == current_pair.first ) {
 				selection1.push_back(current_res);
 			}

--- a/source/src/protocols/rna/movers/RNAIdealizeMover.cc
+++ b/source/src/protocols/rna/movers/RNAIdealizeMover.cc
@@ -237,7 +237,7 @@ RNAIdealizeMover::apply( pose::Pose & pose )
 	suite_mm->set_jump( true );
 	protocols::minimization_packing::MinMoverOP minm = utility::pointer::make_shared< protocols::minimization_packing::MinMover >( suite_mm, scorefxn, "lbfgs_armijo_nonmonotone", 0.001, true );
 
-	for ( Size ii = 1; ii < ideal_pose.size(); ++ii ) {
+	for ( Size ii = 1; ii <= ideal_pose.size(); ++ii ) {
 
 		for ( Size jj = 1; jj <= ideal_pose.residue_type( ii ).natoms(); ++jj ) {
 			ConstraintOP constraint = utility::pointer::make_shared< CoordinateConstraint >( core::id::AtomID( jj, ii ), core::id::AtomID( 1, my_anchor ),

--- a/source/src/protocols/splice/SampleRotamersFromPDB.cc
+++ b/source/src/protocols/splice/SampleRotamersFromPDB.cc
@@ -229,7 +229,7 @@ void SampleRotamersFromPDB_RotamerSetOperation::fill_rotamer_matrix_from_db_file
 			}
 			//new_res->set_all_chi(Rots_real);
 			bool res_exsits_in_db = false;
-			for ( core::Size i=1; i<resi_vec_[resi_num].size(); i++ ) {
+			for ( core::Size i=1; i<=resi_vec_[resi_num].size(); i++ ) {
 				res_exsits_in_db = is_identical_rotamer(resi_vec_[resi_num][i],new_res);
 				if ( res_exsits_in_db ) break;
 				//TR<<"Found identical residue"<<std::endl;
@@ -780,7 +780,7 @@ rot_matrix RotLibdb::fill_rotamer_matrix_from_db_file(std::string fname) {
 			}
 
 			bool res_exsits_in_db = false;
-			for ( core::Size i=1; i<resi_mat[resi_num].size(); i++ ) {
+			for ( core::Size i=1; i<=resi_mat[resi_num].size(); i++ ) {
 				res_exsits_in_db = is_identical_rotamer(resi_mat[resi_num][i],new_res);
 				if ( res_exsits_in_db ) break;
 				//TR<<"Found identical residue"<<std::endl;

--- a/source/src/protocols/splice/SpliceManager.cc
+++ b/source/src/protocols/splice/SpliceManager.cc
@@ -333,7 +333,7 @@ SpliceManager::update_pose_stem_positions() {
 }
 
 void SpliceManager::check_sequence_profile(core::pose::Pose & pose, core::id::SequenceMappingOP smap, core::sequence::SequenceProfileOP seqprof){
-	for ( core::Size row = 1; row < seqprof->size(); row++ ) { //go over all the PSSM sements provided by the user
+	for ( core::Size row = 1; row <= seqprof->size(); row++ ) { //go over all the PSSM sements provided by the user
 		utility::vector1< core::Size > cur_prof_row = seqprof->prof_row(row);
 
 

--- a/source/src/protocols/stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc
+++ b/source/src/protocols/stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc
@@ -233,7 +233,7 @@ StepWiseWorkingParametersSetup::get_user_input_alignment_res_list( core::Size co
 
 			ObjexxFCL::FArray1D < bool > const & partition_definition = working_parameters_->partition_definition();
 			bool contain_non_root_partition_seq_num = false;
-			for ( core::Size ii = 1; ii < working_alignment.size(); ii++ ) {
+			for ( core::Size ii = 1; ii <= working_alignment.size(); ii++ ) {
 				if ( partition_definition( working_alignment[ii] ) != partition_definition( root_res ) ) contain_non_root_partition_seq_num = true;
 			}
 


### PR DESCRIPTION
## Summary

One of **four PRs splitting #707** (originally a single 35-file off-by-one batch) into coherent, per-subsystem pieces, so each can be reviewed and its regression-test impact assessed independently. #707 is being closed in favor of these four. The split is deliberate — the individual diffs are below the usual bundling threshold — because the changes are behavior-affecting and the maintainer asked to isolate regression-test impact per subsystem.

**This PR: SEWING / splice / de novo / RNA structural assembly (10 files).** Two related fixes.

### Off-by-one in 1-indexed loops (`<` → `<=`)

The last element was silently skipped:

- `legacy_sewing/conformation/Assembly.cc` ×2 — `pose_loop_anchors`, `disconnected_segments`; the last segment, which by definition has no next, was skipped — exactly the case the predicate `!has_next(i)` is meant to catch
- `pose_sewing/movers/BlockwiseAnalysisMover.cc`
- `pose_sewing/movers/OmnibusDisulfideAnalysisLabelerMover.cc`
- `splice/SampleRotamersFromPDB.cc` ×2 — rotamer-deduplication scan
- `splice/SpliceManager.cc` — PSSM row check ("go over all the PSSM segments")
- `stepwise/legacy/modeler/rna/StepWiseRNA_WorkingParametersSetup.cc`
- `rna/movers/RNAIdealizeMover.cc` — `CoordinateConstraint` application
- `denovo_design/components/FoldGraph.cc`
- `fldsgn/MatchResidues.cc` ×2 — RMSD / superimpose atom-id map build
- `features/strand_assembly/StrandBundleFeatures.cc` ×2 — per-atom distance scan

### Self-distance copy/paste bug (in the two `pose_sewing` movers)

`pose.residue(upstream_res).xyz(2).distance(pose.residue(upstream_res).xyz(2))` is identically `0`, so the `<= crit_dist_` gate was always satisfied and the distance filter was a no-op. Corrected the second operand to `downstream_res`.

## Regression tests

This PR touches **`pose_sewing`**. The output change is intentional (combined off-by-one + self-distance correction) but results-affecting and warrants scientific sign-off before merge. The other files here are not in the reported changed-test set.
