### PR TITLE
Add `decorator` package as a PyRosetta dependency

### DIFF
--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -73,6 +73,7 @@ DEFAULT_PACKAGE_VERSIONS_FOR_PYROSETTA_DISTRIBUTED = {
     "cryptography": ">=2.8",
     "dask": ">=2.16.0",
     "dask-jobqueue": ">=0.7.0",
+    "decorator": ">=4.3.0",
     "distributed": ">=2.16.0",
     "gitpython": ">=3.1.1",
     "jupyter": ">=1.0.0",


### PR DESCRIPTION
This PR patches a nascent bug in the `pyrosetta.distributed` required dependencies: `source/src/python/PyRosetta/src/pyrosetta/distributed/utility/log.py` imports the `decorator` package, although it's not explicitly declared as a dependency in either the unit tests or the [`pyrosetta-distributed`](https://www.piwheels.org/project/pyrosetta-distributed/) meta-package. Currently, the PyRosetta unit tests indirectly rely on the `decorator` package to be installed via the `jupyter` -> `ipykernel` -> `ipython` -> `decorator` dependency chain, and `ipython` seems to have removed it as a dependency in their latest 9.16.0 version (see the following PR: https://github.com/ipython/ipython/pull/15310).