### PR TITLE
Caching environment manager version in PyRosettaCluster full simulation records

### DIFF
--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/config.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/config.py
@@ -9,7 +9,10 @@ __author__ = "Jason C. Klima"
 
 import logging
 import os
+import re
+import shlex
 import shutil
+import subprocess
 import sys
 import warnings
 
@@ -71,12 +74,41 @@ class EnvironmentConfig:
             else:
                 self.environment_manager = "conda"
                 warnings.warn(
-                    f"Warning: could not configure an environment manager for `PyRosettaCluster`. "
+                    "Could not configure an environment manager for `PyRosettaCluster`. "
                     + "Please ensure that either of 'pixi', 'uv', 'mamba', or 'conda' is installed. "
                     + "Using 'conda' as the default environment manager.",
                     UserWarning,
                     stacklevel=7,
                 )
+
+    @property
+    def environment_manager_version(self) -> str:
+        """Return the version of the given environment manager."""
+
+        cmd = [self.environment_manager, "--version"]
+        try:
+            output = subprocess.check_output(
+                cmd,
+                text=True,
+                stderr=subprocess.STDOUT,
+            ).strip()
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            version = ""
+        else:
+            found = re.search(r"v?(\d+(?:\.\d+)+)", output)
+            version = found.group(1) if found else ""
+
+        if not version:
+            cmd_str = shlex.join(cmd)
+            warnings.warn(
+                f"Could not determine the {self.environment_manager!r} environment manager version "
+                + f"for `PyRosettaCluster` from running `{cmd_str}`. Please ensure that the environment "
+                "manager version is saved for environment reproducibility.",
+                UserWarning,
+                stacklevel=7,
+            )
+
+        return version
 
     @property
     def env_export_cmd(self) -> str:
@@ -129,6 +161,11 @@ def get_environment_config() -> EnvironmentConfig:
 def get_environment_manager() -> str:
     """Get the configured environment manager."""
     return get_environment_config().environment_manager
+
+
+def get_environment_manager_version() -> str:
+    """Get the configured environment manager version."""
+    return get_environment_config().environment_manager_version
 
 
 def get_environment_cmd() -> str:

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/core.py
@@ -528,7 +528,10 @@ from pyrosetta.distributed.cluster.base import (
     TaskBase,
     _get_residue_type_set,
 )
-from pyrosetta.distributed.cluster.config import get_environment_manager
+from pyrosetta.distributed.cluster.config import (
+    get_environment_manager,
+    get_environment_manager_version,
+)
 from pyrosetta.distributed.cluster.converters import (
     is_empty as _is_empty,
     _maybe_issue_environment_warnings,
@@ -974,6 +977,14 @@ class PyRosettaCluster(IO, LoggingSupport, SchedulerManager, SecurityIO, TaskBas
     environment_manager: str = attr.field(
         default=attr.Factory(
             get_environment_manager,
+            takes_self=False,
+        ),
+        init=False,
+        validator=attr.validators.instance_of(str),
+    )
+    environment_manager_version: str = attr.field(
+        default=attr.Factory(
+            get_environment_manager_version,
             takes_self=False,
         ),
         init=False,

--- a/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/io.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/distributed/cluster/io.py
@@ -347,6 +347,7 @@ class IO:
                 "PyRosettaCluster_output_file": output_file,
             }
             extra_kwargs["PyRosettaCluster_environment_manager"] = self.environment_manager
+            extra_kwargs["PyRosettaCluster_environment_manager_version"] = self.environment_manager_version
             if self.toml:
                 extra_kwargs["PyRosettaCluster_toml"] = self.toml
             if self.toml_format:

--- a/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_io.py
+++ b/source/src/python/PyRosetta/src/pyrosetta/tests/distributed/cluster/test_io.py
@@ -180,6 +180,8 @@ class IOTest(unittest.TestCase):
                                     self.assertIn("instance", entry.keys())
                                     self.assertIn("metadata", entry.keys())
                                     self.assertIn("scores", entry.keys())
+                                    self.assertIn("environment_manager", entry["metadata"])
+                                    self.assertIn("environment_manager_version", entry["metadata"])
                                     self.assertIn("my_string_score", entry["scores"])
                                     self.assertEqual(entry["scores"]["my_string_score"], IOTest._my_string_value)
                                     self.assertIn("my_real_score", entry["scores"])
@@ -202,8 +204,11 @@ class IOTest(unittest.TestCase):
                                 self.assertIn("instance", df.columns)
                                 self.assertIn("metadata", df.columns)
                                 self.assertIn("scores", df.columns)
+                                metadata = df["metadata"]
                                 scores = df["scores"]
                                 for index in scores.index:
+                                    self.assertIn("environment_manager", metadata.loc[index].keys())
+                                    self.assertIn("environment_manager_version", metadata.loc[index].keys())
                                     self.assertIn("my_string_score", scores.loc[index].keys())
                                     self.assertEqual(scores.loc[index]["my_string_score"], IOTest._my_string_value)
                                     self.assertIn("my_real_score", scores.loc[index].keys())

--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -73,6 +73,7 @@ DEFAULT_PACKAGE_VERSIONS_FOR_PYROSETTA_DISTRIBUTED = {
     "cryptography": ">=2.8",
     "dask": ">=2.16.0",
     "dask-jobqueue": ">=0.7.0",
+    "decorator": ">=4.3.0",
     "distributed": ">=2.16.0",
     "gitpython": ">=3.1.1",
     "jupyter": ">=1.0.0",


### PR DESCRIPTION
This quick PR adds a caching mechanism for the configured environment manager's version string in the *PyRosettaCluster* full simulation record. The captured version string facilitates environment reproducibility when using Pixi or uv, as described in the accompanying PR: https://github.com/RosettaCommons/pyrosetta-extras/pull/18