### PR TITLE
Fix Segfault with backrub.

### DIFF
--- a/source/src/protocols/backrub/BackrubMover.hh
+++ b/source/src/protocols/backrub/BackrubMover.hh
@@ -134,6 +134,8 @@ public:
 	clear_segments()
 	{
 		segments_.clear();
+		// The BondAngleMap is derived data from segments_
+		bond_angle_map_.clear();
 	}
 
 	/// @brief get the number of segments


### PR DESCRIPTION
While BackrubProtocol clears the BackrubMover's segments between proteins, the bond_angle_map_ data set by add_segment() is not.

This means that when you apply backrub to a large protein and then to a small protein, the residue numbers from the large protein cause a segmentation fault in optimize_branch_angles() when the residual data in bond_angle_map_ is applied to the small protein.

Clearing bond_angle_map_ when we clear the segments addresses the issue.

Thanks to use @tla268 from Discussion #756 for the use case which demonstrated the issue.
